### PR TITLE
Reverted the change to the SonarLint icon in VS2015

### DIFF
--- a/src/Integration.Vsix/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
     <MoreInfo>http://vs.sonarlint.org</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>http://vs.sonarlint.org</GettingStartedGuide>
-    <Icon>sonarlint_wave_128px.png</Icon>
+    <Icon>Resources\sonarlint_32.png</Icon>
     <PreviewImage>Resources\sonarlint_200.png</PreviewImage>
     <Tags>SonarLint, SonarQube, Analysis, Roslyn, CodeAnalysis, Analyzer, Code analysis, Sonar, Debt, Technical, Tech, Quality</Tags>
   </Metadata>


### PR DESCRIPTION
Fixes #407 

The new icon works ok in VS2107 and doesn't stop the package from being uploaded. It's only an issue in VS2015. The icon was changed because it was felt that the image was too small when it appeared in the VS Gallery.  I'll check again when the new package is uploaded and open a new issue if necessary.

Note on local testing: the VSIX builds correctly on VS2015 with the other icon i.e. VS doesn't complain. However, if you install the VSIX locally and look at SonarLint in the Extension Manager you'll see it's using a generic icon.