### PR TITLE
Removed a couple of anti-patterns

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintDaemonTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemonTests.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Threading;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
@@ -37,11 +38,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         [TestInitialize]
         public void SetUp()
         {
+            ISonarLintSettings settings = new Mock<ISonarLintSettings>().Object;
+            ISonarLintOutput output = new Mock<ISonarLintOutput>().Object;
+
             tempPath = Path.Combine(Path.GetRandomFileName());
             storagePath = Path.Combine(Path.GetRandomFileName());
             Directory.CreateDirectory(tempPath);
             Directory.CreateDirectory(storagePath);
-            daemon = new SonarLintDaemon(SonarLintDaemon.daemonVersion, storagePath, tempPath);
+            daemon = new SonarLintDaemon(settings, output, SonarLintDaemon.daemonVersion, storagePath, tempPath);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/SonarLintTracker/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTracker/TaggerProviderTests.cs
@@ -84,12 +84,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             mockSolution.Setup(s => s.FindProjectItem(It.IsAny<string>())).Returns(projectItem);
             var solution = mockSolution.Object;
 
-            var mockDTE = new Mock<_DTE>();
+            var mockDTE = new Mock<DTE>();
             mockDTE.Setup(d => d.Solution).Returns(solution);
             var dte = mockDTE.Object;
 
             var mockServiceProvider = new Mock<IServiceProvider>();
-            mockServiceProvider.Setup(s => s.GetService(typeof(_DTE))).Returns(dte);
+            mockServiceProvider.Setup(s => s.GetService(typeof(DTE))).Returns(dte);
             var serviceProvider = mockServiceProvider.Object;
 
             var mockFileExtensionRegistryService = new Mock<IFileExtensionRegistryService>();

--- a/src/Integration.Vsix.UnitTests/SonarLintTracker/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTracker/TaggerProviderTests.cs
@@ -18,12 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using EnvDTE;
 using FluentAssertions;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.TableManager;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
@@ -42,6 +42,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private ISonarLintDaemon daemon;
         private Mock<ISonarLintDaemon> mockDaemon;
         private Mock<ISonarLintSettings> mockISonarLintSettings;
+        private Mock<ISonarLintOutput> mockLogger;
 
         private string filename = "foo.js";
         private Mock<ITextDocument> mockTextDocument;
@@ -87,9 +88,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             mockDTE.Setup(d => d.Solution).Returns(solution);
             var dte = mockDTE.Object;
 
-            var mockSVsServiceProvider = new Mock<SVsServiceProvider>();
-            mockSVsServiceProvider.Setup(s => s.GetService(typeof(_DTE))).Returns(dte);
-            var SVsServiceProvider = mockSVsServiceProvider.Object;
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(s => s.GetService(typeof(_DTE))).Returns(dte);
+            var serviceProvider = mockServiceProvider.Object;
 
             var mockFileExtensionRegistryService = new Mock<IFileExtensionRegistryService>();
             var fileExtensionRegistryService = mockFileExtensionRegistryService.Object;
@@ -113,7 +114,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 .Setup(t => t.TryGetTextDocument(It.IsAny<ITextBuffer>(), out textDocument))
                 .Returns(true);
 
-            this.provider = new TaggerProvider(tableManagerProvider, textDocumentFactoryService, contentTypeRegistryService, fileExtensionRegistryService, daemon, SVsServiceProvider, sonarLintSettings);
+            mockLogger = new Mock<ISonarLintOutput>();
+
+            this.provider = new TaggerProvider(tableManagerProvider, textDocumentFactoryService, contentTypeRegistryService, fileExtensionRegistryService, daemon, serviceProvider, sonarLintSettings, mockLogger.Object);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix/Settings/GeneralOptionsDialogPage.cs
+++ b/src/Integration.Vsix/Settings/GeneralOptionsDialogPage.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using Microsoft.VisualStudio.Shell;
@@ -33,7 +34,19 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private GeneralOptionsDialogControl dialogControl;
         private ISonarLintSettings settings;
 
-        protected override UIElement Child => dialogControl ?? (dialogControl = new GeneralOptionsDialogControl());
+        protected override UIElement Child
+        {
+            get
+            {
+                if (dialogControl == null)
+                {
+                    Debug.Assert(this.Site != null, "Expecting the page to be sited");
+                    var daemon = this.Site.GetMefService<ISonarLintDaemon>();
+                    dialogControl = new GeneralOptionsDialogControl(Settings, daemon);
+                }
+                return dialogControl;
+            }
+        }
 
         protected override void OnActivate(CancelEventArgs e)
         {
@@ -61,7 +74,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             {
                 if (this.settings == null)
                 {
-                    this.settings = ServiceProvider.GlobalProvider.GetMefService<ISonarLintSettings>();
+                    Debug.Assert(this.Site != null, "Expecting the page to be sited");
+                    this.settings = this.Site.GetMefService<ISonarLintSettings>();
                 }
 
                 return this.settings;

--- a/src/Integration.Vsix/SonarLintDaemon/CFamily.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/CFamily.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         internal const string CPP_LANGUAGE_KEY = "cpp";
         internal const string C_LANGUAGE_KEY = "c";
 
-        public static string TryGetConfig(EnvDTE.ProjectItem projectItem, string absoluteFilePath, out string sqLanguage)
+        public static string TryGetConfig(ISonarLintOutput logger, EnvDTE.ProjectItem projectItem, string absoluteFilePath, out string sqLanguage)
         {
             try
             {
@@ -42,7 +42,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             }
             catch (Exception e)
             {
-                VsShellUtils.WriteToSonarLintOutputPane(ServiceProvider.GlobalProvider, "Unable to collect C/C++ configuration: " + e.ToString());
+                logger.Write("Unable to collect C/C++ configuration: " + e.ToString());
                 sqLanguage = null;
                 return null;
             }

--- a/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemonSplashscreen.xaml.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemonSplashscreen.xaml.cs
@@ -1,6 +1,26 @@
-﻿using System.ComponentModel;
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.ComponentModel;
 using System.Windows;
-using Microsoft.VisualStudio.Shell;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {
@@ -9,8 +29,17 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     /// </summary>
     public partial class SonarLintDaemonSplashscreen : Window
     {
-        public SonarLintDaemonSplashscreen()
+        private readonly ISonarLintSettings settings;
+
+        public SonarLintDaemonSplashscreen(ISonarLintSettings settings)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            this.settings = settings;
+
             InitializeComponent();
         }
 
@@ -23,7 +52,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         {
             base.OnClosing(e);
 
-            var settings = ServiceProvider.GlobalProvider.GetMefService<ISonarLintSettings>();
             settings.SkipActivateMoreDialog = SkipActivateMoreDialogCheckBox.IsChecked.Value;
         }
     }

--- a/src/Integration.Vsix/SonarLintDaemonPackage.cs
+++ b/src/Integration.Vsix/SonarLintDaemonPackage.cs
@@ -95,14 +95,14 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             else if (settings.IsActivateMoreEnabled)
             {
                 // User already agreed to have the daemon installed, so directly start download
-                new SonarLintDaemonInstaller().Show();
+                new SonarLintDaemonInstaller(settings, daemon).Show();
             }
             else if (!settings.SkipActivateMoreDialog)
             {
-                var result = new SonarLintDaemonSplashscreen().ShowDialog();
+                var result = new SonarLintDaemonSplashscreen(settings).ShowDialog();
                 if (result == true)
                 {
-                    new SonarLintDaemonInstaller().Show();
+                    new SonarLintDaemonInstaller(settings, daemon).Show();
                 }
             }
         }

--- a/src/Integration.Vsix/SonarLintTagger/IssueTagger.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueTagger.cs
@@ -38,12 +38,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     /// </remarks>
     internal class IssueTagger : ITagger<IErrorTag>, IDisposable
     {
-        private readonly _DTE dte;
+        private readonly DTE dte;
         private readonly TaggerProvider provider;
         private readonly ITextBuffer textBuffer;
         private readonly IList<IContentType> contentTypes;
 
-        internal EnvDTE.ProjectItem ProjectItem { get; private set; }
+        internal ProjectItem ProjectItem { get; private set; }
         private ITextSnapshot currentSnapshot;
         private NormalizedSnapshotSpanCollection dirtySpans;
 
@@ -54,9 +54,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         internal IssuesSnapshot Snapshot { get; set; }
 
-        internal IssueTagger(IServiceProvider serviceProvider, TaggerProvider provider, ITextBuffer buffer, ITextDocument document, IList<IContentType> contentTypes)
+        internal IssueTagger(DTE dte, TaggerProvider provider, ITextBuffer buffer, ITextDocument document, IList<IContentType> contentTypes)
         {
-            this.dte = (_DTE)serviceProvider.GetService(typeof(_DTE));
+            this.dte = dte;
             this.provider = provider;
             this.textBuffer = buffer;
             this.contentTypes = contentTypes;

--- a/src/Integration.Vsix/SonarLintTagger/IssueTagger.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueTagger.cs
@@ -54,9 +54,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         internal IssuesSnapshot Snapshot { get; set; }
 
-        internal IssueTagger(_DTE dte, TaggerProvider provider, ITextBuffer buffer, ITextDocument document, IList<IContentType> contentTypes)
+        internal IssueTagger(IServiceProvider serviceProvider, TaggerProvider provider, ITextBuffer buffer, ITextDocument document, IList<IContentType> contentTypes)
         {
-            this.dte = dte;
+            this.dte = (_DTE)serviceProvider.GetService(typeof(_DTE));
             this.provider = provider;
             this.textBuffer = buffer;
             this.contentTypes = contentTypes;

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
+using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
@@ -49,7 +50,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         internal readonly ITextDocumentFactoryService TextDocumentFactoryService;
         internal readonly IContentTypeRegistryService ContentTypeRegistryService;
         internal readonly IFileExtensionRegistryService FileExtensionRegistryService;
-        internal readonly IServiceProvider serviceProvider;
+        internal readonly DTE dte;
 
         private readonly List<SinkManager> managers = new List<SinkManager>();
         private readonly TrackerManager taggers = new TrackerManager();
@@ -82,7 +83,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                                                    StandardTableColumnDefinitions.ProjectName);
 
             this.daemon = daemon;
-            this.serviceProvider = serviceProvider;
+            this.dte = (DTE)serviceProvider.GetService(typeof(DTE));
             this.settings = settings;
             this.logger = logger;
         }
@@ -132,7 +133,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             {
                 if (!taggers.ExistsForFile(filePath))
                 {
-                    var tracker = new IssueTagger(serviceProvider, this, buffer, document, contentTypes);
+                    var tracker = new IssueTagger(dte, this, buffer, document, contentTypes);
                     return tracker as ITagger<T>;
                 }
             }

--- a/src/Integration/Helpers/SonarLintOutput.cs
+++ b/src/Integration/Helpers/SonarLintOutput.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 
@@ -27,9 +28,21 @@ namespace SonarLint.VisualStudio.Integration
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class SonarLintOutput : ISonarLintOutput
     {
+        private readonly IServiceProvider serviceProvider;
+
+        [ImportingConstructor]
+        public SonarLintOutput([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+            this.serviceProvider = serviceProvider;
+        }
+
         public void Write(string message)
         {
-            VsShellUtils.WriteToSonarLintOutputPane(ServiceProvider.GlobalProvider, message);
+            VsShellUtils.WriteToSonarLintOutputPane(this.serviceProvider, message);
         }
     }
 }


### PR DESCRIPTION
* removed uses of the static _ServiceProvider.GlobalProvider_ (it should always be possible to get hold of a specific service provider, and it makes testing simpler)
* changed variables typed as _SVSServiceProvider_ (it's a marker interface - should always use _IServiceProvider_)
* removed _GetMefService_ calls from MEF components (if a component is created using MEF then it should import any MEF components it needs; it should not query for them using the service provider)
