### PR TITLE
Added IConfigurationProvider abstraction

### DIFF
--- a/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
@@ -25,6 +25,7 @@ using EnvDTE;
 using FluentAssertions;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
@@ -32,7 +33,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     public class SolutionBindingInformationProviderTests
     {
         private ConfigurableServiceProvider serviceProvider;
-        private ConfigurableSolutionBindingSerializer bindingSerializer;
+        private ConfigurableConfigurationProvider configProvider;
         private ConfigurableRuleSetSerializer ruleSetSerializer;
         private ConfigurableVsProjectSystemHelper projectSystemHelper;
         private ConfigurableSolutionRuleSetsInformationProvider ruleSetInfoProvider;
@@ -42,8 +43,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             this.serviceProvider = new ConfigurableServiceProvider();
 
-            this.bindingSerializer = new ConfigurableSolutionBindingSerializer();
-            this.serviceProvider.RegisterService(typeof(Persistence.ISolutionBindingSerializer), this.bindingSerializer);
+            this.configProvider = new ConfigurableConfigurationProvider();
+            this.serviceProvider.RegisterService(typeof(IConfigurationProvider), this.configProvider);
 
             this.projectSystemHelper = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystemHelper);
@@ -70,13 +71,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
 
             // Case 1: Not bound
-            this.bindingSerializer.CurrentBinding = null;
+            this.configProvider.ProjectToReturn = null;
 
             // Act + Assert
             testSubject.IsSolutionBound().Should().BeFalse();
 
             // Case 2: Bound
-            this.bindingSerializer.CurrentBinding = new Persistence.BoundSonarQubeProject();
+            this.configProvider.ProjectToReturn = new Persistence.BoundSonarQubeProject();
 
             // Act + Assert
             testSubject.IsSolutionBound().Should().BeTrue();
@@ -89,13 +90,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
 
             // Case 1: Not bound
-            this.bindingSerializer.CurrentBinding = null;
+            this.configProvider.ProjectToReturn = null;
 
             // Act + Assert
             testSubject.GetProjectKey().Should().BeNull();
 
             // Case 2: Bound
-            this.bindingSerializer.CurrentBinding = new Persistence.BoundSonarQubeProject { ProjectKey = "PROJECT_KEY" };
+            this.configProvider.ProjectToReturn = new Persistence.BoundSonarQubeProject { ProjectKey = "PROJECT_KEY" };
 
             // Act + Assert
             testSubject.GetProjectKey().Should().Be("PROJECT_KEY");
@@ -106,7 +107,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
-            this.bindingSerializer.CurrentBinding = null;
+            this.configProvider.ProjectToReturn = null;
             IEnumerable<Project> projects;
 
             // Act
@@ -229,7 +230,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
-            this.bindingSerializer.CurrentBinding = null;
+            this.configProvider.ProjectToReturn = null;
             IEnumerable<Project> projects;
 
             // Act
@@ -279,7 +280,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private void SetValidSolutionBinding()
         {
-            this.bindingSerializer.CurrentBinding = new Persistence.BoundSonarQubeProject { ProjectKey = "projectKey" };
+            this.configProvider.ProjectToReturn = new Persistence.BoundSonarQubeProject { ProjectKey = "projectKey" };
         }
 
         private void SetValidFilteredProjects()

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarLint.VisualStudio.Integration.Helpers;
 using SonarLint.VisualStudio.Integration.InfoBar;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
@@ -156,6 +157,9 @@ namespace SonarLint.VisualStudio.Integration
 
         internal /*for testing purposes*/ void ProcessSolutionBinding()
         {
+            // TODO: CM2: this code is old relevant for legacy connected mode
+            // (checks for projects that do not have a ruleset, or rulesets that are out of date)
+
             // No need to do anything if by the time got here the solution was closed (or unbound)
             if (!this.IsActiveSolutionBound)
             {
@@ -235,10 +239,10 @@ namespace SonarLint.VisualStudio.Integration
 
                 // Need to capture the current binding information since the user can change the binding
                 // and running the Update should just no-op in that case.
-                var solutionBinding = this.host.GetService<ISolutionBindingSerializer>();
-                solutionBinding.AssertLocalServiceIsNotNull();
+                var configProvider = this.host.GetService<IConfigurationProvider>();
+                configProvider.AssertLocalServiceIsNotNull();
 
-                this.infoBarBinding = solutionBinding.ReadSolutionBinding();
+                this.infoBarBinding = configProvider.GetBoundProject();
             }
         }
 
@@ -261,10 +265,12 @@ namespace SonarLint.VisualStudio.Integration
             var componentModel = host.GetService<SComponentModel, IComponentModel>();
             TelemetryLoggerAccessor.GetLogger(componentModel)?.ReportEvent(TelemetryEvent.ErrorListInfoBarUpdateCalled);
 
-            var bindingSerialzer = this.host.GetService<ISolutionBindingSerializer>();
-            bindingSerialzer.AssertLocalServiceIsNotNull();
+            var configProvider = this.host.GetService<IConfigurationProvider>();
+            configProvider.AssertLocalServiceIsNotNull();
 
-            BoundSonarQubeProject binding = bindingSerialzer.ReadSolutionBinding();
+            // TODO: CM2: only relevant for old connected mode
+
+            BoundSonarQubeProject binding = configProvider.GetBoundProject();
             if (binding == null
                 || this.infoBarBinding == null
                 || binding.ServerUri != this.infoBarBinding.ServerUri
@@ -572,10 +578,11 @@ namespace SonarLint.VisualStudio.Integration
                     return;
                 }
 
-                var solutionBinding = this.host.GetService<ISolutionBindingSerializer>();
-                solutionBinding.AssertLocalServiceIsNotNull();
+                var configProvider = this.host.GetService<IConfigurationProvider>();
+                configProvider.AssertLocalServiceIsNotNull();
 
-                var binding = solutionBinding.ReadSolutionBinding();
+                // TODO: CM2: only relevant for legacy connected mode
+                var binding = configProvider.GetBoundProject();
                 if (binding == null)
                 {
                     return;

--- a/src/Integration/LocalServices/ISolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/ISolutionBindingInformationProvider.cs
@@ -23,6 +23,11 @@ using EnvDTE;
 
 namespace SonarLint.VisualStudio.Integration
 {
+    // Legacy connected mode
+    // The "GetUnboundProjects"/"GetBoundProjects" are only used by the error list controller
+    // in legacy mode to find projects that have been added to a legacy bound solution (and
+    // in fact "GetBoundProjects" doesn't seem to be called at all).
+
     /// <summary>
     /// SonarQube-bound project discovery
     /// </summary>

--- a/src/Integration/LocalServices/ISolutionRuleSetsInformationProvider.cs
+++ b/src/Integration/LocalServices/ISolutionRuleSetsInformationProvider.cs
@@ -23,6 +23,9 @@ using EnvDTE;
 
 namespace SonarLint.VisualStudio.Integration
 {
+    // Legacy connected mode:
+    // Gets the rulesets/paths/solution folder for the old connected mode.
+
     interface ISolutionRuleSetsInformationProvider : ILocalService
     {
         /// <summary>

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -24,10 +24,14 @@ using System.Diagnostics;
 using System.Linq;
 using EnvDTE;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 
 namespace SonarLint.VisualStudio.Integration
 {
+    // Legacy connected mode
+    // Not required in for the new connected mode
+
     internal class SolutionBindingInformationProvider : ISolutionBindingInformationProvider
     {
         private readonly IServiceProvider serviceProvider;
@@ -45,6 +49,7 @@ namespace SonarLint.VisualStudio.Integration
         #region ISolutionBindingInformationProvider
         public bool IsSolutionBound()
         {
+            // TODO: CM2: consider changing this method to "IsLegacySolutionBound"
             return this.GetSolutionBinding() != null;
         }
 
@@ -67,10 +72,10 @@ namespace SonarLint.VisualStudio.Integration
         #region Non-public API
         private BoundSonarQubeProject GetSolutionBinding()
         {
-            var bindingSerializer = this.serviceProvider.GetService<ISolutionBindingSerializer>();
-            bindingSerializer.AssertLocalServiceIsNotNull();
+            var configProvider = this.serviceProvider.GetService<IConfigurationProvider>();
+            configProvider.AssertLocalServiceIsNotNull();
 
-            return bindingSerializer.ReadSolutionBinding();
+            return configProvider.GetBoundProject();
         }
 
         private IEnumerable<Project> GetUnboundProjects(BoundSonarQubeProject binding)

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Windows.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.ProfileConflicts;
 using SonarLint.VisualStudio.Integration.Progress;
@@ -53,6 +54,7 @@ namespace SonarLint.VisualStudio.Integration
                 typeof(IRuleSetConflictsController),
                 typeof(IProjectSystemFilter),
                 typeof(IErrorListInfoBarController),
+                typeof(IConfigurationProvider),
                 typeof(ISolutionBindingInformationProvider)
         };
 
@@ -296,6 +298,7 @@ namespace SonarLint.VisualStudio.Integration
             this.localServices.Add(typeof(ISolutionRuleSetsInformationProvider), new Lazy<ILocalService>(() => new SolutionRuleSetsInformationProvider(this, Logger)));
             this.localServices.Add(typeof(IRuleSetSerializer), new Lazy<ILocalService>(() => new RuleSetSerializer(this)));
             this.localServices.Add(typeof(ISolutionBindingSerializer), new Lazy<ILocalService>(() => new SolutionBindingSerializer(this)));
+            this.localServices.Add(typeof(IConfigurationProvider), new Lazy<ILocalService>(() => new LegacyConfigurationProviderAdapter(this.GetService<ISolutionBindingSerializer>())));
             this.localServices.Add(typeof(IProjectSystemHelper), new Lazy<ILocalService>(() => new ProjectSystemHelper(this)));
             this.localServices.Add(typeof(IConflictsManager), new Lazy<ILocalService>(() => new ConflictsManager(this, Logger)));
             this.localServices.Add(typeof(IRuleSetInspector), new Lazy<ILocalService>(() => new RuleSetInspector(this, Logger)));

--- a/src/Integration/NewConnectedMode/ConnectionMode.cs
+++ b/src/Integration/NewConnectedMode/ConnectionMode.cs
@@ -1,0 +1,29 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Integration.NewConnectedMode
+{
+    internal enum ConnectedMode
+    {
+        Standalone,
+        LegacyConnected,
+        Connected
+    }
+}

--- a/src/Integration/NewConnectedMode/IConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/IConfigurationProvider.cs
@@ -1,0 +1,35 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.NewConnectedMode
+{
+    internal interface IConfigurationProvider : ILocalService
+    {
+        /// <summary>
+        /// Returns the currently bound project, or null if the current solution is
+        /// not bound, or if there is not a current solution
+        /// </summary>
+        BoundSonarQubeProject GetBoundProject();
+
+//        ConnectedMode GetMode();
+    }
+}

--- a/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
+++ b/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
@@ -23,9 +23,13 @@ using SonarLint.VisualStudio.Integration.Persistence;
 
 namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 {
+
+    // TODO: remove this class
+    // It's a temporary measure to keep the existing code working while
+    // refactoring/adding the new lightweight connected mode
+
     internal class LegacyConfigurationProviderAdapter : IConfigurationProvider
     {
-
         private readonly ISolutionBindingSerializer legacySerializer;
 
         public LegacyConfigurationProviderAdapter(ISolutionBindingSerializer legacySerializer)

--- a/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
+++ b/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
@@ -1,0 +1,49 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.NewConnectedMode
+{
+    internal class LegacyConfigurationProviderAdapter : IConfigurationProvider
+    {
+
+        private readonly ISolutionBindingSerializer legacySerializer;
+
+        public LegacyConfigurationProviderAdapter(ISolutionBindingSerializer legacySerializer)
+        {
+            if (legacySerializer == null)
+            {
+                throw new ArgumentNullException(nameof(legacySerializer));
+            }
+            this.legacySerializer = legacySerializer;
+        }
+
+        /// <summary>
+        /// Returns the currently bound project, or null if the current solution is
+        /// not bound, or if there is not a current solution
+        /// </summary>
+        public BoundSonarQubeProject GetBoundProject()
+        {
+            return legacySerializer.ReadSolutionBinding();
+        }
+    }
+}

--- a/src/Integration/NewConnectedMode/SonarLintMode.cs
+++ b/src/Integration/NewConnectedMode/SonarLintMode.cs
@@ -20,7 +20,7 @@
 
 namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 {
-    internal enum ConnectedMode
+    internal enum SonarLintMode
     {
         Standalone,
         LegacyConnected,

--- a/src/Integration/ProfileConflicts/ConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/ConflictsManager.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using System.Linq;
 using EnvDTE;
 using Microsoft.VisualStudio;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Resources;
 
@@ -107,10 +108,11 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
 
         private RuleSetInformation[] GetAggregatedSolutionRuleSets()
         {
-            var solutionBinding = this.serviceProvider.GetService<ISolutionBindingSerializer>();
-            solutionBinding.AssertLocalServiceIsNotNull();
+            var configProvider = this.serviceProvider.GetService<IConfigurationProvider>();
+            configProvider.AssertLocalServiceIsNotNull();
 
-            BoundSonarQubeProject bindingInfo = solutionBinding.ReadSolutionBinding();
+            BoundSonarQubeProject bindingInfo = configProvider.GetBoundProject();
+            // TODO: CM2 - check that we are in legacy connected mode
             if (bindingInfo == null)
             {
                 return new RuleSetInformation[0];

--- a/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    /// <summary>
+    /// Configurable service provider used for testing
+    /// </summary>
+    internal class ConfigurableConfigurationProvider : IConfigurationProvider
+    {
+        public BoundSonarQubeProject ProjectToReturn { get; set; }
+        public BoundSonarQubeProject GetBoundProject()
+        {
+            return ProjectToReturn;
+        }
+    }
+}


### PR DESCRIPTION
First part of the changes to support the new lightweight connected mode ("LCM").

Previously, multiple classes needed to get information about the bound project. They all did this by using the _ISolutionBindingSerializer_ directly (which looks for and reads old legacy configuration from disc).

I've changed all of the existing code to use this new abstraction instead. The next step will be to make this class able to detect both the old and new connected modes.
