### PR TITLE
Fixed path to icon in VS2015

### DIFF
--- a/src/Integration.Vsix/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
     <MoreInfo>http://vs.sonarlint.org</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>http://vs.sonarlint.org</GettingStartedGuide>
-    <Icon>sonarlint_wave_128px.png</Icon>
+    <Icon>Resources\sonarlint_wave_128px.png</Icon>
     <PreviewImage>Resources\sonarlint_200.png</PreviewImage>
     <Tags>SonarLint, SonarQube, Analysis, Roslyn, CodeAnalysis, Analyzer, Code analysis, Sonar, Debt, Technical, Tech, Quality</Tags>
   </Metadata>


### PR DESCRIPTION
Fixes #407 

Note: VS doesn't complain about a missing icon during the build, but if you install the VSIX locally and look in the Extension Manager you'll see that VS uses a generic icon if it can't find the one specified in the manifest file.