### PR TITLE
Fix notification tests

### DIFF
--- a/src/Integration/Notifications/SonarQubeNotificationService.cs
+++ b/src/Integration/Notifications/SonarQubeNotificationService.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using SonarQube.Client.Models;
@@ -109,6 +110,8 @@ namespace SonarLint.VisualStudio.Integration.Notifications
 
         private async void OnTimerElapsed(object sender, EventArgs e)
         {
+            Debug.Assert(this.cancellation != null, "Cancellation token should not be null if the timer is active - check StartAsync has been called");
+
             await UpdateEvents();
         }
 


### PR DESCRIPTION
Two tests are failing following the fix for #330

It's a test setup issue: previously, the tests didn't called _StartAsync_ as it didn't use to be necessary as the cancellation source was created when the class was constructed.