### PR TITLE
Revert "Drop support for VS2015 earlier to Update 3 (#425)" - Postponed

### DIFF
--- a/src/Integration.Vsix/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
     <Tags>SonarLint, SonarQube, Analysis, Roslyn, CodeAnalysis, Analyzer, Code analysis, Sonar, Debt, Technical, Tech, Quality</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0.25420.00,15.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />


### PR DESCRIPTION
This reverts commit 7ecfc8fd29206a5d2a9f8d523de1aaa0d0d061e3.