### PR TITLE
Fixes to suppression calculation and matching

### DIFF
--- a/src/Integration.Vsix.UnitTests/Helpers/FileUtilitiesTests.cs
+++ b/src/Integration.Vsix.UnitTests/Helpers/FileUtilitiesTests.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.Vsix.Helpers;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class FileUtilitiesTests
+    {
+        [TestMethod]
+        public void Path_Relative_InSameFolder()
+        {
+            string path = FileUtilities.GetRelativePath("c:\\proj1.csproj", "c:\\file1.cs");
+            path.Should().Be("file1.cs");
+
+            path = FileUtilities.GetRelativePath("c:\\aaa\\proj2.csproj", "c:\\aaa\\file2.cs");
+            path.Should().Be("file2.cs");
+        }
+
+        [TestMethod]
+        public void Path_Relative_InChildFolders()
+        {
+            string path = FileUtilities.GetRelativePath("c:\\sub1\\proj1.proj", "c:\\sub1\\sub2\\sub3\\myfile.cs");
+            path.Should().Be("sub2\\sub3\\myfile.cs");
+
+            path = FileUtilities.GetRelativePath("c:\\proj1.proj", "c:\\sub1\\sub2\\sub3\\myfile.cs");
+            path.Should().Be("sub1\\sub2\\sub3\\myfile.cs");
+        }
+
+        [TestMethod]
+        public void Path_NotRelative_InNonChildFolders()
+        {
+            string path = FileUtilities.GetRelativePath("c:\\aaaa\\myproject.csproj", "c:\\bbbb\\file1.cs");
+            path.Should().Be("..\\bbbb\\file1.cs");
+        }
+
+        [TestMethod]
+        public void Path_NotRelative_OnDifferentDrives()
+        {
+            string path = FileUtilities.GetRelativePath("c:\\folder1\\project1.vbproj", "d:\\folder1\\file2.vb");
+            path.Should().Be("d:\\folder1\\file2.vb");
+        }
+
+        [TestMethod]
+        public void Path_Relative_IsNotCaseSensitive()
+        {
+            string path = FileUtilities.GetRelativePath("c:\\aaa\\proj1.csproj", "C:\\AAA\\file1.cs");
+            path.Should().Be("file1.cs");
+        }
+
+    }
+}

--- a/src/Integration.Vsix/Helpers/FileUtilities.cs
+++ b/src/Integration.Vsix/Helpers/FileUtilities.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Helpers
+{
+    internal static class FileUtilities
+    {
+        [DllImport("shlwapi.dll", CharSet = CharSet.Auto)]
+        private static extern bool PathRelativePathTo(
+            [Out] StringBuilder pszPath,
+            [In] string pszFrom,
+            [In] FileAttributes dwAttrFrom,
+            [In] string pszTo,
+            [In] FileAttributes dwAttrTo);
+
+        /// <summary>
+        /// Returns the relative path to the second file from the first, or 
+        /// <paramref name="toFilePath"/> if the paths are not relative.
+        /// </summary>
+        public static string GetRelativePath(string fromFilePath, string toFilePath)
+        {
+            StringBuilder sb = new StringBuilder(260);
+            bool success = PathRelativePathTo(sb, fromFilePath, FileAttributes.Normal, toFilePath, FileAttributes.Normal);
+
+            if (success)
+            {
+                // Strip of the the leading ".\" (i.e. if the files are in the same directory)
+                int offset = 0;
+                if (sb[0] == '.' && sb[1] == '\\')
+                {
+                    offset = 2;
+                }
+                return sb.ToString(offset, sb.Length - offset);
+            }
+
+            return toFilePath;
+        }
+
+    }
+}

--- a/src/Integration.Vsix/Helpers/FileUtilities.cs
+++ b/src/Integration.Vsix/Helpers/FileUtilities.cs
@@ -40,7 +40,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Helpers
         /// </summary>
         public static string GetRelativePath(string fromFilePath, string toFilePath)
         {
-            StringBuilder sb = new StringBuilder(260);
+            var sb = new StringBuilder(260);
             bool success = PathRelativePathTo(sb, fromFilePath, FileAttributes.Normal, toFilePath, FileAttributes.Normal);
 
             if (success)

--- a/src/Integration.Vsix/Suppression/LiveIssue.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssue.cs
@@ -29,13 +29,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
     /// </summary>
     internal class LiveIssue
     {
-        public LiveIssue(Diagnostic diagnostic, string issueFilePath, string projectFilePath, string projectGuid, int startLine,
+        public LiveIssue(Diagnostic diagnostic, string issueFilePath, string projectGuid, int startLine,
             string wholeLineText)
         {
             Diagnostic = diagnostic;
             IssueFilePath = issueFilePath;
             ProjectGuid = projectGuid;
-            ProjectFilePath = projectFilePath;
             StartLine = startLine;
             WholeLineText = wholeLineText;
             LineHash = ChecksumCalculator.Calculate(WholeLineText);
@@ -44,7 +43,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
         public Diagnostic Diagnostic { get; }
         public string IssueFilePath { get; }
         public string LineHash { get; }
-        public string ProjectFilePath { get; }
         public string ProjectGuid { get; }
         public int StartLine { get; }
         public string WholeLineText { get; }

--- a/src/Integration.Vsix/Suppression/LiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssueFactory.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell.Interop;
+using SonarLint.VisualStudio.Integration.Vsix.Helpers;
 
 /* To map from a diagnostic to a SonarQube issue we need to work out the SQ moduleId
  * corresponding to the MSBuild project.
@@ -102,8 +103,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
             int startLine = lineSpan.StartLinePosition.Line;
             int additionalLineCount = lineSpan.EndLinePosition.Line - startLine;
             string lineText = tree.GetText().Lines[startLine + additionalLineCount].ToString();
+            string relativeFilePath = FileUtilities.GetRelativePath(project.FilePath, lineSpan.Path);
 
-            LiveIssue liveIssue = new LiveIssue(diagnostic, lineSpan.Path, project.FilePath, projectId,
+            LiveIssue liveIssue = new LiveIssue(diagnostic, relativeFilePath, projectId,
                 startLine + 1, lineText); // Roslyn lines are 0-based, SonarQube lines are 1-based
             return liveIssue;
         }

--- a/src/Integration/Suppression/SonarQubeIssuesProvider.cs
+++ b/src/Integration/Suppression/SonarQubeIssuesProvider.cs
@@ -76,7 +76,7 @@ namespace SonarLint.VisualStudio.Integration.Suppression
         {
             // TODO: Block the call while the cache is being built + handle multi-threading
 
-            // HACK: ensure we've got data to enable end to end testing
+            // TODO: ensure we've got data to enable end to end testing
             if (solutionBoundTacker.IsActiveSolutionBound &&
                 this.cachedSuppressedIssues == null)
             {

--- a/src/Integration/Suppression/SonarQubeIssuesProvider.cs
+++ b/src/Integration/Suppression/SonarQubeIssuesProvider.cs
@@ -75,7 +75,22 @@ namespace SonarLint.VisualStudio.Integration.Suppression
         public IEnumerable<SonarQubeIssue> GetSuppressedIssues(string projectGuid, string filePath)
         {
             // TODO: Block the call while the cache is being built + handle multi-threading
-            return this.cachedSuppressedIssues.Where(x => x.FilePath == filePath && x.ModuleKey == BuildModuleKey(projectGuid));
+
+            // HACK: ensure we've got data to enable end to end testing
+            if (solutionBoundTacker.IsActiveSolutionBound &&
+                this.cachedSuppressedIssues == null)
+            {
+                SynchronizeSuppressedIssues().Wait(30000);
+            }
+
+            if (this.cachedSuppressedIssues == null)
+            {
+                return Enumerable.Empty<SonarQubeIssue>();
+            }
+
+            return this.cachedSuppressedIssues.Where(x =>
+                x.FilePath.Equals(filePath, StringComparison.OrdinalIgnoreCase) &&
+                x.ModuleKey.Equals(BuildModuleKey(projectGuid), StringComparison.OrdinalIgnoreCase));
         }
 
         private string BuildModuleKey(string projectGuid)
@@ -103,6 +118,12 @@ namespace SonarLint.VisualStudio.Integration.Suppression
 
         private async Task SynchronizeSuppressedIssues()
         {
+            // TODO: may not be connected
+            if (!this.sonarQubeService.IsConnected)
+            {
+                return;
+            }
+
             cancellationTokenSource?.Cancel();
             cancellationTokenSource = new CancellationTokenSource();
 

--- a/src/SonarQube.Client/Models/SonarQubeIssue.cs
+++ b/src/SonarQube.Client/Models/SonarQubeIssue.cs
@@ -55,6 +55,7 @@ namespace SonarQube.Client.Models
         {
             switch (resolution)
             {
+                case "": // TODO - check whether an empty string is a valid response
                 case "OPEN":
                     return SonarQubeIssueResolutionState.Open;
                 case "WONTFIX":


### PR DESCRIPTION
1/ The _LiveIssue_ file path should be the relative path from the MSBuild project file
2/ Comparison of module keys and file paths should be case-insensitive
3/ The function calculating the suppression was called _ShouldIssueBeSuppressed,_ but the suppression property is _ShouldIssueBeReported_. The function was returning the wrong logical result.