### PR TITLE
Added reader for new config mode

### DIFF
--- a/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
@@ -374,6 +374,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             ConfigurableVsShell shell = new ConfigurableVsShell();
             shell.RegisterPropertyGetter((int)__VSSPROPID2.VSSPROPID_InstallRootDir, () => this.TestContext.TestRunDirectory);
             this.serviceProvider.RegisterService(typeof(SVsShell), shell);
+            this.serviceProvider.RegisterService(typeof(SVsSolution), new Mock<IVsSolution>().Object);
 
             // Local services
             // Act + Assert

--- a/src/Integration.UnitTests/NewConnectedMode/BindingConfigurationTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/BindingConfigurationTests.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class BindingConfigurationTests
+    {
+        [TestMethod]
+        public void Static_CheckStandaloneSingleton()
+        {
+            BindingConfiguration.Standalone.Project.Should().BeNull();
+            BindingConfiguration.Standalone.Mode.Should().Be(SonarLintMode.Standalone);
+        }
+
+        [TestMethod]
+        public void StaticCreator_InvalidArgs_NullProject_Throws()
+        {
+            // Arrange
+            Action act = () => BindingConfiguration.CreateBoundConfiguration(null, false);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("project");
+        }
+
+        [TestMethod]
+        public void StaticCreator_LegacyProject_ModeIsLegacy()
+        {
+            // Arrange & Act
+            var actual =  BindingConfiguration.CreateBoundConfiguration(new BoundSonarQubeProject(), isLegacy: true);
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Project.Should().NotBeNull();
+            actual.Mode.Should().Be(SonarLintMode.LegacyConnected);
+        }
+
+        [TestMethod]
+        public void StaticCreator_LegacyProject_ModeIsNotLegacy()
+        {
+            // Arrange & Act
+            var actual = BindingConfiguration.CreateBoundConfiguration(new BoundSonarQubeProject(), isLegacy: false);
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Project.Should().NotBeNull();
+            actual.Mode.Should().Be(SonarLintMode.Connected);
+        }
+    }
+}

--- a/src/Integration.UnitTests/NewConnectedMode/ConfigurationProviderTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/ConfigurationProviderTests.cs
@@ -1,0 +1,110 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class ConfigurationProviderTests
+    {
+        [TestMethod]
+        public void Ctor_InvalidArgs_NullLegacySerializer_Throws()
+        {
+            // Arrange
+            var serializer = new ConfigurableSolutionBindingSerializer();
+            Action act = () => new ConfigurationProvider(null, serializer);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("legacySerializer");
+        }
+
+        [TestMethod]
+        public void Ctor_InvalidArgs_NullConnectedModeSerializer_Throws()
+        {
+            // Arrange
+            var serializer = new ConfigurableSolutionBindingSerializer();
+            Action act = () => new ConfigurationProvider(serializer, null);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("newConnectedModeSerializer");
+        }
+
+        [TestMethod]
+        public void GetConfig_NoConfig_ReturnsStandalone()
+        {
+            // Arrange
+            var legacySerializer = new ConfigurableSolutionBindingSerializer { CurrentBinding = null };
+            var newSerializer = new ConfigurableSolutionBindingSerializer { CurrentBinding = null };
+            var configProvider = new ConfigurationProvider(legacySerializer, newSerializer);
+
+            // Act
+            var actual = configProvider.GetConfiguration();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Project.Should().BeNull();
+            actual.Mode.Should().Be(SonarLintMode.Standalone);
+        }
+
+        [TestMethod]
+        public void GetConfig_LegacyAndNewConfig_ReturnsLegacy()
+        {
+            // Note that this should not happen in practice - we only expect the legacys
+            // or new bindings to present. However, the legacy should take priority.
+
+            // Arrange
+            var legacySerializer = new ConfigurableSolutionBindingSerializer { CurrentBinding = new BoundSonarQubeProject() };
+            var newSerializer = new ConfigurableSolutionBindingSerializer { CurrentBinding = new BoundSonarQubeProject() };
+            var configProvider = new ConfigurationProvider(legacySerializer, newSerializer);
+
+            // Act
+            var actual = configProvider.GetConfiguration();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Project.Should().NotBeNull();
+            actual.Project.Should().BeSameAs(legacySerializer.CurrentBinding);
+            actual.Mode.Should().Be(SonarLintMode.LegacyConnected);
+        }
+
+        [TestMethod]
+        public void GetConfig_NewConfigOnly_ReturnsLegacy()
+        {
+            // Arrange
+            var legacySerializer = new ConfigurableSolutionBindingSerializer { CurrentBinding = null };
+            var newSerializer = new ConfigurableSolutionBindingSerializer { CurrentBinding = new BoundSonarQubeProject() };
+            var configProvider = new ConfigurationProvider(legacySerializer, newSerializer);
+
+            // Act
+            var actual = configProvider.GetConfiguration();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Project.Should().NotBeNull();
+            actual.Project.Should().BeSameAs(newSerializer.CurrentBinding);
+            actual.Mode.Should().Be(SonarLintMode.Connected);
+        }
+    }
+}

--- a/src/Integration.UnitTests/NewConnectedMode/ConfigurationSerializerTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/ConfigurationSerializerTests.cs
@@ -1,0 +1,217 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.Alm.Authentication;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Integration.Helpers;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class ConfigurationSerializerTests
+    {
+        private Mock<IVsSolution> solutionMock;
+        private ICredentialStore configurableStore;
+        private Mock<ILogger> loggerMock;
+        private Mock<IFile> fileMock;
+        private ConfigurationSerializer testSubject;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            solutionMock = new Mock<IVsSolution>();
+            configurableStore = new ConfigurableCredentialStore();
+            loggerMock = new Mock<ILogger>();
+            fileMock = new Mock<IFile>();
+            testSubject = new ConfigurationSerializer(solutionMock.Object, configurableStore, loggerMock.Object, fileMock.Object);
+        }
+
+        [TestMethod]
+        public void Ctor_InvalidArgs_NullSolution_Throws()
+        {
+            // Arrange
+            Action act = () => new ConfigurationSerializer(null, configurableStore, loggerMock.Object);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("solution");
+        }
+
+        [TestMethod]
+        public void Ctor_InvalidArgs_NullCredentialStore_Throws()
+        {
+            // Arrange
+            Action act = () => new ConfigurationSerializer(solutionMock.Object, null, loggerMock.Object);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("credentialStore");
+        }
+
+        [TestMethod]
+        public void Ctor_InvalidArgs_NullLogger_Throws()
+        {
+            // Arrange
+            Action act = () => new ConfigurationSerializer(solutionMock.Object, configurableStore, null);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("logger");
+        }
+
+        [TestMethod]
+        public void CalculateConfigFileName_NullInput_ReturnsNull()
+        {
+            // Arrange & Act & Assert
+            ConfigurationSerializer.GetConnectionFilePath(null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void CalculateConfigFileName_ReturnsExpectedName()
+        {
+            // Arrange
+            var fullSolutionFilePath = @"c:\aaa\bbbb\C C\mysolutionName.sln";
+
+            // Act
+            string actual = ConfigurationSerializer.GetConnectionFilePath(fullSolutionFilePath);
+
+            // Assert
+            actual.Should().Be(@"c:\aaa\bbbb\C C\.sonarlint\mysolutionName.sqconfig");
+        }
+
+        [TestMethod]
+        public void CalculateConfigFileName_ReturnsExpectedName2()
+        {
+            // Arrange
+            var fullSolutionFilePath = @"c:\aaa\bbbb\C C\mysolutionName.foo.xxx";
+
+            // Act
+            string actual = ConfigurationSerializer.GetConnectionFilePath(fullSolutionFilePath);
+
+            // Assert
+            actual.Should().Be(@"c:\aaa\bbbb\C C\.sonarlint\mysolutionName.foo.sqconfig");
+        }
+
+        [TestMethod]
+        public void ReadSolution_NoFileName_ReturnsNull()
+        {
+            // Arrange
+            Mock<IVsSolution> solutionMock = new Mock<IVsSolution>();
+            ConfigurableCredentialStore configurableStore = new ConfigurableCredentialStore();
+            Mock<ILogger> loggerMock = new Mock<ILogger>();
+
+            SetSolutionFilePath(null);
+
+            // Act
+            var actual = testSubject.ReadSolutionBinding();
+
+            // Assert
+            actual.Should().BeNull();
+            solutionMock.VerifyAll(); // check the solution interface was called with the correct args
+        }
+
+        [TestMethod]
+        public void ReadSolution_MissingSolutionFile_ReturnsNull()
+        {
+            // Arrange
+            SetSolutionFilePath(@"c:\file that does not.exist");
+
+            // Act
+            var actual = testSubject.ReadSolutionBinding();
+
+            // Assert
+            actual.Should().BeNull();
+            solutionMock.VerifyAll(); // check the solution interface was called with the correct args
+        }
+
+        [TestMethod]
+        public void ReadSolution_SolutionFileExists_NoCredentials_ReturnsConfig()
+        {
+            // Arrange
+            var validConfig = @"{
+  ""ServerUri"": ""http://xxx.www.zzz/yyy:9000"",
+  ""Organization"": null,
+  ""ProjectKey"": ""MyProject Key""
+}";
+            SetSolutionFilePath(@"c:\mysolutionfile.foo");
+            SetFileContents(@"c:\.sonarlint\mysolutionfile.sqconfig", validConfig);
+
+            // Act
+            var actual = testSubject.ReadSolutionBinding();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Credentials.Should().BeNull();
+            actual.ServerUri.Should().Be("http://xxx.www.zzz/yyy:9000");
+            actual.Organization.Should().BeNull();
+            actual.ProjectKey.Should().Be("MyProject Key");
+        }
+
+        [TestMethod]
+        public void ReadSolution_SolutionFileExists_CredentialsExist_ReturnsConfig()
+        {
+            // Arrange
+            var validConfig = @"{
+  ""ServerUri"": ""https://xxx:123"",
+  ""Organization"": { ""Key"" : ""OrgKey"", ""Name"" : ""OrgName"" },
+  ""ProjectKey"": ""key111""
+}";
+            SetSolutionFilePath(@"c:\mysolutionfile.foo");
+            SetFileContents(@"c:\.sonarlint\mysolutionfile.sqconfig", validConfig);
+
+            Credential cred = new Credential("user1");
+            configurableStore.WriteCredentials(new TargetUri("https://xxx:123"), cred);
+            
+            // Act
+            var actual = testSubject.ReadSolutionBinding();
+
+            // Assert
+            actual.Should().NotBeNull();
+
+            actual.Credentials.Should().NotBeNull();
+            var actualCreds = actual.Credentials as BasicAuthCredentials;
+            actualCreds.Should().NotBeNull();
+            actualCreds.UserName.Should().Be("user1");
+
+            actual.ServerUri.Should().Be("https://xxx:123");
+            actual.Organization.Should().NotBeNull();
+            actual.Organization.Key.Should().Be("OrgKey");
+            actual.Organization.Name.Should().Be("OrgName");
+            actual.ProjectKey.Should().Be("key111");
+        }
+
+        private void SetSolutionFilePath(string filePath)
+        {
+            object outVal = filePath;
+            int returnCode = filePath == null ? VSConstants.S_FALSE : VSConstants.S_OK;
+            solutionMock.Setup(x => x.GetProperty((int)__VSPROPID.VSPROPID_SolutionFileName, out outVal)).Returns(returnCode);
+        }
+
+        private void SetFileContents(string fullPath, string contents)
+        {
+            fileMock.Setup(x => x.Exists(fullPath)).Returns(true);
+            fileMock.Setup(x => x.ReadAllText(fullPath)).Returns(contents);
+        }
+    }
+}

--- a/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
+++ b/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
@@ -26,7 +26,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+using SonarLint.VisualStudio.Integration.Helpers;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarQube.Client.Helpers;
 
@@ -79,8 +79,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void SolutionBindingSerializer_ArgChecks()
         {
             Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingSerializer(null));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingSerializer(this.serviceProvider, null, new Mock<ILogger>().Object));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingSerializer(this.serviceProvider, this.store, null));
         }
 
         [TestMethod]
@@ -356,7 +354,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private SolutionBindingSerializer CreateTestSubject()
         {
-            return new SolutionBindingSerializer(this.serviceProvider, this.store, new SonarLintOutputLogger(serviceProvider));
+            return new SolutionBindingSerializer(this.serviceProvider, this.store, new SonarLintOutputLogger(serviceProvider), new FileWrapper());
         }
 
         #endregion Helpers

--- a/src/Integration/Helpers/IO/FileWrapper.cs
+++ b/src/Integration/Helpers/IO/FileWrapper.cs
@@ -33,5 +33,9 @@ namespace SonarLint.VisualStudio.Integration.Helpers
         public TextReader OpenText(string path) => File.OpenText(path);
 
         public TextWriter CreateText(string path) => File.CreateText(path);
+
+        public string ReadAllText(string path) => File.ReadAllText(path);
+
+        public void WriteAllText(string path, string contents) => File.WriteAllText(path, contents);
     }
 }

--- a/src/Integration/Helpers/IO/IFile.cs
+++ b/src/Integration/Helpers/IO/IFile.cs
@@ -28,5 +28,7 @@ namespace SonarLint.VisualStudio.Integration.Helpers
         void Delete(string path);
         TextReader OpenText(string path);
         TextWriter CreateText(string path);
+        string ReadAllText(string path);
+        void WriteAllText(string path, string contents);
     }
 }

--- a/src/Integration/NewConnectedMode/ConfigFileUtilities.cs
+++ b/src/Integration/NewConnectedMode/ConfigFileUtilities.cs
@@ -1,0 +1,98 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Alm.Authentication;
+using Newtonsoft.Json;
+using SonarLint.VisualStudio.Integration.Helpers;
+using SonarLint.VisualStudio.Integration.Persistence;
+using SonarLint.VisualStudio.Integration.Resources;
+using SonarQube.Client.Helpers;
+
+namespace SonarLint.VisualStudio.Integration.NewConnectedMode
+{
+    internal static class ConfigFileUtilities
+    {
+        public static BoundSonarQubeProject ReadBindingFile(string fullConfigFilePath, ICredentialStore credentialStore, ILogger logger, IFile fileWrapper)
+        {
+            Debug.Assert(credentialStore != null);
+            Debug.Assert(logger != null);
+
+            if (string.IsNullOrWhiteSpace(fullConfigFilePath) || !fileWrapper.Exists(fullConfigFilePath))
+            {
+                return null;
+            }
+
+            BoundSonarQubeProject bound = SafeDeserializeConfigFile(fullConfigFilePath, logger, fileWrapper);
+            if (bound?.ServerUri != null)
+            {
+                var credentials = credentialStore.ReadCredentials(bound.ServerUri);
+                if (credentials != null)
+                {
+                    bound.Credentials = new BasicAuthCredentials(credentials.Username,
+                        credentials.Password.ToSecureString());
+                }
+            }
+
+            return bound;
+        }
+        
+        private static BoundSonarQubeProject SafeDeserializeConfigFile(string configFilePath, ILogger logger, IFile fileWrapper)
+        {
+            string configJson = null;
+            if (SafePerformFileSystemOperation(logger, () => { configJson = fileWrapper.ReadAllText(configFilePath); } ))
+            {
+                try
+                {
+                    return JsonHelper.Deserialize<BoundSonarQubeProject>(configJson);
+                }
+                catch (JsonException)
+                {
+                    logger.WriteLine(Strings.FailedToDeserializeSQCOnfiguration, configFilePath);
+                }
+            }
+            return null;
+        }
+
+        public static bool SafePerformFileSystemOperation(ILogger logger, Action operation)
+        {
+            Debug.Assert(logger != null);
+            Debug.Assert(operation != null);
+
+            try
+            {
+                operation();
+                return true;
+            }
+            catch (Exception e) when (e is PathTooLongException
+                                    || e is UnauthorizedAccessException
+                                    || e is FileNotFoundException
+                                    || e is DirectoryNotFoundException
+                                    || e is IOException
+                                    || e is System.Security.SecurityException)
+            {
+                logger.WriteLine(e.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/src/Integration/NewConnectedMode/ConfigFileUtilities.cs
+++ b/src/Integration/NewConnectedMode/ConfigFileUtilities.cs
@@ -32,7 +32,11 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 {
     internal static class ConfigFileUtilities
     {
-        public static BoundSonarQubeProject ReadBindingFile(string fullConfigFilePath, ICredentialStore credentialStore, ILogger logger, IFile fileWrapper)
+        public static BoundSonarQubeProject ReadBindingFile(
+            string fullConfigFilePath,
+            ICredentialStore credentialStore,
+            ILogger logger,
+            IFile fileWrapper)
         {
             Debug.Assert(credentialStore != null);
             Debug.Assert(logger != null);

--- a/src/Integration/NewConnectedMode/ConfigurationSerializer.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationSerializer.cs
@@ -1,0 +1,108 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Alm.Authentication;
+using Microsoft.VisualStudio.Shell.Interop;
+using SonarLint.VisualStudio.Integration.Helpers;
+using SonarLint.VisualStudio.Integration.Persistence;
+
+namespace SonarLint.VisualStudio.Integration.NewConnectedMode
+{
+    /// <summary>
+    /// Reads/write the binding configuration for the new connected mode.
+    /// The legacy connected mode binding is written using <see cref="SolutionBindingSerializer"/>.
+    /// </summary>
+    internal class ConfigurationSerializer : ISolutionBindingSerializer
+    {
+        private readonly IVsSolution solution;
+        private readonly ICredentialStore credentialStore;
+        private readonly ILogger logger;
+        private readonly IFile fileWrapper;
+
+        public ConfigurationSerializer(IVsSolution solution, ICredentialStore credentialStore, ILogger logger)
+            :this(solution, credentialStore, logger, new FileWrapper())
+        {
+
+        }
+
+        internal /* for testing */ ConfigurationSerializer(IVsSolution solution, ICredentialStore credentialStore, ILogger logger, IFile fileWrapper)
+        {
+            if (solution == null)
+            {
+                throw new ArgumentNullException(nameof(solution));
+            }
+            if (credentialStore == null)
+            {
+                throw new ArgumentNullException(nameof(credentialStore));
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+            Debug.Assert(fileWrapper != null);
+
+            this.solution = solution;
+            this.credentialStore = credentialStore;
+            this.logger = logger;
+            this.fileWrapper = fileWrapper;
+        }
+
+        #region ISolutionBindingSerializer interface
+
+        public BoundSonarQubeProject ReadSolutionBinding()
+        {
+            var solutionFilePath = GetCurrentSolutionFilePath();
+            string configFilePath = GetConnectionFilePath(solutionFilePath);
+            return ConfigFileUtilities.ReadBindingFile(configFilePath, credentialStore, logger, fileWrapper);
+        }
+
+        public string WriteSolutionBinding(BoundSonarQubeProject binding)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        internal static string GetConnectionFilePath(string solutionFilePath)
+        {
+            if (solutionFilePath == null)
+            {
+                return null;
+            }
+
+            var solutionFolder = Path.GetDirectoryName(solutionFilePath);
+            var solutionName = Path.GetFileNameWithoutExtension(solutionFilePath);
+
+            return Path.Combine(solutionFolder, ".sonarlint", $"{solutionName}.sqconfig");
+        }
+
+        private string GetCurrentSolutionFilePath()
+        {
+            object fullSolutionName;
+            // If there isn't an open solution the returned hresult will indicate an error
+            // and the returned solution name will be null. We'll just ignore the hresult.
+            solution.GetProperty((int)__VSPROPID.VSPROPID_SolutionFileName, out fullSolutionName);
+            return (string)fullSolutionName;
+        }
+    }
+}


### PR DESCRIPTION
With this change, the _IConfigurationProvider_ will correctly detect whether it is in standalone, legacy or new connected mode.

There isn't any way to configure a project to be in "new" connected mode yet except by manually setting it up i.e. writing the expected file to disk in the correct location.

Related to #508 