### PR TITLE
Refactor bind command to use strongly-type arguments

### DIFF
--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
@@ -29,6 +29,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.InfoBar;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Resources;
@@ -380,10 +381,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = new ErrorListInfoBarController(this.host);
             this.ConfigureLoadedSolution();
             int bindingCalled = 0;
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm =>
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args =>
             {
                 bindingCalled++;
-                vm.Key.Should().Be(this.configProvider.ProjectToReturn.ProjectKey);
+                args.ProjectKey.Should().Be(this.configProvider.ProjectToReturn.ProjectKey);
             });
             int refreshCalled = 0;
             this.ConfigureActiveSectionWithRefreshCommand(connection =>
@@ -435,10 +436,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ConfigureLoadedSolution();
             int bindingCalled = 0;
             ProjectViewModel project = null;
-            this.ConfigureActiveSectionWithBindCommand(vm =>
+            this.ConfigureActiveSectionWithBindCommand(args =>
             {
                 bindingCalled++;
-                vm.Should().Be(project);
+                args.ProjectKey.Should().Be(project.Key);
+                args.ProjectName.Should().Be(project.ProjectName);
             });
             int refreshCalled = 0;
             this.ConfigureActiveSectionWithRefreshCommand(connection =>
@@ -474,11 +476,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             int bindExecuted = 0;
             bool canExecute = false;
             ProjectViewModel project = null;
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm =>
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args =>
             {
                 bindExecuted++;
-                vm.Should().Be(project);
-            }, vm => canExecute);
+                args.ProjectKey.Should().Be(project.Key);
+                args.ProjectName.Should().Be(project.ProjectName);
+            }, args => canExecute);
             this.ConfigureActiveSectionWithRefreshCommand(c =>
             {
                 FluentAssertions.Execution.Execute.Assertion.FailWith("Refresh is not expected to be called");
@@ -525,10 +528,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ConfigureLoadedSolution();
             int executed = 0;
             ProjectViewModel project = null;
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm =>
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args =>
             {
                 executed++;
-                vm.Should().Be(project);
+                args.ProjectKey.Should().Be(project.Key);
             });
             project = this.ConfigureProjectViewModel(section);
             testSubject.Refresh();
@@ -563,10 +566,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ConfigureLoadedSolution();
             int executed = 0;
             ProjectViewModel project = null;
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm =>
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args =>
             {
                 executed++;
-                vm.Should().Be(project);
+                args.ProjectKey.Should().Be(project.Key);
+                args.ProjectName.Should().Be(project.ProjectName);
             });
             project = this.ConfigureProjectViewModel(section);
             testSubject.Refresh();
@@ -602,10 +606,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ConfigureLoadedSolution();
             int executed = 0;
             ProjectViewModel project = null;
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm =>
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args =>
             {
                 executed++;
-                vm.Should().Be(project);
             });
             project = this.ConfigureProjectViewModel(section);
             testSubject.Refresh();
@@ -653,9 +656,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 disconnectCalled++;
             });
             int bindCalled = 0;
-            this.ConfigureActiveSectionWithBindCommand(vm =>
+            this.ConfigureActiveSectionWithBindCommand(args =>
             {
-                vm.Key.Should().Be(this.configProvider.ProjectToReturn.ProjectKey);
+                args.ProjectKey.Should().Be(this.configProvider.ProjectToReturn.ProjectKey);
                 bindCalled++;
             });
 
@@ -699,7 +702,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = new ErrorListInfoBarController(this.host);
             this.ConfigureLoadedSolution();
             int bindCommandExecuted = 0;
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm => { bindCommandExecuted++; });
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args => { bindCommandExecuted++; });
             this.ConfigureProjectViewModel(section);
             testSubject.Refresh();
             RunAsyncAction();
@@ -741,7 +744,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.SetBindingMode(SonarLintMode.LegacyConnected);
             var testSubject = new ErrorListInfoBarController(this.host);
             this.ConfigureLoadedSolution();
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm => { });
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args => { });
             this.ConfigureProjectViewModel(section);
             testSubject.Refresh();
             RunAsyncAction();
@@ -768,7 +771,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.SetBindingMode(SonarLintMode.LegacyConnected);
             var testSubject = new ErrorListInfoBarController(this.host);
             this.ConfigureLoadedSolution();
-            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(vm => { });
+            ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args => { });
             this.ConfigureProjectViewModel(section);
             testSubject.Refresh();
             RunAsyncAction();
@@ -792,7 +795,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Test helpers
 
-        private ConfigurableSectionController ConfigureActiveSectionWithBindCommand(Action<ProjectViewModel> commandAction, Predicate<ProjectViewModel> canExecuteCommand = null)
+        private ConfigurableSectionController ConfigureActiveSectionWithBindCommand(Action<BindCommandArgs> commandAction, Predicate<BindCommandArgs> canExecuteCommand = null)
         {
             var section = this.host.ActiveSection as ConfigurableSectionController;
             if (section == null)
@@ -800,9 +803,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 section = ConfigurableSectionController.CreateDefault();
             }
             section.ViewModel.State = this.host.VisualStateManager.ManagedState;
-            section.BindCommand = new RelayCommand<ProjectViewModel>(pvm =>
+            section.BindCommand = new RelayCommand<BindCommandArgs>(args =>
             {
-                commandAction(pvm);
+                commandAction(args);
                 this.stateManager.SetAndInvokeBusyChanged(true);// Simulate product
             }, canExecuteCommand);
             this.host.SetActiveSection(section);

--- a/src/Integration.UnitTests/MefServices/ActiveSolutionBoundTrackerTests.cs
+++ b/src/Integration.UnitTests/MefServices/ActiveSolutionBoundTrackerTests.cs
@@ -194,7 +194,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Case 2: Set bound project
             ConfigureSolutionBinding(boundProject);
             // Act
-            host.VisualStateManager.SetBoundProject(new SonarQubeProject("", ""));
+            host.VisualStateManager.SetBoundProject(new ConnectionInformation(new Uri("http://localhost")), new SonarQubeProject("", ""));
 
             // Assert
             testSubject.IsActiveSolutionBound.Should().BeTrue("Bound solution should report true activation");

--- a/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
@@ -257,8 +257,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.CreateTestSubject(tracker);
             // Previous binding information that should be cleared once there's no solution
             var boundProject = new SonarQubeProject("bla", "");
+            var connection = new ConnectionInformation(new Uri("http://localhost"));
+
             this.stateManager.BoundProjectKey = boundProject.Key;
-            this.stateManager.SetBoundProject(boundProject);
+            this.stateManager.SetBoundProject(connection, boundProject);
 
             // Sanity
             this.stateManager.BoundProject.Should().Be(boundProject);
@@ -280,8 +282,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = this.CreateTestSubject(tracker);
             var boundProject = new SonarQubeProject("bla", "");
+            var connection = new ConnectionInformation(new Uri("http://bound"));
             SetConfiguration(new Persistence.BoundSonarQubeProject(new Uri("http://bound"), boundProject.Key), SonarLintMode.LegacyConnected);
-            this.stateManager.SetBoundProject(boundProject);
+            this.stateManager.SetBoundProject(connection, boundProject);
 
             // Sanity
             this.stateManager.BoundProject.Should().Be(boundProject);
@@ -315,7 +318,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = this.CreateTestSubject(tracker);
             var boundProject = new SonarQubeProject("bla", "");
-            this.stateManager.SetBoundProject(boundProject);
+            var connection = new ConnectionInformation(new Uri("http://bound"));
+            this.stateManager.SetBoundProject(connection, boundProject);
             SetConfiguration(new Persistence.BoundSonarQubeProject(new Uri("http://bound"), boundProject.Key), SonarLintMode.LegacyConnected);
             var section = ConfigurableSectionController.CreateDefault();
             bool refreshCalled = false;
@@ -343,7 +347,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = this.CreateTestSubject(tracker);
             var boundProject = new SonarQubeProject("bla", "");
-            this.stateManager.SetBoundProject(boundProject);
+            var connection = new ConnectionInformation(new Uri("http://bound"));
+
+            this.stateManager.SetBoundProject(connection, boundProject);
             SetConfiguration(new BoundSonarQubeProject(new Uri("http://bound"), boundProject.Key), SonarLintMode.LegacyConnected);
             var section = ConfigurableSectionController.CreateDefault();
             testSubject.SetActiveSection(section);

--- a/src/Integration.UnitTests/ProfileConflicts/RuleSetConflictsControllerTests.cs
+++ b/src/Integration.UnitTests/ProfileConflicts/RuleSetConflictsControllerTests.cs
@@ -155,7 +155,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Case 3: Valid input, busy, has bound project
             this.host.VisualStateManager.IsBusy = true;
-            this.host.VisualStateManager.SetBoundProject(new SonarQubeProject("", ""));
+            this.host.VisualStateManager.SetBoundProject(new ConnectionInformation(new Uri("http://foo")), new SonarQubeProject("", ""));
             testSubject.FixConflictsCommand.CanExecute(conflicts).Should().BeFalse();
 
             // Case 4: Valid input, not busy, not bound project
@@ -165,7 +165,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Case 5: Valid input, not busy, has bound project
             this.host.VisualStateManager.IsBusy = false;
-            this.host.VisualStateManager.SetBoundProject(new SonarQubeProject("", ""));
+            this.host.VisualStateManager.SetBoundProject(new ConnectionInformation(new Uri("http://bar")), new SonarQubeProject("", ""));
             testSubject.FixConflictsCommand.CanExecute(conflicts).Should().BeTrue();
         }
 
@@ -176,7 +176,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = new RuleSetConflictsController(this.host);
             this.ConfigureServiceProviderForFixConflictsCommandExecution();
             this.host.VisualStateManager.IsBusy = false;
-            this.host.VisualStateManager.SetBoundProject(new SonarQubeProject("", ""));
+            this.host.VisualStateManager.SetBoundProject(new ConnectionInformation(new Uri("http://localhost")), new SonarQubeProject("", ""));
             var section = ConfigurableSectionController.CreateDefault();
             this.host.SetActiveSection(section);
             ConfigurableUserNotification notifications = (ConfigurableUserNotification)section.UserNotifications;

--- a/src/Integration.UnitTests/State/StateManagerTests.cs
+++ b/src/Integration.UnitTests/State/StateManagerTests.cs
@@ -228,9 +228,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
             section.UserNotifications.ShowNotificationError("message", NotificationIds.FailedToFindBoundProjectKeyId, null);
             testSubject.ManagedState.ConnectedServers.Add(new ServerViewModel(new ConnectionInformation(new Uri("http://zzz1"))));
             testSubject.ManagedState.ConnectedServers.Add(new ServerViewModel(new ConnectionInformation(new Uri("http://zzz2"))));
-            testSubject.ManagedState.ConnectedServers.ToList().ForEach(s => s.Projects.Add(new ProjectViewModel(s, new SonarQubeProject("", ""))));
+            testSubject.ManagedState.ConnectedServers.ToList().ForEach(s => s.Projects.Add(new ProjectViewModel(s, new SonarQubeProject(Guid.NewGuid().ToString(), ""))));
             var allProjects = testSubject.ManagedState.ConnectedServers.SelectMany(s => s.Projects).ToList();
-            testSubject.SetBoundProject(allProjects.First().Project);
+            testSubject.SetBoundProject(new ConnectionInformation(new Uri("http://zzz1")), allProjects.First().Project);
 
             // Sanity
             testSubject.ManagedState.HasBoundProject.Should().BeTrue();
@@ -255,7 +255,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
 
             section.UserNotifications.ShowNotificationError("message", NotificationIds.FailedToFindBoundProjectKeyId, null);
             var conn = new ConnectionInformation(new Uri("http://xyz"));
-            var projects = new[] { new SonarQubeProject("", ""), new SonarQubeProject("", "") };
+            var projects = new[] { new SonarQubeProject("111", ""), new SonarQubeProject("222", "") };
             testSubject.SetProjects(conn, projects);
             TransferableVisualState state = testSubject.ManagedState;
             bool hasBoundProjectChanged = false;
@@ -266,7 +266,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
               };
 
             // Act
-            testSubject.SetBoundProject(projects[1]);
+            testSubject.SetBoundProject(conn, new SonarQubeProject("222", ""));
 
             // Assert
             notifications.AssertNoNotification(NotificationIds.FailedToFindBoundProjectKeyId);
@@ -333,14 +333,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
             testSubject.BindingStateChanged += (sender, e) => countOnBindingStateChangeFired++;
 
             testSubject.ManagedState.ConnectedServers.Add(new ServerViewModel(new ConnectionInformation(new Uri("http://zzz1"))));
-            testSubject.ManagedState.ConnectedServers.ToList().ForEach(s => s.Projects.Add(new ProjectViewModel(s, new SonarQubeProject("", ""))));
+            testSubject.ManagedState.ConnectedServers.ToList().ForEach(s => s.Projects.Add(new ProjectViewModel(s, new SonarQubeProject(Guid.NewGuid().ToString(), ""))));
             var allProjects = testSubject.ManagedState.ConnectedServers.SelectMany(s => s.Projects).ToList();
+
+            
 
             // Sanity
             countOnBindingStateChangeFired.Should().Be(0);
 
             // Act
-            testSubject.SetBoundProject(allProjects.First().Project);
+            // Note: creating new project and connection objects with the same uri/key as above
+            testSubject.SetBoundProject(new ConnectionInformation(new Uri("http://zzz1")),  new SonarQubeProject(allProjects.First().Project.Key, ""));
 
             // Assert
             countOnBindingStateChangeFired.Should().Be(1);
@@ -423,30 +426,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
 
             // Assert
             connection1.IsDisposed.Should().BeTrue("Leaking connections?");
-        }
-
-        [TestMethod]
-        public void StateManager_GetConnectedServer()
-        {
-            // Arrange
-            const string SharedKey = "Key"; // The key is the same for all projects on purpose
-            ConfigurableHost host = new ConfigurableHost();
-            StateManager testSubject = this.CreateTestSubject(host);
-            var connection1 = new ConnectionInformation(new Uri("http://conn1"));
-            var project1 = new SonarQubeProject(SharedKey, "");
-            var connection2 = new ConnectionInformation(new Uri("http://conn2"));
-            var project2 = new SonarQubeProject(SharedKey, "");
-            testSubject.SetProjects(connection1, new SonarQubeProject[] { project1 });
-            testSubject.SetProjects(connection2, new SonarQubeProject[] { project2 });
-
-            // Case 1: Exists
-            // Act+Verify
-            testSubject.GetConnectedServer(project1).Should().Be(connection1);
-            testSubject.GetConnectedServer(project2).Should().Be(connection2);
-
-            // Case 2: Doesn't exist
-            // Act+Verify
-            testSubject.GetConnectedServer(new SonarQubeProject(SharedKey, "")).Should().BeNull();
         }
 
         #endregion Tests

--- a/src/Integration/Binding/BindCommandArgs.cs
+++ b/src/Integration/Binding/BindCommandArgs.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -22,9 +22,22 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    // Test only interface
-    internal interface IBindingWorkflowExecutor
+    /// <summary>
+    /// Data class containing the arguments required by the bind command
+    /// </summary>
+    internal class BindCommandArgs
     {
-        void BindProject(SonarQubeProject projectInformation, ConnectionInformation connection);
+        public BindCommandArgs(string projectKey, string projectName, ConnectionInformation connection)
+        {
+            this.ProjectKey = projectKey;
+            this.ProjectName = projectName;
+            this.Connection = connection;
+        }
+
+        public string ProjectKey { get; }
+
+        public string ProjectName { get; }
+
+        public ConnectionInformation Connection { get; }
     }
 }

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Helpers;
 using SonarLint.VisualStudio.Integration.InfoBar;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
@@ -466,9 +467,10 @@ namespace SonarLint.VisualStudio.Integration
                     return;
                 }
 
-                if (this.host.ActiveSection.BindCommand.CanExecute(boundProject))
+                BindCommandArgs bindingArgs = new BindCommandArgs(boundProject.Project?.Key, boundProject.Project?.Name, binding.CreateConnectionInformation());
+                if (this.host.ActiveSection.BindCommand.CanExecute(bindingArgs))
                 {
-                    this.host.ActiveSection.BindCommand.Execute(boundProject);
+                    this.host.ActiveSection.BindCommand.Execute(bindingArgs);
                     this.OnFinished(BindingRequestResult.StartedUpdating);
                 }
                 else

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -260,9 +260,11 @@ namespace SonarLint.VisualStudio.Integration
             Debug.Assert(this.ActiveSection?.RefreshCommand != null, "Refresh command is not set");
             // Run the refresh workflow, passing the connection information
             var refreshCmd = this.ActiveSection.RefreshCommand;
-            if (refreshCmd.CanExecute(bindingConfig))
+
+            var connection = bindingConfig.Project.CreateConnectionInformation();
+            if (refreshCmd.CanExecute(connection))
             {
-                refreshCmd.Execute(bindingConfig); // start the workflow
+                refreshCmd.Execute(connection); // start the workflow
             }
         }
 

--- a/src/Integration/State/IStateManager.cs
+++ b/src/Integration/State/IStateManager.cs
@@ -55,11 +55,9 @@ namespace SonarLint.VisualStudio.Integration.State
 
         IEnumerable<ConnectionInformation> GetConnectedServers();
 
-        ConnectionInformation GetConnectedServer(SonarQubeProject project);
-
         void SetProjects(ConnectionInformation connection, IEnumerable<SonarQubeProject> projects);
 
-        void SetBoundProject(SonarQubeProject project);
+        void SetBoundProject(ConnectionInformation connection, SonarQubeProject project);
 
         void ClearBoundProject();
 

--- a/src/Integration/TeamExplorer/ISectionController.cs
+++ b/src/Integration/TeamExplorer/ISectionController.cs
@@ -19,7 +19,9 @@
  */
 
 using System.Windows.Input;
+using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Progress;
+using SonarLint.VisualStudio.Integration.WPF;
 
 namespace SonarLint.VisualStudio.Integration.TeamExplorer
 {
@@ -52,7 +54,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         ICommand ConnectCommand { get; }
 
-        ICommand BindCommand { get; }
+        ICommand<BindCommandArgs> BindCommand { get; }
 
         ICommand BrowseToUrlCommand { get; }
 

--- a/src/Integration/TeamExplorer/SectionController.cs
+++ b/src/Integration/TeamExplorer/SectionController.cs
@@ -28,6 +28,7 @@ using Microsoft.TeamFoundation.Client.CommandTarget;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
 using Microsoft.VisualStudio.ComponentModelHost;
+using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.WPF;
 
@@ -183,7 +184,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             private set;
         }
 
-        public ICommand BindCommand
+        public ICommand<BindCommandArgs> BindCommand
         {
             get;
             private set;

--- a/src/Integration/WPF/ContextualCommandViewModel.cs
+++ b/src/Integration/WPF/ContextualCommandViewModel.cs
@@ -30,6 +30,7 @@ namespace SonarLint.VisualStudio.Integration.WPF
     public class ContextualCommandViewModel : ViewModelBase
     {
         private readonly object fixedContext;
+        private readonly object commandArgs;
         private readonly RelayCommand proxyCommand;
 
         private ICommand command;
@@ -43,6 +44,17 @@ namespace SonarLint.VisualStudio.Integration.WPF
         /// <param name="fixedContext">Required context</param>
         /// <param name="command">Optional real command to trigger and pass the fixed context to</param>
         public ContextualCommandViewModel(object fixedContext, ICommand command)
+            : this(fixedContext, command, commandArgs: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of contextual command view model
+        /// </summary>
+        /// <param name="fixedContext">Required context</param>
+        /// <param name="command">Optional real command to trigger and pass the fixed context to</param>
+        /// <param name="commandArgs">Optional arguments to pass to the command. If null then <paramref name="fixedContent"/> will be passed.</param>
+        public ContextualCommandViewModel(object fixedContext, ICommand command, object commandArgs)
         {
             if (fixedContext == null)
             {
@@ -50,10 +62,10 @@ namespace SonarLint.VisualStudio.Integration.WPF
             }
 
             this.fixedContext = fixedContext;
+            this.commandArgs = commandArgs ?? fixedContext;
             this.proxyCommand = new RelayCommand(this.Execute, this.CanExecute);
             this.SetCommand(command);
         }
-
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability",
             "S3236:Methods with caller info attributes should not be invoked with explicit arguments",
@@ -142,12 +154,12 @@ namespace SonarLint.VisualStudio.Integration.WPF
 
         private void Execute()
         {
-            this.command.Execute(this.fixedContext);
+            this.command.Execute(this.commandArgs);
         }
 
         private bool CanExecute()
         {
-            return this.command != null && this.command.CanExecute(this.fixedContext);
+            return this.command != null && this.command.CanExecute(this.commandArgs);
         }
     }
 }

--- a/src/Integration/WPF/ICommand`1.cs
+++ b/src/Integration/WPF/ICommand`1.cs
@@ -18,13 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarQube.Client.Models;
+using System.Windows.Input;
 
-namespace SonarLint.VisualStudio.Integration.Binding
+namespace SonarLint.VisualStudio.Integration.WPF
 {
-    // Test only interface
-    internal interface IBindingWorkflowExecutor
+    internal interface ICommand<T> : ICommand where T: class
     {
-        void BindProject(SonarQubeProject projectInformation, ConnectionInformation connection);
+        bool CanExecute(T parameter);
+        void Execute(T parameter);
     }
 }

--- a/src/Integration/WPF/RelayCommand`1.cs
+++ b/src/Integration/WPF/RelayCommand`1.cs
@@ -35,7 +35,7 @@ namespace SonarLint.VisualStudio.Integration.WPF
     /// To use value types with this class you should box your type in a <see cref="Nullable{T}"/>.
     /// </remarks>
     /// <typeparam name="T"><see cref="Execute(T)"/> and <see cref="CanExecute(T)"/> parameter type</typeparam>
-    internal class RelayCommand<T> : RelayCommandBase where T : class
+    internal class RelayCommand<T> : RelayCommandBase, ICommand<T> where T : class
     {
         private readonly Action<T> execute;
         private readonly Predicate<T> canExecute;

--- a/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Windows.Input;
+using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
@@ -29,7 +30,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     {
         #region ISectionController
 
-        public ICommand BindCommand
+        public ICommand<BindCommandArgs> BindCommand
         {
             get;
             set;
@@ -106,7 +107,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             section.View = new ConnectSectionView();
             section.ProgressHost = new ConfigurableProgressControlHost();
             section.UserNotifications = new ConfigurableUserNotification();
-            section.BindCommand = new RelayCommand(() => { });
+            section.BindCommand = new RelayCommand<BindCommandArgs>(args => { });
             section.ConnectCommand = new RelayCommand(() => { });
             section.DisconnectCommand = new RelayCommand(() => { });
             section.RefreshCommand = new RelayCommand(() => { });

--- a/src/TestInfrastructure/Framework/ConfigurableStateManager.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableStateManager.cs
@@ -70,8 +70,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.BindingStateChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        public void SetBoundProject(SonarQubeProject project)
+        public void SetBoundProject(ConnectionInformation connection, SonarQubeProject project)
         {
+            connection.Should().NotBeNull();
             project.Should().NotBeNull();
 
             this.VerifyActiveSection();
@@ -98,16 +99,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public IEnumerable<ConnectionInformation> GetConnectedServers()
         {
             return this.ConnectedServers;
-        }
-
-        public ConnectionInformation GetConnectedServer(SonarQubeProject project)
-        {
-            ConnectionInformation conn;
-            var isFound = this.ProjectServerMap.TryGetValue(project, out conn);
-
-            isFound.Should().BeTrue("Test setup: project-server mapping is not available for the specified project");
-
-            return conn;
         }
 
         #endregion IStateManager


### PR DESCRIPTION
Refactoring to make adding support for the new connected mode easier.

Some of the WPF commands expect a single parameter. However, the commands are typed as _ICommand_ so it isn't obvious what should be passed in in each case. I added _ICommand[T]_ to make it obvious what is required. I also added command args class for the binding command to make it explicit what data is required for binding.

No new functionality added in this commit - just reconfiguring what was already there.