### PR TITLE
Added type parameters for parameterised commands

### DIFF
--- a/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
@@ -111,9 +111,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var section1 = ConfigurableSectionController.CreateDefault();
             var section2 = ConfigurableSectionController.CreateDefault();
             bool refresh1Called = false;
-            section1.RefreshCommand = new RelayCommand(() => refresh1Called = true);
+            section1.RefreshCommand = new RelayCommand<ConnectionInformation>(c => refresh1Called = true);
             bool refresh2Called = false;
-            section2.RefreshCommand = new RelayCommand(() => refresh2Called = true);
+            section2.RefreshCommand = new RelayCommand<ConnectionInformation>(c => refresh2Called = true);
 
             // Act (set section1)
             testSubject.SetActiveSection(section1);
@@ -298,7 +298,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             // Act (set active section)
             var section = ConfigurableSectionController.CreateDefault();
             bool refreshCalled = false;
-            section.RefreshCommand = new RelayCommand(() => refreshCalled = true);
+            section.RefreshCommand = new RelayCommand<ConnectionInformation>(c => refreshCalled = true);
             testSubject.SetActiveSection(section);
 
             // Assert (section has refreshed, no further aborts were required)
@@ -318,7 +318,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             SetConfiguration(new Persistence.BoundSonarQubeProject(new Uri("http://bound"), "bla"), SonarLintMode.LegacyConnected);
             var section = ConfigurableSectionController.CreateDefault();
             bool refreshCalled = false;
-            section.RefreshCommand = new RelayCommand(() => refreshCalled = true);
+            section.RefreshCommand = new RelayCommand<ConnectionInformation>(c => refreshCalled = true);
             testSubject.SetActiveSection(section);
 
             // Sanity

--- a/src/Integration.UnitTests/TeamExplorer/SectionControllerTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/SectionControllerTests.cs
@@ -338,7 +338,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             host.VisualStateManager.ManagedState.ConnectedServers.Clear();
             controller.Initialize(null, new Microsoft.TeamFoundation.Controls.SectionInitializeEventArgs(new ServiceContainer(), null));
             bool refreshCalled = false;
-            controller.RefreshCommand = new RelayCommand(() => refreshCalled = true);
+            controller.RefreshCommand = new RelayCommand<ConnectionInformation>(c => refreshCalled = true);
             controller.Refresh();
             refreshCalled.Should().BeTrue("Refresh command execution was expected");
         }

--- a/src/Integration/TeamExplorer/ConnectSectionViewModel.cs
+++ b/src/Integration/TeamExplorer/ConnectSectionViewModel.cs
@@ -22,7 +22,9 @@ using System;
 using System.Windows.Input;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
+using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.State;
+using SonarLint.VisualStudio.Integration.WPF;
 
 namespace SonarLint.VisualStudio.Integration.TeamExplorer
 {
@@ -31,8 +33,8 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
     {
         private TransferableVisualState state;
         private ICommand connectCommand;
-        private ICommand bindCommand;
-        private ICommand browseToUrl;
+        private ICommand<BindCommandArgs> bindCommand;
+        private ICommand<string> browseToUrl;
 
         public ConnectSectionViewModel()
         {
@@ -73,13 +75,13 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             set { SetAndRaisePropertyChanged(ref this.connectCommand, value); }
         }
 
-        public ICommand BindCommand
+        public ICommand<BindCommandArgs> BindCommand
         {
             get { return this.bindCommand; }
             set { SetAndRaisePropertyChanged(ref this.bindCommand, value); }
         }
 
-        public ICommand BrowseToUrlCommand
+        public ICommand<string> BrowseToUrlCommand
         {
             get { return this.browseToUrl; }
             set { SetAndRaisePropertyChanged(ref this.browseToUrl, value); }

--- a/src/Integration/TeamExplorer/ISectionController.cs
+++ b/src/Integration/TeamExplorer/ISectionController.cs
@@ -22,6 +22,7 @@ using System.Windows.Input;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.WPF;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.TeamExplorer
 {
@@ -56,14 +57,14 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         ICommand<BindCommandArgs> BindCommand { get; }
 
-        ICommand BrowseToUrlCommand { get; }
+        ICommand<string> BrowseToUrlCommand { get; }
 
-        ICommand BrowseToProjectDashboardCommand { get; }
+        ICommand<ProjectViewModel> BrowseToProjectDashboardCommand { get; }
 
-        ICommand RefreshCommand { get; }
+        ICommand<ConnectionInformation> RefreshCommand { get; }
 
         ICommand DisconnectCommand { get; }
 
-        ICommand ToggleShowAllProjectsCommand { get; }
+        ICommand<ServerViewModel> ToggleShowAllProjectsCommand { get; }
     }
 }

--- a/src/Integration/TeamExplorer/SectionController.cs
+++ b/src/Integration/TeamExplorer/SectionController.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.WPF;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.TeamExplorer
 {
@@ -190,19 +191,19 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             private set;
         }
 
-        public ICommand BrowseToUrlCommand
+        public ICommand<string> BrowseToUrlCommand
         {
             get;
             private set;
         }
 
-        public ICommand BrowseToProjectDashboardCommand
+        public ICommand<ProjectViewModel> BrowseToProjectDashboardCommand
         {
             get;
             private set;
         }
 
-        public ICommand RefreshCommand
+        public ICommand<ConnectionInformation> RefreshCommand
         {
             get;
             internal /*for test purposes*/ set;
@@ -214,7 +215,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             private set;
         }
 
-        public ICommand ToggleShowAllProjectsCommand
+        public ICommand<ServerViewModel> ToggleShowAllProjectsCommand
         {
             get;
             private set;

--- a/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
@@ -23,6 +23,7 @@ using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
@@ -54,13 +55,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             set;
         }
 
-        public ICommand RefreshCommand
+        public ICommand<ConnectionInformation> RefreshCommand
         {
             get;
             set;
         }
 
-        public ICommand ToggleShowAllProjectsCommand
+        public ICommand<ServerViewModel> ToggleShowAllProjectsCommand
         {
             get;
             set;
@@ -84,13 +85,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             set;
         }
 
-        public ICommand BrowseToUrlCommand
+        public ICommand<string> BrowseToUrlCommand
         {
             get;
             set;
         }
 
-        public ICommand BrowseToProjectDashboardCommand
+        public ICommand<ProjectViewModel> BrowseToProjectDashboardCommand
         {
             get;
             set;
@@ -110,10 +111,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             section.BindCommand = new RelayCommand<BindCommandArgs>(args => { });
             section.ConnectCommand = new RelayCommand(() => { });
             section.DisconnectCommand = new RelayCommand(() => { });
-            section.RefreshCommand = new RelayCommand(() => { });
-            section.BrowseToUrlCommand = new RelayCommand(() => { });
-            section.BrowseToProjectDashboardCommand = new RelayCommand(() => { });
-            section.ToggleShowAllProjectsCommand = new RelayCommand(() => { });
+            section.RefreshCommand = new RelayCommand<ConnectionInformation>(c => { });
+            section.BrowseToUrlCommand = new RelayCommand<string>(url => { });
+            section.BrowseToProjectDashboardCommand = new RelayCommand<ProjectViewModel>(vm => { });
+            section.ToggleShowAllProjectsCommand = new RelayCommand<ServerViewModel>(vm => { });
             return section;
         }
 


### PR DESCRIPTION
Minor refactoring - changed commands that take an argument from _ICommand_ to use _ICommand[T]_.

_ICommand[T]_ inherits from _ICommand_ so it is still possible to use the overload defined in _ICommand_ to pass in a parameter of the wrong type. It's still an improvement as at least we get an overload in IntelliSense that shows the expected argument type.