### PR TITLE
Cannot update bindings when SonarC# 6.7 is installed on SonarQube

### DIFF
--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -451,6 +451,26 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             controller.NumberOfAbortRequests.Should().Be(1);
         }
 
+        [TestMethod]
+        public async Task ConnectionWorkflow_DownloadServiceParameters_NoTestProjectRegexProperty()
+        {
+            // Arrange
+            var controller = new ConfigurableProgressController();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            this.sonarQubeServiceMock.Setup(x => x.GetAllPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<SonarQubeProperty> { });
+
+            ConnectionWorkflow testSubject = SetTestSubjectWithConnectedServer();
+
+            // Act
+            await testSubject.DownloadServiceParametersAsync(controller, progressEvents, CancellationToken.None);
+
+            // Assert
+            filter.AssertTestRegex(SonarQubeProperty.TestProjectRegexDefaultValue, RegexOptions.IgnoreCase);
+            progressEvents.AssertProgressMessages(Strings.DownloadingServerSettingsProgessMessage);
+        }
+
         #endregion Tests
 
         #region Helpers

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -223,7 +223,6 @@ namespace SonarLint.VisualStudio.Integration.Connection
         {
             Debug.Assert(this.ConnectedServer != null);
 
-            const string TestProjectRegexKey = "sonar.cs.msbuild.testProjectPattern";
             const string TestProjectRegexDefaultValue = @"[^\\]*test[^\\]*$";
 
             // Should never realistically take more than 1 second to match against a project name
@@ -239,7 +238,7 @@ namespace SonarLint.VisualStudio.Integration.Connection
                 return;
             }
 
-            var testProjRegexPattern = properties.First(x => StringComparer.Ordinal.Equals(x.Key, TestProjectRegexKey)).Value;
+            var testProjRegexPattern = properties.FirstOrDefault(IsTestProjectPatternProperty)?.Value;
 
             Regex regex = null;
             if (testProjRegexPattern != null)
@@ -261,6 +260,12 @@ namespace SonarLint.VisualStudio.Integration.Connection
             var projectFilter = this.host.GetService<IProjectSystemFilter>();
             projectFilter.AssertLocalServiceIsNotNull();
             projectFilter.SetTestRegex(regex ?? defaultRegex);
+        }
+
+        private static bool IsTestProjectPatternProperty(SonarQubeProperty property)
+        {
+            const string TestProjectRegexKey = "sonar.cs.msbuild.testProjectPattern";
+            return StringComparer.Ordinal.Equals(property.Key, TestProjectRegexKey);
         }
 
         #endregion


### PR DESCRIPTION
Fix #473 