### PR TITLE
New settings for Nuget package installation

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -34,6 +34,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private ConfigurableSonarQubeServiceWrapper sonarQubeService;
         private ConfigurableVsOutputWindowPane outputWindowPane;
         private ConfigurableVsProjectSystemHelper projectSystemHelper;
+        private ConfigurableIntegrationSettings settings;
 
         public TestContext TestContext { get; set; }
 
@@ -52,6 +53,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var sccFileSystem = new ConfigurableSourceControlledFileSystem();
             var ruleSerializer = new ConfigurableRuleSetSerializer(sccFileSystem);
             var solutionBinding = new ConfigurableSolutionBindingSerializer();
+
+            this.settings = new ConfigurableIntegrationSettings {AllowNuGetPackageInstall = true};
+
+            var mefExports = MefTestHelpers.CreateExport<IIntegrationSettings>(settings);
+            var mefModel = ConfigurableComponentModel.CreateWithExports(mefExports);
+            this.serviceProvider.RegisterService(typeof(SComponentModel), mefModel);
 
             this.serviceProvider.RegisterService(typeof(ISourceControlledFileSystem), sccFileSystem);
             this.serviceProvider.RegisterService(typeof(IRuleSetSerializer), ruleSerializer);
@@ -557,7 +564,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             ConfigurablePackageInstaller packageInstaller = new ConfigurablePackageInstaller(nugetPackagesByLanguage.Values.SelectMany(x => x));
             this.serviceProvider.RegisterService(typeof(SComponentModel),
-                ConfigurableComponentModel.CreateWithExports(MefTestHelpers.CreateExport<IVsPackageInstaller>(packageInstaller)));
+                ConfigurableComponentModel.CreateWithExports(MefTestHelpers.CreateExport<IVsPackageInstaller>(packageInstaller)), true);
 
             return packageInstaller;
         }

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -46,7 +46,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             this.sonarQubeService.RegisterServerPlugin(new ServerPlugin { Key = MinimumSupportedServerPlugin.CSharp.Key, Version = MinimumSupportedServerPlugin.CSharp.MinimumVersion });
             this.sonarQubeService.RegisterServerPlugin(new ServerPlugin { Key = MinimumSupportedServerPlugin.VbNet.Key, Version = MinimumSupportedServerPlugin.VbNet.MinimumVersion });
-            this.settings = new ConfigurableIntegrationSettings();
+            this.settings = new ConfigurableIntegrationSettings {AllowNuGetPackageInstall = true};
 
             var mefExports = MefTestHelpers.CreateExport<IIntegrationSettings>(settings);
             var mefModel = ConfigurableComponentModel.CreateWithExports(mefExports);

--- a/src/Integration.Vsix/Settings/IntegrationSettings.cs
+++ b/src/Integration.Vsix/Settings/IntegrationSettings.cs
@@ -23,6 +23,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     {
         public const string SettingsRoot = "SonarLintForVisualStudio";
         public const string ShowServerNuGetTrustWarningKey = "ShowServerNuGetTrustWarning";
+        public const string AllowNuGetPackageInstallKey = "AllowNuGetPackageInstall";
 
         private readonly WritableSettingsStore store;
 
@@ -117,6 +118,15 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         {
             get { return this.GetValueOrDefault(ShowServerNuGetTrustWarningKey, true); }
             set { this.SetValue(ShowServerNuGetTrustWarningKey, value); }
+        }
+
+        [LocalizedCategory(nameof(Strings.NugetSettingsCategory))]
+        [LocalizedDisplayName(nameof(Strings.AllowNuGetPackageInstallationName))]
+        [LocalizedDescription(nameof(Strings.AllowNuGetPackageInstallationSettingDescription))]
+        public bool AllowNuGetPackageInstall
+        {
+            get { return this.GetValueOrDefault(AllowNuGetPackageInstallKey, true); }
+            set { this.SetValue(AllowNuGetPackageInstallKey, value); }
         }
 
         #endregion

--- a/src/Integration.Vsix/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
-    <Identity Id="SonarLint.8c442ec8-0208-4840-b83f-acd24f41acf7" Version="2.8.0.0" Language="en-US" Publisher="SonarSource SA" />
+    <Identity Id="SonarLint.8c442ec8-0208-4840-b83f-acd24f41acf7" Version="2.8.1.0" Language="en-US" Publisher="SonarSource SA" />
     <DisplayName>SonarLint for Visual Studio</DisplayName>
     <Description xml:space="preserve">SonarLint provides on-the-fly feedback to developers on new bugs and quality issues injected into C# and VB.Net code. In addition the connected mode allows to enforce governance policies by reporting the same issues in Visual Studio and in SonarQube server.</Description>
     <MoreInfo>http://vs.sonarlint.org</MoreInfo>

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -33,6 +33,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly ProjectInformation project;
         private readonly IProjectSystemHelper projectSystem;
         private readonly SolutionBindingOperation solutionBindingOperation;
+        private readonly IIntegrationSettings settings;
 
         public BindingWorkflow(IHost host, ConnectionInformation connectionInformation, ProjectInformation project)
         {
@@ -56,6 +57,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             this.project = project;
             this.projectSystem = this.host.GetService<IProjectSystemHelper>();
             this.projectSystem.AssertLocalServiceIsNotNull();
+            this.settings = this.host.GetMefService<IIntegrationSettings>();
 
             this.solutionBindingOperation = new SolutionBindingOperation(
                     this.host,
@@ -301,7 +303,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// </summary>
         internal /*for testing purposes*/ void InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents)
         {
-            if (!this.NuGetPackages.Any())
+            if (!this.NuGetPackages.Any() || !this.settings.AllowNuGetPackageInstall)
             {
                 return;
             }

--- a/src/Integration/MefServices/IIntegrationSettings.cs
+++ b/src/Integration/MefServices/IIntegrationSettings.cs
@@ -10,5 +10,6 @@ namespace SonarLint.VisualStudio.Integration
     public interface IIntegrationSettings
     {
         bool ShowServerNuGetTrustWarning { get; set; }
+        bool AllowNuGetPackageInstall { get; set; }
     }
 }

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -61,6 +61,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow Nuget package installation.
+        /// </summary>
+        public static string AllowNuGetPackageInstallationName {
+            get {
+                return ResourceManager.GetString("AllowNuGetPackageInstallationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow the installation of Nuget packages required for the analysis (package.config).
+        /// </summary>
+        public static string AllowNuGetPackageInstallationSettingDescription {
+            get {
+                return ResourceManager.GetString("AllowNuGetPackageInstallationSettingDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bound project: {0}.
         /// </summary>
         public static string AutomationProjectBoundDescription {
@@ -680,6 +698,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string NotEmptyValidatorRequiredField {
             get {
                 return ResourceManager.GetString("NotEmptyValidatorRequiredField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nuget.
+        /// </summary>
+        public static string NugetSettingsCategory {
+            get {
+                return ResourceManager.GetString("NugetSettingsCategory", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -700,4 +700,16 @@ This is the general format to use when writing errors to output window or when t
     <value>{0}profiles/show?key={1}</value>
     <comment>Used to create the Quality Profile URL. This will be integrated as part of the ruleset description. {0} the server URL. {1} the quality profile key.</comment>
   </data>
+  <data name="AllowNuGetPackageInstallationName" xml:space="preserve">
+    <value>Allow Nuget package installation</value>
+    <comment>Name of the AllowNuGetPackageInstall setting</comment>
+  </data>
+  <data name="AllowNuGetPackageInstallationSettingDescription" xml:space="preserve">
+    <value>Allow the installation of Nuget packages required for the analysis (package.config)</value>
+    <comment>Description for the AllowNuGetPackageInstall setting</comment>
+  </data>
+  <data name="NugetSettingsCategory" xml:space="preserve">
+    <value>Nuget</value>
+    <comment>Nuget settings category for Nuget for options page</comment>
+  </data>
 </root>

--- a/src/TestInfrastructure/Framework/ConfigurableIntegrationSettings.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableIntegrationSettings.cs
@@ -12,6 +12,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         #region IIntegrationSettings
 
         public bool ShowServerNuGetTrustWarning { get; set; }
+        public bool AllowNuGetPackageInstall { get; set; }
 
         #endregion
     }


### PR DESCRIPTION
This new settings can disable the installation of Nuget packages
required by the analyzer (package.config). You may have your own
solution for package restore e.g. Paket