### PR TITLE
Modified IConfigurationProvider to return a config object

### DIFF
--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
@@ -120,7 +120,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             var testSubject = this.GetTestSubject();
-            this.configProvider.ModeToReturn = SonarLintMode.LegacyConnected;
+            SetBinding(new BoundSonarQubeProject(), SonarLintMode.LegacyConnected);
             this.SetFilteredProjects(); // no filtered projects
 
             // Act
@@ -135,7 +135,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             var testSubject = this.GetTestSubject();
-            this.configProvider.ModeToReturn = SonarLintMode.Standalone;
+            SetBinding(null, SonarLintMode.Standalone);
             this.SetFilteredProjects(ProjectSystemHelper.CSharpProjectKind);
 
             // Act
@@ -150,7 +150,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             var testSubject = this.GetTestSubject();
-            this.configProvider.ModeToReturn = SonarLintMode.Connected;
+            SetBinding(new BoundSonarQubeProject(), SonarLintMode.Connected);
             this.SetFilteredProjects(ProjectSystemHelper.CSharpProjectKind);
 
             // Act
@@ -166,8 +166,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Arrange
             var testSubject = this.GetTestSubject();
             this.SetFilteredProjects(ProjectSystemHelper.CSharpProjectKind, ProjectSystemHelper.CSharpProjectKind);
-            this.configProvider.ProjectToReturn = new BoundSonarQubeProject();
-            this.configProvider.ModeToReturn = SonarLintMode.LegacyConnected;
+            SetBinding(new BoundSonarQubeProject(), SonarLintMode.LegacyConnected);
             int called = 0;
 
             // Act
@@ -431,6 +430,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                project.SetProjectKind(new Guid(projectKind));
                return project;
            });
+        }
+
+        private void SetBinding(BoundSonarQubeProject boundProject, SonarLintMode mode)
+        {
+            this.configProvider.ProjectToReturn = boundProject;
+            this.configProvider.ModeToReturn = mode;
         }
 
         #endregion Helpers

--- a/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
@@ -86,6 +86,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Arrange
             var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
             this.configProvider.ModeToReturn = SonarLintMode.Connected;
+            this.configProvider.ProjectToReturn = new Persistence.BoundSonarQubeProject();
             IEnumerable<Project> projects;
 
             // Act

--- a/src/Integration.UnitTests/MefServices/ActiveSolutionBoundTrackerTests.cs
+++ b/src/Integration.UnitTests/MefServices/ActiveSolutionBoundTrackerTests.cs
@@ -418,6 +418,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private void ConfigureSolutionBinding(BoundSonarQubeProject boundProject)
         {
             this.configProvider.ProjectToReturn = boundProject;
+            this.configProvider.ModeToReturn = boundProject == null ? SonarLintMode.Standalone : SonarLintMode.LegacyConnected;
         }
 
         private void VerifyServiceConnect(Times expected)

--- a/src/Integration.Vsix/BoundSolutionAnalyzer.cs
+++ b/src/Integration.Vsix/BoundSolutionAnalyzer.cs
@@ -28,6 +28,8 @@ using Microsoft.VisualStudio.Shell;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {
+    // TODO: CM2: update to record telemetry for the new connected mode
+
     /// <summary>
     /// Analyzes the solution on build in order to determine if it has SonarQube rulesets
     /// and log that using <see cref="ITelemetryLogger"/>.

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -40,10 +40,14 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
+    // Legacy connected mode:
+    // Handles binding a solution for legacy connected mode i.e. writes the
+    // solution-level files and adds rulesets to every applicable project.
+
     /// <summary>
     /// Workflow execution for the bind command
     /// </summary>
-    internal class BindingWorkflow
+    internal class BindingWorkflow : IBindingWorkflow
     {
         private readonly IHost host;
         private readonly ConnectionInformation connectionInformation;

--- a/src/Integration/Binding/IBindingWorkflow.cs
+++ b/src/Integration/Binding/IBindingWorkflow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -18,15 +18,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Integration
-{
-    public enum DaemonLogLevel { Verbose, Info, Minimal };
+using SonarLint.VisualStudio.Progress.Controller;
 
-    public interface ISonarLintSettings
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    /// <summary>
+    /// Workflow for the bind command
+    /// </summary>
+    internal interface IBindingWorkflow
     {
-        bool ShowServerNuGetTrustWarning { get; set; } // Legacy connected mode: not used by the new connected mode
-        bool IsActivateMoreEnabled { get; set; }
-        bool SkipActivateMoreDialog { get; set; }
-        DaemonLogLevel DaemonLogLevel { get; set; }
-    }
+        IProgressEvents Run();
+   }
 }

--- a/src/Integration/Binding/ProjectBindingOperation.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.cs
@@ -28,6 +28,10 @@ using EnvDTE;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
+    // Legacy connected mode:
+    // * make binding changes to a single project i.e. writes the ruleset files
+    // and updates the project file
+
     internal partial class ProjectBindingOperation : IBindingOperation
     {
         private readonly IServiceProvider serviceProvider;

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -30,6 +30,10 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
+    // Legacy connected mode:
+    // * writes the binding info files to disk and adds them as solution items.
+    // * co-ordinates writing project-level changes
+
     /// <summary>
     /// Solution level binding by delegating some of the work to <see cref="ProjectBindingOperation"/>
     /// </summary>

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -275,6 +275,10 @@ namespace SonarLint.VisualStudio.Integration.Connection
         private async Task<bool> AreSolutionProjectsAndSonarQubePluginsCompatible(IProgressController controller,
             IProgressStepExecutionEvents notifications, CancellationToken cancellationToken)
         {
+            // TODO: CM2: specific to legacy connection mode???
+            // The new connection mode doesn't care which plugin versions are installed on the
+            // server, but what if C#/VB are not installed?
+
             notifications.ProgressChanged(Strings.DetectingSonarQubePlugins);
 
             var plugins = await this.host.SonarQubeService.GetAllPluginsAsync(cancellationToken);

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -66,9 +66,10 @@ namespace SonarLint.VisualStudio.Integration
             configProvider.AssertLocalServiceIsNotNull();
 
             // Only applicable in legacy mode
-            if (configProvider.GetMode() == SonarLintMode.LegacyConnected)
+            BindingConfiguration bindingConfig = configProvider.GetConfiguration();
+            if (bindingConfig.Mode == SonarLintMode.LegacyConnected)
             {
-                return configProvider.GetBoundProject();
+                return bindingConfig.Project;
             }
             return null;
         }

--- a/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
@@ -81,10 +81,9 @@ namespace SonarLint.VisualStudio.Integration
             // The solution changed inside the IDE
             this.solutionTracker.ActiveSolutionChanged += this.OnActiveSolutionChanged;
 
-            BoundSonarQubeProject project = this.configurationProvider.GetBoundProject();
-
-            this.IsActiveSolutionBound = project != null;
-            this.ProjectKey = project?.ProjectKey;
+            var bindingConfig = this.configurationProvider.GetConfiguration();
+            this.IsActiveSolutionBound = bindingConfig.Mode != SonarLintMode.Standalone;
+            this.ProjectKey = bindingConfig.Project?.ProjectKey;
         }
 
         private async void OnActiveSolutionChanged(object sender, EventArgs e)
@@ -114,7 +113,7 @@ namespace SonarLint.VisualStudio.Integration
             Debug.Assert(!sonarQubeService.IsConnected,
                 "SonarQube service should always be disconnected at this point");
 
-            var boundProject = this.configurationProvider.GetBoundProject();
+            var boundProject = this.configurationProvider.GetConfiguration().Project;
 
             if (boundProject != null)
             {
@@ -158,7 +157,7 @@ namespace SonarLint.VisualStudio.Integration
 
         private void RaiseAnalyzersChangedIfBindingChanged()
         {
-            var boundProject = this.configurationProvider.GetBoundProject();
+            var boundProject = this.configurationProvider.GetConfiguration().Project;
 
             bool isSolutionCurrentlyBound = boundProject != null;
             string projectKey = boundProject?.ProjectKey;

--- a/src/Integration/NewConnectedMode/BindingConfiguration.cs
+++ b/src/Integration/NewConnectedMode/BindingConfiguration.cs
@@ -18,20 +18,32 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using SonarLint.VisualStudio.Integration.Persistence;
 
 namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 {
-    internal interface IConfigurationProvider : ILocalService
+    internal class BindingConfiguration
     {
-        BindingConfiguration GetConfiguration();
+        public readonly static BindingConfiguration Standalone = new BindingConfiguration(null, SonarLintMode.Standalone);
 
-        /// <summary>
-        /// Returns the currently bound project, or null if the current solution is
-        /// not bound, or if there is not a current solution
-        /// </summary>
-        BoundSonarQubeProject GetBoundProject();
+        public static BindingConfiguration CreateBoundConfiguration(BoundSonarQubeProject project, bool isLegacy)
+        {
+            if(project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+            return new BindingConfiguration(project, isLegacy ? SonarLintMode.LegacyConnected : SonarLintMode.Connected);
+        }
 
-        SonarLintMode GetMode();
+        private BindingConfiguration(BoundSonarQubeProject project, SonarLintMode mode)
+        {
+            this.Project = project;
+            this.Mode = mode;
+        }
+
+        public BoundSonarQubeProject Project { get; }
+
+        public SonarLintMode Mode { get; }
     }
 }

--- a/src/Integration/NewConnectedMode/IConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/IConfigurationProvider.cs
@@ -18,20 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Integration.Persistence;
-
 namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 {
     internal interface IConfigurationProvider : ILocalService
     {
         BindingConfiguration GetConfiguration();
-
-        /// <summary>
-        /// Returns the currently bound project, or null if the current solution is
-        /// not bound, or if there is not a current solution
-        /// </summary>
-        BoundSonarQubeProject GetBoundProject();
-
-        SonarLintMode GetMode();
     }
 }

--- a/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
+++ b/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
@@ -51,20 +51,5 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             }
             return BindingConfiguration.CreateBoundConfiguration(project, isLegacy: true);
         }
-
-        /// <summary>
-        /// Returns the currently bound project, or null if the current solution is
-        /// not bound, or if there is not a current solution
-        /// </summary>
-        public BoundSonarQubeProject GetBoundProject()
-        {
-            return legacySerializer.ReadSolutionBinding();
-        }
-
-        public SonarLintMode GetMode()
-        {
-            //TODO: support new connected mode
-            return GetBoundProject() != null ? SonarLintMode.LegacyConnected : SonarLintMode.Standalone;
-        }
     }
 }

--- a/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
+++ b/src/Integration/NewConnectedMode/LegacyConfigurationProviderAdapter.cs
@@ -41,6 +41,17 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             this.legacySerializer = legacySerializer;
         }
 
+        public BindingConfiguration GetConfiguration()
+        {
+            //TODO: support new connected mode
+            var project = legacySerializer.ReadSolutionBinding();
+            if (project == null)
+            {
+                return BindingConfiguration.Standalone;
+            }
+            return BindingConfiguration.CreateBoundConfiguration(project, isLegacy: true);
+        }
+
         /// <summary>
         /// Returns the currently bound project, or null if the current solution is
         /// not bound, or if there is not a current solution

--- a/src/Integration/ProfileConflicts/ConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/ConflictsManager.cs
@@ -66,19 +66,18 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
             configProvider.AssertLocalServiceIsNotNull();
 
             // Check that we are in legacy connected mode
-            if (configProvider.GetMode() != SonarLintMode.LegacyConnected)
+            var bindingConfig = configProvider.GetConfiguration();
+            if (bindingConfig.Mode != SonarLintMode.LegacyConnected)
             {
                 return new ProjectRuleSetConflict[0];
             }
+            Debug.Assert(bindingConfig.Project != null, "Bound project should not be null if in legacy connected mode");
 
             // Note: some of the assumptions (see asserts below) are because have just bounded the solution (as documented on the interface),
             // in other cases assuming that the rule set are indeed on disk is not possible, and in fact re-syncing
             // would be required when we have missing rule-sets, otherwise finding conflicts will not be possible.
 
-            BoundSonarQubeProject bindingInfo = configProvider.GetBoundProject();
-            Debug.Assert(bindingInfo != null, "Bound project should not be null when in legacy connected mode");
-
-            RuleSetInformation[] aggregatedRuleSets = GetAggregatedSolutionRuleSets(bindingInfo);
+            RuleSetInformation[] aggregatedRuleSets = GetAggregatedSolutionRuleSets(bindingConfig.Project);
 
             if (aggregatedRuleSets.Length > 0)
             {

--- a/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 
@@ -28,16 +29,34 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     /// </summary>
     internal class ConfigurableConfigurationProvider : IConfigurationProvider
     {
-        public BoundSonarQubeProject ProjectToReturn { get; set; }
         public BoundSonarQubeProject GetBoundProject()
         {
             return ProjectToReturn;
         }
 
-        public SonarLintMode ModeToReturn { get; set; }
         public SonarLintMode GetMode()
         {
             return ModeToReturn;
         }
+
+        public BindingConfiguration GetConfiguration()
+        {
+            GetConfigurationAction?.Invoke();
+            
+            if (ModeToReturn == SonarLintMode.Standalone)
+            {
+                return BindingConfiguration.Standalone;
+            }
+            return BindingConfiguration.CreateBoundConfiguration(ProjectToReturn, SonarLintMode.LegacyConnected == ModeToReturn);
+        }
+
+        #region Test helpers
+
+        public BoundSonarQubeProject ProjectToReturn { get; set; }
+        public SonarLintMode ModeToReturn { get; set; }
+        public Action GetConfigurationAction { get; set; }
+
+        #endregion Test helpers
+
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
@@ -29,16 +29,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     /// </summary>
     internal class ConfigurableConfigurationProvider : IConfigurationProvider
     {
-        public BoundSonarQubeProject GetBoundProject()
-        {
-            return ProjectToReturn;
-        }
-
-        public SonarLintMode GetMode()
-        {
-            return ModeToReturn;
-        }
-
         public BindingConfiguration GetConfiguration()
         {
             GetConfigurationAction?.Invoke();


### PR DESCRIPTION
... instead of having multiple separate methods. This is required for the upcoming changes to the command handling as the command methods that implement _ICommand_ can only accept a single parameter.

* added comments/TODOs to identify required legacy modes changes
* added _IBindingWorkflow_ interface so we can inject different binding behaviours later

Relates to #508 