### PR TITLE
Removed solution tracking from the issues provider

### DIFF
--- a/src/Integration.Vsix/Suppression/SuppressionManager.cs
+++ b/src/Integration.Vsix/Suppression/SuppressionManager.cs
@@ -67,7 +67,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
         {
             liveIssueFactory = new LiveIssueFactory(serviceProvider);
             delegateInjector = new DelegateInjector(ShouldIssueBeReported, serviceProvider);
-            sonarqubeIssueProvider = new SonarQubeIssuesProvider(sonarQubeService, activeSolutionBoundTracker, timerFactory);
+            sonarqubeIssueProvider = new SonarQubeIssuesProvider(sonarQubeService, this.activeSolutionBoundTracker.ProjectKey, timerFactory);
         }
 
         private void CleanupSuppressionHandling()


### PR DESCRIPTION
Previously, the issue provider was tracking solution events to work out when it needed to fetch issues from the server. However, this wasn't necessary as the suppression manager was also tracking the solution events and creates a new issue provider whenever the bound solution changes.

I've removed the solution tracking code from the issue provider and deleted the unnecessary tests.