### PR TITLE
Added unit tests for suppression matching

### DIFF
--- a/src/Integration.Vsix.UnitTests/Integration.Vsix.UnitTests.csproj
+++ b/src/Integration.Vsix.UnitTests/Integration.Vsix.UnitTests.csproj
@@ -323,6 +323,10 @@
       <Project>{03278c1a-ee78-4fa7-a5b0-1ab0a81ea76f}</Project>
       <Name>Integration</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SonarQube.Client\SonarQube.Client.csproj">
+      <Project>{5e513fc3-bda7-40f2-8b6a-1bb9372acb99}</Project>
+      <Name>SonarQube.Client</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TestInfrastructure\TestInfrastructure.csproj">
       <Project>{fbd8024a-9795-4e5b-938e-afe44fca240c}</Project>
       <Name>TestInfrastructure</Name>

--- a/src/Integration.Vsix.UnitTests/Suppression/SuppressionHandlerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Suppression/SuppressionHandlerTests.cs
@@ -1,0 +1,189 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Integration.Suppression;
+using SonarLint.VisualStudio.Integration.Vsix.Suppression;
+using SonarQube.Client.Models;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
+{
+    [TestClass]
+    public class SuppressionHandlerTests
+    {
+        private static readonly DiagnosticDescriptor DummyDescriptor = new DiagnosticDescriptor("dummyId",
+            "dummy title", "dummy Message", "dummy category", DiagnosticSeverity.Error, false);
+
+        private readonly Expression<Func<ILiveIssueFactory, LiveIssue>> createMethod =
+            x => x.Create(It.IsAny<SyntaxTree>(), It.IsAny<Diagnostic>());
+
+        private readonly Expression<Func<ISonarQubeIssuesProvider, IEnumerable<SonarQubeIssue>>> getSuppressedIssuesMethod =
+            x => x.GetSuppressedIssues(It.IsAny<string>(), It.IsAny<string>());
+
+        private Mock<ILiveIssueFactory> issueFactoryMock;
+        private Mock<ISonarQubeIssuesProvider> issueProviderMock;
+        private Mock<SyntaxTree> syntaxTreeMock;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            issueFactoryMock = new Mock<ILiveIssueFactory>();
+            issueProviderMock = new Mock<ISonarQubeIssuesProvider>();
+            syntaxTreeMock = new Mock<SyntaxTree>();
+        }
+
+        [TestMethod]
+        public void Ctor_Arguments()
+        {
+            Action op = () => new SuppressionHandler(null, issueProviderMock.Object);
+            op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("liveIssueFactory");
+
+            op = () => new SuppressionHandler(issueFactoryMock.Object, null);
+            op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("serverIssuesProvider");
+        }
+
+        [TestMethod]
+        public void ShouldReport_LocationNotInSource_ReturnsTrue()
+        {
+            Diagnostic diag = CreateDiagnostic(CreateNonSourceLocation());
+
+            SuppressionHandler handler = new SuppressionHandler(issueFactoryMock.Object, issueProviderMock.Object);
+
+            bool result = handler.ShouldIssueBeReported(new Mock<SyntaxTree>().Object, diag);
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldReport_CannotCreateLiveIssue_ReturnsTrue()
+        {
+            // Arrange
+            Diagnostic diag = CreateDiagnostic(CreateSourceLocation());
+            issueFactoryMock.Setup(createMethod)
+                .Returns((LiveIssue)null)
+                .Verifiable();
+
+            SuppressionHandler handler = new SuppressionHandler(issueFactoryMock.Object, issueProviderMock.Object);
+
+            // Act
+            bool result = handler.ShouldIssueBeReported(syntaxTreeMock.Object, diag);
+
+            // Assert
+            VerifyLiveIssueCreated(Times.Once());
+            VerifyServerIssuesRequested(Times.Never());
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldReport_NoServerIssues_ReturnsTrue()
+        {
+            // Arrange
+            Diagnostic diag = CreateDiagnostic(CreateSourceLocation());
+            issueFactoryMock.Setup(createMethod)
+                .Returns(new LiveIssue(diag, Guid.NewGuid().ToString()))
+                .Verifiable();
+
+            issueProviderMock.Setup(getSuppressedIssuesMethod)
+                .Returns((IEnumerable<SonarQubeIssue>)null)
+                .Verifiable();
+
+            SuppressionHandler handler = new SuppressionHandler(issueFactoryMock.Object, issueProviderMock.Object);
+
+            // Act
+            bool result = handler.ShouldIssueBeReported(syntaxTreeMock.Object, diag);
+
+            // Assert
+            VerifyLiveIssueCreated(Times.Once());
+            VerifyServerIssuesRequested(Times.Once());
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldReport_ProjectIssue_NoMatch_ReturnsTrue()
+        {
+            Diagnostic diag = CreateDiagnostic(Location.None);
+
+            SuppressionHandler handler = new SuppressionHandler(issueFactoryMock.Object, issueProviderMock.Object);
+
+            bool result = handler.ShouldIssueBeReported(new Mock<SyntaxTree>().Object, diag);
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldReport_ProjectIssue_MatchExists_ReturnsFalse()
+        {
+            Diagnostic diag = CreateDiagnostic(Location.None);
+
+            SuppressionHandler handler = new SuppressionHandler(issueFactoryMock.Object, issueProviderMock.Object);
+
+            bool result = handler.ShouldIssueBeReported(new Mock<SyntaxTree>().Object, diag);
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldReport_NoMatches_ReturnsTrue()
+        {
+            SuppressionHandler handler = new SuppressionHandler(issueFactoryMock.Object, issueProviderMock.Object);
+
+         //   bool result = handler.ShouldIssueBeReported()
+
+        }
+
+        private static Location CreateNonSourceLocation()
+        {
+            var nonSourceLocation = Location.Create("dummyFilePath.cs", new TextSpan(), new LinePositionSpan());
+            nonSourceLocation.IsInSource.Should().BeFalse();
+            return nonSourceLocation;
+        }
+
+        private Location CreateSourceLocation()
+        {
+            var sourceLocation = Location.Create(syntaxTreeMock.Object, new TextSpan());
+            sourceLocation.IsInSource.Should().BeTrue();
+            return sourceLocation;
+        }
+
+        private static Diagnostic CreateDiagnostic(Location loc)
+        {
+            return Diagnostic.Create(DummyDescriptor, loc);
+        }
+
+        private void SetServerIssues(IEnumerable<SonarQubeIssue> issues)
+        {
+            issueProviderMock.Setup(getSuppressedIssuesMethod).Returns(issues);
+        }
+
+        private void VerifyLiveIssueCreated(Times expected)
+        {
+            issueFactoryMock.Verify(createMethod, expected);
+        }
+
+        private void VerifyServerIssuesRequested(Times expected)
+        {
+            issueProviderMock.Verify(getSuppressedIssuesMethod, expected);
+        }
+    }
+}

--- a/src/Integration.Vsix.UnitTests_2017/Integration.Vsix.UnitTests.csproj
+++ b/src/Integration.Vsix.UnitTests_2017/Integration.Vsix.UnitTests.csproj
@@ -336,6 +336,10 @@
       <Project>{03278c1a-ee78-4fa7-a5b0-1ab0a81ea76f}</Project>
       <Name>Integration</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SonarQube.Client\SonarQube.Client.csproj">
+      <Project>{5e513fc3-bda7-40f2-8b6a-1bb9372acb99}</Project>
+      <Name>SonarQube.Client</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TestInfrastructure_2017\TestInfrastructure.csproj">
       <Project>{fbd8024a-9795-4e5b-938e-afe44fca240c}</Project>
       <Name>TestInfrastructure</Name>

--- a/src/Integration.Vsix/Suppression/ILiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/ILiveIssueFactory.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
+{
+    public interface ILiveIssueFactory
+    {
+        LiveIssue Create(SyntaxTree syntaxTree, Diagnostic diagnostic);
+    }
+}

--- a/src/Integration.Vsix/Suppression/LiveIssue.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssue.cs
@@ -24,10 +24,10 @@ using SonarLint.VisualStudio.Integration.Suppression;
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {
     /// <summary>
-    ///     Information about a single Roslyn issue, decorated with the extra information required to map it to a
-    ///     SonarQube issue.
+    /// Information about a single Roslyn issue, decorated with the extra information required to map it to a
+    /// SonarQube issue.
     /// </summary>
-    internal class LiveIssue
+    public class LiveIssue
     {
         public LiveIssue(Diagnostic diagnostic, string projectGuid, string issueFilePath = "", int startLine = 0,
             string wholeLineText = "")

--- a/src/Integration.Vsix/Suppression/LiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssueFactory.cs
@@ -43,7 +43,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
     /// Factory for <see cref="LiveIssue"/>s i.e. diagnostics that are decorated with
     /// additional information required to map to issues in the SonarQube server format
     /// </summary>
-    internal sealed class LiveIssueFactory
+    internal sealed class LiveIssueFactory : ILiveIssueFactory
     {
         private readonly Workspace workspace;
 

--- a/src/Integration.Vsix/Suppression/SuppressionHandler.cs
+++ b/src/Integration.Vsix/Suppression/SuppressionHandler.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using SonarLint.VisualStudio.Integration.Suppression;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
+{
+    internal class SuppressionHandler
+    {
+        private readonly ILiveIssueFactory liveIssueFactory;
+        private readonly ISonarQubeIssuesProvider serverIssuesProvider;
+
+        public SuppressionHandler(ILiveIssueFactory liveIssueFactory, ISonarQubeIssuesProvider serverIssuesProvider)
+        {
+            if (liveIssueFactory == null)
+            {
+                throw new ArgumentNullException(nameof(liveIssueFactory));
+            }
+            if (serverIssuesProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serverIssuesProvider));
+            }
+
+            this.liveIssueFactory = liveIssueFactory;
+            this.serverIssuesProvider = serverIssuesProvider;
+        }
+
+        public bool ShouldIssueBeReported(SyntaxTree syntaxTree, Diagnostic diagnostic)
+        {
+            // This method is called for every analyzer issue that is raised so it should be fast.
+            if (!diagnostic.Location.IsInSource &&
+                diagnostic.Location != Location.None)
+            {
+                return true;
+            }
+
+            LiveIssue liveIssue = liveIssueFactory.Create(syntaxTree, diagnostic);
+            if (liveIssue == null)
+            {
+                return true; // Unable to get the data required to map a Roslyn issue to a SonarQube issue
+            }
+
+            // Issues match if:
+            // 1. Same component, same file, same error code, same line hash        // tolerant to line number changing
+            // 2. Same component, same file, same error code, same line             // tolerant to code on the line changing e.g. var rename
+
+            // As a minimum, the project, file and rule id must match
+            var issuesInFile = serverIssuesProvider.GetSuppressedIssues(liveIssue.ProjectGuid, liveIssue.IssueFilePath);
+            if (issuesInFile == null)
+            {
+                return true;
+            }
+
+            // TODO: rule repository?
+            issuesInFile = issuesInFile.Where(i => StringComparer.OrdinalIgnoreCase.Equals(liveIssue.Diagnostic.Id, i.RuleId));
+
+            bool matchFound = issuesInFile.Any(i =>
+                    liveIssue.StartLine == i.Line ||
+                    StringComparer.Ordinal.Equals(liveIssue.LineHash, i.Hash));
+            return !matchFound;
+        }
+    }
+}


### PR DESCRIPTION
I made some minor changes to the product code to make it more testable - I moved the suppression matching code into a separate class and added an interface for the live issue factory.