### PR TITLE
fix failing test

### DIFF
--- a/src/Integration.UnitTests/Telemetry/TelemetryManagerTests.cs
+++ b/src/Integration.UnitTests/Telemetry/TelemetryManagerTests.cs
@@ -104,7 +104,7 @@ namespace SonarLint.VisualStudio.Integration.Tests
 
             // Assert
             telemetryData.InstallationDate.Should().BeAfter(DateTime.Now.AddMinutes(-5));
-            telemetryData.InstallationDate.Should().BeBefore(DateTime.Now);
+            telemetryData.InstallationDate.Should().BeOnOrBefore(DateTime.Now);
             this.telemetryRepositoryMock.Verify(x => x.Save(), Times.Once);
         }
 


### PR DESCRIPTION
That's a funny one. The test fails on the build machine, but on mine it's fine.

Reported problem is:
[vs2015] Failed   Ctor_WhenInstallationDateIsDateTimeMin_SetsCurrentDateAndSave
Expected a date and time before <2017-10-11 12:07:42.470>, but found <2017-10-11 12:07:42.470>.

This is likely caused by DateTime accuracy. It is as accurate as OS timer, which on Windows defaults to ~15ms. So it is quite possible that calling DateTime.Now in short intervals gives the same answer.
