### PR TITLE
Fixing the version number extraction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
         unstash 'vsix-vs2015'
         unstash 'vsix-vs2017'
         script {
-          version = sh returnStdout: true, script: 'cat build/Version.props | grep MainVersion\\> | cut -d\'>\' -f 2 | cut -c 1-5'
+          version = sh returnStdout: true, script: 'cat build/Version.props | grep MainVersion\\> | cut -d \\> -f 2 | cut --complement -d \\< -f 2'
           version = version.trim() + ".${env.BUILD_NUMBER}"
         } 
         echo "${version}"


### PR DESCRIPTION
if the string returned from grep is `<MainVersion>1.2.3.4.5</MainVersion>`, first `cut` will return everything after `>`, e.g. `1.2.3.4.5</MainVersion>` and the second will return everything before `<`, e.g. `1.2.3.4.5`