### PR TITLE
Added skeleton classes for suppressions handling

### DIFF
--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Integration.Vsix.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {
@@ -52,6 +53,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private BoundSolutionAnalyzer usageAnalyzer;
         private PackageCommandManager commandManager;
         private SonarAnalyzerManager sonarAnalyzerManager;
+        private SuppressionManager suppressionManager;
 
         protected override void Initialize()
         {
@@ -61,6 +63,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             IServiceProvider serviceProvider = this;
 
             this.sonarAnalyzerManager = new SonarAnalyzerManager(serviceProvider);
+            this.suppressionManager = new SuppressionManager(serviceProvider);
             this.usageAnalyzer = new BoundSolutionAnalyzer(serviceProvider);
             this.commandManager = new PackageCommandManager(serviceProvider);
 

--- a/src/Integration.Vsix/Suppression/DelegateInjector.cs
+++ b/src/Integration.Vsix/Suppression/DelegateInjector.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
- using System;
+using System;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
@@ -28,7 +28,7 @@ using Microsoft.CodeAnalysis;
  * assemblies will be loaded in memory, each with its own static class + property).
  * We need to set the static property for each Sonar analyzer assembly that is loaded.
  * 
- * Version-compatibility: the NuGet package and VSIX might reference different versions of Roslyn etc,
+ * Version-compatibility: the NuGet package and VSIX might reference different versions of Roslyn etc,git branch
  * but we need to be able to assign a delegate from the VSIX to the NuGet static property.
  * If the NuGet package is using a higher version of Roslyn then the analyzer won't work anyway.
  * If is is using a lower version of Roslyn then the binding redirect in VS should make the assignment works.
@@ -40,7 +40,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
     /// Injects the suppression calculator function into any versions of the Sonar
     /// analyzers that are already loaded, or in to any new versions as they are loaded
     /// </summary>
-    internal class DelegateInjector : IDisposable
+    internal sealed class DelegateInjector : IDisposable
     {
         public DelegateInjector(Func<Diagnostic, bool> function)
         {
@@ -68,7 +68,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
         #region IDisposable Support
         private bool disposedValue = false; // To detect redundant calls
 
-        protected virtual void Dispose(bool disposing)
+        void Dispose(bool disposing)
         {
             if (!disposedValue)
             {

--- a/src/Integration.Vsix/Suppression/DelegateInjector.cs
+++ b/src/Integration.Vsix/Suppression/DelegateInjector.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+ using System;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+/* We want to suppress issues from Sonar analyzers that are added via NuGet.
+ * If the analyzer in the NuGet is of a different version from the one in the VSIX then just
+ * setting the static property on the version referenced by the VSIX won't work (both analyzer
+ * assemblies will be loaded in memory, each with its own static class + property).
+ * We need to set the static property for each Sonar analyzer assembly that is loaded.
+ * 
+ * Version-compatibility: the NuGet package and VSIX might reference different versions of Roslyn etc,
+ * but we need to be able to assign a delegate from the VSIX to the NuGet static property.
+ * If the NuGet package is using a higher version of Roslyn then the analyzer won't work anyway.
+ * If is is using a lower version of Roslyn then the binding redirect in VS should make the assignment works.
+ */
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
+{
+    /// <summary>
+    /// Injects the suppression calculator function into any versions of the Sonar
+    /// analyzers that are already loaded, or in to any new versions as they are loaded
+    /// </summary>
+    internal class DelegateInjector : IDisposable
+    {
+        public DelegateInjector(Func<Diagnostic, bool> function)
+        {
+            // Inject the delegate into any Sonar analyzer assemblies that are already loaded
+            foreach(Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                InjectSuppressionDelegate(asm);
+            }
+
+            // Monitor assemblies as they are loaded and inject the delegate if necessary
+            AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+        }
+
+        private void OnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
+        {
+            InjectSuppressionDelegate(args.LoadedAssembly);
+        }
+
+        private void InjectSuppressionDelegate(Assembly asm)
+        {
+            // TODO: if this is a Sonar analyzer assembly, try to set the suppression delegate
+            // Note: the property might not exist for down-level versions of the analyzer
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/src/Integration.Vsix/Suppression/DelegateInjector.cs
+++ b/src/Integration.Vsix/Suppression/DelegateInjector.cs
@@ -81,10 +81,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
             }
         }
 
-        // This code added to correctly implement the disposable pattern.
         public void Dispose()
         {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
         }
         #endregion

--- a/src/Integration.Vsix/Suppression/LiveIssue.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssue.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using SonarLint.VisualStudio.Integration.Suppression;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
+{
+    /// <summary>
+    /// Information about a single Roslyn issue, decorated with the 
+    /// extra information required to map it to a SonarQube issue
+    /// </summary>
+    internal class LiveIssue
+    {
+        // TODO: make properties read-only
+
+        public Diagnostic Diagnostic { get; set; }
+        public string IssueFilePath { get; set; }
+        public string ProjectId { get; set; }
+        public string ProjectFilePath { get; set; }
+        public int StartLine { get; set; }
+        public string WholeLineText { get; set; }
+
+        private string checksum;
+        public string LineChecksum
+        {
+            get
+            {
+                if (checksum == null)
+                {
+                    // TODO: checksum for file-level issues?
+                    checksum = ChecksumCalculator.Calculate(this.WholeLineText);
+                }
+                return checksum;
+            }
+        }
+
+    }
+}

--- a/src/Integration.Vsix/Suppression/LiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssueFactory.cs
@@ -1,0 +1,137 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.LanguageServices;
+using Microsoft.VisualStudio.Shell.Interop;
+
+/* To map from a diagnostic to a SonarQube issue we need to work out the SQ moduleId
+ * corresponding to the MSBuild project.
+ * 
+ * To speed things up, we cache the mapping from project file path to project id
+ * for the loaded projects (which means we need to rebuild the mapping when the
+ * solution changes).
+ * 
+ * Note: this class does not monitor changes to the solution. If the solution/binding
+ * changes then create a new instance.
+ */
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
+{
+    /// <summary>
+    /// Factory for <see cref="LiveIssue"/>s i.e. diagnostics that are decorated with
+    /// additional information required to map to issues in the SonarQube server format
+    /// </summary>
+    internal sealed class LiveIssueFactory
+    {
+        private readonly Workspace workspace;
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Mapping from full project file path to the unique project id
+        /// </summary>
+        private Dictionary<string, string> projectPathToProjectIdMap;
+
+        public LiveIssueFactory(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+
+            var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
+            workspace = componentModel.GetService<VisualStudioWorkspace>();
+
+            BuildProjectPathToIdMap();
+        }
+
+        /// <summary>
+        /// Attempts to fetch the extra information required to map from a Roslyn issue
+        /// to a SonarQube server issue. Returns null if there is not enough information
+        /// to produce the mapping.
+        /// </summary>
+        public LiveIssue TryCreate(Diagnostic diagnostic)
+        {
+            // Get the file and project containing the issue
+            SyntaxTree tree = diagnostic.Location?.SourceTree;
+            if (tree == null) { return null; }
+            if (diagnostic.Location == Location.None) { return null; }
+
+            Project project = workspace?.CurrentSolution?.GetDocument(tree)?.Project;
+            if (project == null) { return null; }
+
+            string projectId;
+            if (!projectPathToProjectIdMap.TryGetValue(project.FilePath, out projectId))
+            {
+                Debug.Fail($"Expecting to have a project id for the Roslyn project: {project.FilePath}");
+                return null;
+            }
+
+            // Get the whole of the line of text containing the issue (needed to compute the checksum)
+            // TODO: checksum for file level issues?
+            FileLinePositionSpan lineSpan = diagnostic.Location.GetLineSpan();
+
+            int startLine = lineSpan.StartLinePosition.Line;
+            int endLine = lineSpan.EndLinePosition.Line;
+            string lineText = tree.GetText().Lines[startLine + endLine - startLine].ToString();
+
+            LiveIssue liveIssue = new LiveIssue()
+            {
+                Diagnostic = diagnostic,
+                IssueFilePath = lineSpan.Path,
+                ProjectId = projectId,
+                ProjectFilePath = project.FilePath,
+                WholeLineText = lineText
+            };
+            return liveIssue;
+        }
+
+        private void BuildProjectPathToIdMap()
+        {
+            projectPathToProjectIdMap = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+
+            IVsSolution solution = this.serviceProvider.GetService<SVsSolution, IVsSolution>();
+            Debug.Assert(solution != null, "Cannot find SVsSolution");
+
+            // TODO: handle return codes
+            uint projectCount;
+            solution.GetProjectFilesInSolution((uint)__VSGETPROJFILESFLAGS.GPFF_SKIPUNLOADEDPROJECTS, 0, null, out projectCount);
+
+            string[] fileNames = new string[projectCount];
+            solution.GetProjectFilesInSolution((uint)__VSGETPROJFILESFLAGS.GPFF_SKIPUNLOADEDPROJECTS, projectCount, fileNames, out projectCount);
+
+            IVsSolution5 soln5 = (IVsSolution5)solution;
+
+            foreach (string projectFile in fileNames)
+            {
+                // We need to use the same project id that is used by the Scanner for MSBuild.
+                // For non-.Net Core projects, the scanner will use the <ProjectGuid> value in the project.
+                // .Net Core projects don't have a <ProjectGuid> property so the scanner uses the GUID allocated
+                // to the project in the solution file.
+                // Fortunately, this is the logic used by soln5.GetGuidOfProjectFile... so we can just use that.
+                Guid projectId = soln5.GetGuidOfProjectFile(projectFile);
+                Debug.Assert(projectId != null, "Not expecting VS to return a null project guid");
+
+                projectPathToProjectIdMap.Add(projectFile, projectId.ToString().Replace("{", "").Replace("}", ""));
+            }
+        }
+    }
+}

--- a/src/Integration.Vsix/Suppression/SuppressionManager.cs
+++ b/src/Integration.Vsix/Suppression/SuppressionManager.cs
@@ -120,10 +120,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
             }
         }
 
-        // This code added to correctly implement the disposable pattern.
         public void Dispose()
         {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
         }
         #endregion

--- a/src/Integration.Vsix/Suppression/SuppressionManager.cs
+++ b/src/Integration.Vsix/Suppression/SuppressionManager.cs
@@ -83,7 +83,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
             if (!diagnostic.Location.IsInSource) { return false; }
             if (activeSolutionBoundTracker == null || !activeSolutionBoundTracker.IsActiveSolutionBound) { return false; }
 
-            LiveIssue liveIssue = liveIssueFactory.TryCreate(diagnostic);
+            LiveIssue liveIssue = liveIssueFactory.Create(diagnostic);
             if (liveIssue == null)
             {
                 return false; // Unable to get the data required to map a Roslyn issue to a SonarQube issue
@@ -95,10 +95,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 
             // TODO: ?need to make file path relative to the project file path
             // As a minimum, the project, file and rule id must match
-            IEnumerable<ServerIssue> issuesInFile = serverIssueProvider.GetServerIssues(liveIssue.ProjectId, liveIssue.IssueFilePath)
+            var issuesInFile = serverIssueProvider.GetServerIssues(liveIssue.ProjectId, liveIssue.IssueFilePath)
                     .Where(i => StringComparer.OrdinalIgnoreCase.Equals(liveIssue.Diagnostic.Id, i.RuleKey)); // TODO: rule repository?
 
-            return issuesInFile.Any(i => liveIssue.StartLine == i.Line || StringComparer.Ordinal.Equals(liveIssue.LineChecksum, i.Checksum));
+            return issuesInFile.Any(i =>
+                    liveIssue.StartLine == i.Line ||
+                    StringComparer.Ordinal.Equals(liveIssue.LineChecksum, i.Checksum));
         }
 
         #region IDisposable Support

--- a/src/Integration.Vsix/Suppression/SuppressionManager.cs
+++ b/src/Integration.Vsix/Suppression/SuppressionManager.cs
@@ -1,0 +1,129 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using SonarLint.VisualStudio.Integration.Suppression;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
+{
+    internal sealed class SuppressionManager : IDisposable
+    {
+        private readonly IServiceProvider serviceProvider;
+        private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
+
+        private DelegateInjector delegateInjector;
+        private LiveIssueFactory liveIssueFactory;
+        private ServerIssuesProvider serverIssueProvider;
+
+        public SuppressionManager(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+            activeSolutionBoundTracker = serviceProvider.GetMefService<IActiveSolutionBoundTracker>();
+            activeSolutionBoundTracker.SolutionBindingChanged += OnSolutionBindingChanged;
+
+            RefreshSuppresionHandling();
+        }
+
+        private void RefreshSuppresionHandling()
+        {
+            if (activeSolutionBoundTracker.IsActiveSolutionBound)
+            {
+                SetupSuppressionHandling();
+            }
+            else
+            {
+                CleanupSuppressionHandling();
+            }
+        }
+
+        private void SetupSuppressionHandling()
+        {
+            liveIssueFactory = new LiveIssueFactory(serviceProvider);
+            delegateInjector = new DelegateInjector(ShouldIssueBeSuppressed);
+            serverIssueProvider = new ServerIssuesProvider(serviceProvider);
+        }
+
+        private void CleanupSuppressionHandling()
+        {
+            delegateInjector?.Dispose();
+            delegateInjector = null;
+            liveIssueFactory = null;
+            serverIssueProvider?.Dispose();
+            serverIssueProvider = null;
+        }
+
+        private void OnSolutionBindingChanged(object sender, bool e)
+        {
+            RefreshSuppresionHandling();
+        }
+
+        private bool ShouldIssueBeSuppressed(Diagnostic diagnostic)
+        {
+            // This method is called for every analyzer issue that is raised so it should be fast.
+            if (!diagnostic.Location.IsInSource) { return false; }
+            if (activeSolutionBoundTracker == null || !activeSolutionBoundTracker.IsActiveSolutionBound) { return false; }
+
+            LiveIssue liveIssue = liveIssueFactory.TryCreate(diagnostic);
+            if (liveIssue == null)
+            {
+                return false; // Unable to get the data required to map a Roslyn issue to a SonarQube issue
+            }
+
+            // Issues match if:
+            // 1. Same component, same file, same error code, same line hash        // tolerant to line number changing
+            // 2. Same component, same file, same error code, same line             // tolarant to code on the line changing e.g. var rename
+
+            // TODO: ?need to make file path relative to the project file path
+            // As a minimum, the project, file and rule id must match
+            IEnumerable<ServerIssue> issuesInFile = serverIssueProvider.GetServerIssues(liveIssue.ProjectId, liveIssue.IssueFilePath)
+                    .Where(i => StringComparer.OrdinalIgnoreCase.Equals(liveIssue.Diagnostic.Id, i.RuleKey)); // TODO: rule repository?
+
+            return issuesInFile.Any(i => liveIssue.StartLine == i.Line || StringComparer.Ordinal.Equals(liveIssue.LineChecksum, i.Checksum));
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    CleanupSuppressionHandling();
+                    activeSolutionBoundTracker.SolutionBindingChanged -= OnSolutionBindingChanged;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/src/Integration/Suppression/ChecksumCalculator.cs
+++ b/src/Integration/Suppression/ChecksumCalculator.cs
@@ -31,7 +31,7 @@ namespace SonarLint.VisualStudio.Integration.Suppression
     /// <remarks>
     /// For the corresponding code in SL IntelliJ see src\main\java\org\sonarlint\intellij\issue\LiveIssue.java::checksum
     /// </remarks>
-    internal static class ChecksumCalculator
+    public static class ChecksumCalculator
     {
         public static string Calculate(string text)
         {

--- a/src/Integration/Suppression/IServerIssuesProvider.cs
+++ b/src/Integration/Suppression/IServerIssuesProvider.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+
+namespace SonarLint.VisualStudio.Integration.Suppression
+{
+    public interface IServerIssuesProvider
+    {
+        /// <summary>
+        /// Returns server issues for the specified project and file
+        /// </summary>
+        IEnumerable<ServerIssue> GetServerIssues(string projectId, string filePath);
+    }
+}

--- a/src/Integration/Suppression/ServerIssue.cs
+++ b/src/Integration/Suppression/ServerIssue.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+
+namespace SonarLint.VisualStudio.Integration.Suppression
+{
+    /// <summary>
+    /// TODO: placeholder class: data contract for server-side issues
+    /// </summary>
+    /// <remarks>Maps to the fields returned by SonarQube web service GET /batch/issues</remarks>
+    public class ServerIssue
+    {
+//        String Key { get; set; }
+        public string ModuleKey { get; set; }
+        public string Path { get; set; }
+        public string RuleRespository { get; set; }
+        public string RuleKey { get; set; }
+        public int Line { get; set; }
+        public string Message { get; set; }
+        //        String Severity { get; set; }
+        //        bool ManualSeverity { get; set; }
+        public string Resolution { get; set; }
+        public string Status { get; set; }
+        public string Checksum { get; set; }
+        //        String AssigneeLogin { get; set; }
+        //        long CreationDate { get; set; }
+    }
+}

--- a/src/Integration/Suppression/ServerIssuesProvider.cs
+++ b/src/Integration/Suppression/ServerIssuesProvider.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SonarLint.VisualStudio.Integration.Suppression
+{
+    // TODO:
+    // * needs a connection to the current SonarQube server
+    // * maintain a list of server-side issues
+    // * update the list periodically - triggers?
+    // * provide fast access to locate issues by project and file
+    // * locking?
+
+    public sealed class ServerIssuesProvider : IServerIssuesProvider, IDisposable
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public ServerIssuesProvider(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+
+            SetupRefreshTriggers();
+        }
+
+        public IEnumerable<ServerIssue> GetServerIssues(string projectId, string filePath)
+        {
+            // TODO: if the issues have not been fetch yet, block until they are fetched (or error/timeout)
+            // TODO: locking
+            return Enumerable.Empty<ServerIssue>();
+        }
+
+        private void SetupRefreshTriggers()
+        {
+            // TODO: set up triggers to re-fetch the issues from the server
+
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+        #endregion
+    }
+}

--- a/src/Integration/Suppression/ServerIssuesProvider.cs
+++ b/src/Integration/Suppression/ServerIssuesProvider.cs
@@ -71,10 +71,8 @@ namespace SonarLint.VisualStudio.Integration.Suppression
             }
         }
 
-        // This code added to correctly implement the disposable pattern.
         public void Dispose()
         {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
         }
         #endregion


### PR DESCRIPTION
Added skeleton classes as a starting point for the end-to-end suppressions experience.

This commit is a first attempt at breaking the whole problem into a series of smaller pieces that can be tackled individually. All of the classes have TODOs in them and we'll probably want to split/move some of the code around.

I was struggling to understand what the logical split between the _Integration_ and the _Integration.VSIX_ is supposed to be. I've put classes that need to access the SQ server in the _Integration_ project since that is the only place the server connection information is available, and I've put the code that uses Roslyn in the _Integration.VSIX_ project since that already references Roslyn and the other project doesn't.  I did that simply because that required fewest changes for now.