### PR TITLE
Added unbind command for new connected mode

### DIFF
--- a/src/Integration.UnitTests/NewConnectedMode/UnbindCommandTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/UnbindCommandTests.cs
@@ -126,9 +126,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             host.TestStateManager.IsBusy = false;
             configProvider.ModeToReturn = SonarLintMode.Connected;
 
-            bool eventRaised = false;
-            host.TestStateManager.BindingStateChanged += (s, e) => eventRaised = true;
-
             bool disconnectCalled = false;
             section.DisconnectCommand = new RelayCommand(exec =>
                 {
@@ -141,7 +138,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Assert
             configProvider.DeleteCallCount.Should().Be(1);
-            eventRaised.Should().BeTrue();
             disconnectCalled.Should().BeTrue();
 
             outputWindowPane.AssertOutputStrings(

--- a/src/Integration.UnitTests/NewConnectedMode/UnbindCommandTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/UnbindCommandTests.cs
@@ -1,0 +1,187 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Windows.Threading;
+using FluentAssertions;
+using Microsoft.TeamFoundation.MVVM;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
+using SonarLint.VisualStudio.Integration.Persistence;
+using SonarLint.VisualStudio.Integration.Resources;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class UnbindCommandTests
+    {
+        private readonly BoundSonarQubeProject ValidProject = new BoundSonarQubeProject(new Uri("http://any"), "projectKey");
+
+        private ConfigurableHost host;
+        private ConfigurableServiceProvider serviceProvider;
+        private ConfigurableConfigurationProvider configProvider;
+        private ConfigurableVsOutputWindowPane outputWindowPane;
+        private ConfigurableSectionController section;
+
+        private UnbindCommand testSubject;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            serviceProvider = new ConfigurableServiceProvider();
+
+            configProvider = new ConfigurableConfigurationProvider();
+            configProvider.ProjectToReturn = ValidProject;
+            serviceProvider.RegisterService(typeof(IConfigurationProvider), configProvider);
+
+            var outputWindow = new ConfigurableVsOutputWindow();
+            outputWindowPane = outputWindow.GetOrCreateSonarLintPane();
+            serviceProvider.RegisterService(typeof(SVsOutputWindow), outputWindow);
+
+            host = new ConfigurableHost(serviceProvider, Dispatcher.CurrentDispatcher);
+
+            section = new ConfigurableSectionController();
+            host.SetActiveSection(section);
+
+            testSubject = new UnbindCommand(host);
+        }
+
+        [TestMethod]
+        public void Ctor_NullHost_Throws()
+        {
+            // Arrange
+            Action act = () => new UnbindCommand(null);
+
+            // Act & Assert
+            act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("host");
+        }
+
+        [TestMethod]
+        public void CanExecute_HostIsBusy_ReturnsFalse()
+        {
+            // Arrange
+            host.TestStateManager.IsBusy = true;
+
+            // Act & Assert
+            testSubject.CanExecute().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CanExecute_InStandaloneMode_ReturnsFalse()
+        {
+            // Arrange
+            host.TestStateManager.IsBusy = false;
+            configProvider.ModeToReturn = SonarLintMode.Standalone;
+
+            // Act & Assert
+            testSubject.CanExecute().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CanExecute_InLegacyConnectedMode_ReturnsFalse()
+        {
+            // Arrange
+            host.TestStateManager.IsBusy = false;
+            configProvider.ModeToReturn = SonarLintMode.LegacyConnected;
+
+            // Act & Assert
+            testSubject.CanExecute().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CanExecute_InConnectedMode_ReturnsTrue()
+        {
+            // Arrange
+            host.TestStateManager.IsBusy = false;
+            configProvider.ModeToReturn = SonarLintMode.Connected;
+
+            // Act & Assert
+            testSubject.CanExecute().Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Execute_NoErrors_Succeed()
+        {
+            // Arrange
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            host.TestStateManager.IsBusy = false;
+            configProvider.ModeToReturn = SonarLintMode.Connected;
+
+            bool eventRaised = false;
+            host.TestStateManager.BindingStateChanged += (s, e) => eventRaised = true;
+
+            bool disconnectCalled = false;
+            section.DisconnectCommand = new RelayCommand(exec =>
+                {
+                    host.TestStateManager.IsBusy.Should().BeTrue(); // check busy flag is set
+                    disconnectCalled = true;
+                });
+
+            // Act
+            testSubject.Execute();
+
+            // Assert
+            configProvider.DeleteCallCount.Should().Be(1);
+            eventRaised.Should().BeTrue();
+            disconnectCalled.Should().BeTrue();
+
+            outputWindowPane.AssertOutputStrings(
+                Strings.Unbind_State_Started,
+                Strings.Unbind_DeletingBinding,
+                Strings.Unbind_DisconnectingFromSonarQube,
+                Strings.Unbind_State_Succeeded);
+            host.VisualStateManager.IsBusy.Should().BeFalse();  
+        }
+
+        [TestMethod]
+        public void Execute_ErrorThrown_FailsButNoExceptionThrow()
+        {
+            // Arrange
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            host.TestStateManager.IsBusy = false;
+            configProvider.ModeToReturn = SonarLintMode.Connected;
+
+            bool eventRaised = false;
+            host.TestStateManager.BindingStateChanged += (s, e) => eventRaised = true;
+
+            section.DisconnectCommand = new RelayCommand(exec =>
+                {
+                    host.TestStateManager.IsBusy.Should().BeTrue(); // check busy flag is set
+                    throw new InvalidCastException("my error message");
+                });
+
+            // Act
+            testSubject.Execute();
+
+            // Assert
+            eventRaised.Should().BeFalse();
+            outputWindowPane.AssertOutputStrings(
+                Strings.Unbind_State_Started,
+                Strings.Unbind_DeletingBinding,
+                Strings.Unbind_DisconnectingFromSonarQube,
+                "my error message",
+                Strings.Unbind_State_Failed);
+            host.VisualStateManager.IsBusy.Should().BeFalse();
+        }
+    }
+}

--- a/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
+++ b/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
@@ -358,6 +358,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             solutionProject.Files.ContainsKey(output).Should().BeTrue("File {0} should remain in the project", output);
         }
 
+        [TestMethod]
+        public void SolutionBindingSerializer_Delete_Throws()
+        {
+            // Arrange
+            var testSubject = this.CreateTestSubject();
+            Action act = () => testSubject.DeleteBinding();
+
+            // Act & Assert
+            act.ShouldThrow<InvalidOperationException>();
+        }
+
         #region Helpers
 
         private SolutionBindingSerializer CreateTestSubject()

--- a/src/Integration.UnitTests/State/StateManagerTests.cs
+++ b/src/Integration.UnitTests/State/StateManagerTests.cs
@@ -483,10 +483,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
 
         private static void VerifySectionCommands(ISectionController section, ServerViewModel serverVM)
         {
-            AssertExpectedNumberOfCommands(serverVM.Commands, 3);
+            AssertExpectedNumberOfCommands(serverVM.Commands, 4);
             VerifyServerViewModelCommand(serverVM, section.RefreshCommand, fixedContext: serverVM, hasIcon: true);
             VerifyServerViewModelCommand(serverVM, section.BrowseToUrlCommand, fixedContext: serverVM.ConnectionInformation.ServerUri.ToString(), hasIcon: true);
             VerifyServerViewModelCommand(serverVM, section.ToggleShowAllProjectsCommand, fixedContext: serverVM, hasIcon: false);
+            VerifyServerViewModelCommand(serverVM, section.UnbindCommand, fixedContext: serverVM, hasIcon: true);
 
             foreach (ProjectViewModel project in serverVM.Projects)
             {

--- a/src/Integration.UnitTests/TeamExplorer/SectionControllerTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/SectionControllerTests.cs
@@ -26,6 +26,7 @@ using Microsoft.TeamFoundation.Client.CommandTarget;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
 using SonarQube.Client.Models;
@@ -49,6 +50,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);
             this.host.SonarQubeService = this.sonarQubeServiceMock.Object;
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), new ConfigurableVsProjectSystemHelper(this.serviceProvider));
+            this.serviceProvider.RegisterService(typeof(IConfigurationProvider), new ConfigurableConfigurationProvider());
         }
 
         #region Tests

--- a/src/Integration/NewConnectedMode/ConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationProvider.cs
@@ -68,7 +68,6 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            string fileName = null;
             switch (configuration.Mode)
             {
                 case SonarLintMode.LegacyConnected:
@@ -80,6 +79,18 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
                 default:
                     Debug.Fail("Unrecognised write mode");
                     return false;
+            }
+        }
+
+        public void DeleteConfiguration()
+        {
+            var mode = this.GetConfiguration().Mode;
+            Debug.Assert(mode == SonarLintMode.Connected,
+                "Cannot only delete a configuration when in new connected mode");
+
+            if (mode == SonarLintMode.Connected)
+            {
+                newConnectedModeSerializer.DeleteBinding();
             }
         }
     }

--- a/src/Integration/NewConnectedMode/ConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationProvider.cs
@@ -86,7 +86,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
         {
             var mode = this.GetConfiguration().Mode;
             Debug.Assert(mode == SonarLintMode.Connected,
-                "Cannot only delete a configuration when in new connected mode");
+                "Can only delete a configuration when in new connected mode");
 
             if (mode == SonarLintMode.Connected)
             {

--- a/src/Integration/NewConnectedMode/ConfigurationSerializer.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationSerializer.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.Alm.Authentication;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -34,13 +35,14 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
     internal class ConfigurationSerializer : FileBindingSerializer
     {
         private readonly IVsSolution solution;
+        private readonly IDirectory directoryWrapper;
 
         public ConfigurationSerializer(
             IVsSolution solution,
             ISourceControlledFileSystem sccFileSystem,
             ICredentialStore store,
             ILogger logger)
-            :this(solution, sccFileSystem, store, logger, new FileWrapper())
+            :this(solution, sccFileSystem, store, logger, new FileWrapper(), new DirectoryWrapper())
         {
         }
 
@@ -49,15 +51,37 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             ISourceControlledFileSystem sccFileSystem,
             ICredentialStore store,
             ILogger logger,
-            IFile fileWrapper)
+            IFile fileWrapper,
+            IDirectory directoryWrapper)
             :base(sccFileSystem, store, logger, fileWrapper)
         {
             if (solution == null)
             {
                 throw new ArgumentNullException(nameof(solution));
             }
+            Debug.Assert(directoryWrapper != null);
 
             this.solution = solution;
+            this.directoryWrapper = directoryWrapper;
+        }
+
+        public override void DeleteBinding()
+        {
+            //TODO: we are assuming the files are not under source control
+            string configFile = this.GetFullConfigurationFilePath();
+
+            if (!fileWrapper.Exists(configFile))
+            {
+                Debug.Fail($"Nothing to delete - binding file does not exist: {configFile}");
+                return;
+            }
+
+            SafePerformFileSystemOperation(() =>
+            {
+                fileWrapper.Delete(configFile);
+                string sonarLintDir = Path.GetDirectoryName(configFile);
+                directoryWrapper.Delete(sonarLintDir);
+            });
         }
 
         protected override WriteMode Mode

--- a/src/Integration/NewConnectedMode/IConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/IConfigurationProvider.cs
@@ -25,5 +25,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
         BindingConfiguration GetConfiguration();
 
         bool WriteConfiguration(BindingConfiguration configuration);
+
+        void DeleteConfiguration();
     }
 }

--- a/src/Integration/NewConnectedMode/UnbindCommand.cs
+++ b/src/Integration/NewConnectedMode/UnbindCommand.cs
@@ -1,0 +1,84 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Diagnostics;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Integration.Resources;
+
+namespace SonarLint.VisualStudio.Integration.NewConnectedMode
+{
+    internal class UnbindCommand
+    {
+        private readonly IHost host;
+        private readonly IConfigurationProvider configProvider;
+
+        public UnbindCommand(IHost host)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+            this.host = host;
+
+            this.configProvider = this.host.GetService<IConfigurationProvider>();
+            configProvider.AssertLocalServiceIsNotNull();
+        }
+
+        public bool CanExecute()
+        {
+            // Can only unbind if currently in new bound mode
+            return  !host.VisualStateManager.IsBusy &&
+                configProvider.GetConfiguration().Mode == SonarLintMode.Connected;
+        }
+
+        public void Execute()
+        {
+            Debug.Assert(this.CanExecute(), $"Should not be called UnbindCommand.Execute if CanExecute is false");
+            Debug.Assert(ThreadHelper.CheckAccess(), "Expected step to be run on the UI thread");
+
+            host.Logger.WriteLine(Strings.Unbind_State_Started);
+            try
+            {
+                host.VisualStateManager.IsBusy = true;
+
+                host.Logger.WriteLine(Strings.Unbind_DeletingBinding);
+                configProvider.DeleteConfiguration();
+
+                host.Logger.WriteLine(Strings.Unbind_DisconnectingFromSonarQube);
+                host.ActiveSection.DisconnectCommand.Execute(null);
+
+                host.VisualStateManager.ClearBoundProject(); // this will raise a "binding changed" event
+
+                host.Logger.WriteLine(Strings.Unbind_State_Succeeded);
+            }
+            catch(Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+            {
+                host.Logger.WriteLine(ex.Message);
+                host.Logger.WriteLine(Strings.Unbind_State_Failed);
+            }
+            finally
+            {
+                host.VisualStateManager.IsBusy = false;
+            }
+        }
+    }
+}

--- a/src/Integration/NewConnectedMode/UnbindCommand.cs
+++ b/src/Integration/NewConnectedMode/UnbindCommand.cs
@@ -52,7 +52,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 
         public void Execute()
         {
-            Debug.Assert(this.CanExecute(), $"Should not be called UnbindCommand.Execute if CanExecute is false");
+            Debug.Assert(this.CanExecute(), "UnbindCommand.Execute should not be called if CanExecute is false");
             Debug.Assert(ThreadHelper.CheckAccess(), "Expected step to be run on the UI thread");
 
             host.Logger.WriteLine(Strings.Unbind_State_Started);
@@ -74,7 +74,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 
                 host.Logger.WriteLine(Strings.Unbind_State_Succeeded);
             }
-            catch(Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+            catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
                 host.Logger.WriteLine(ex.Message);
                 host.Logger.WriteLine(Strings.Unbind_State_Failed);

--- a/src/Integration/NewConnectedMode/UnbindCommand.cs
+++ b/src/Integration/NewConnectedMode/UnbindCommand.cs
@@ -66,7 +66,11 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
                 host.Logger.WriteLine(Strings.Unbind_DisconnectingFromSonarQube);
                 host.ActiveSection.DisconnectCommand.Execute(null);
 
-                host.VisualStateManager.ClearBoundProject(); // this will raise a "binding changed" event
+                Debug.Assert(!host.VisualStateManager.HasBoundProject,
+                    "Bound project should be null after unbinding");
+
+                Debug.Assert(!host.VisualStateManager.IsConnected,
+                    "Should be disconnected from the SQ server after unbinding");
 
                 host.Logger.WriteLine(Strings.Unbind_State_Succeeded);
             }

--- a/src/Integration/Persistence/FileBindingSerializer.cs
+++ b/src/Integration/Persistence/FileBindingSerializer.cs
@@ -31,7 +31,7 @@ namespace SonarLint.VisualStudio.Integration.Persistence
 {
     internal abstract class FileBindingSerializer : ISolutionBindingSerializer
     {
-        private readonly IFile fileWrapper;
+        protected readonly IFile fileWrapper;
 
         protected readonly ISourceControlledFileSystem sccFileSystem;
         protected readonly ILogger logger;
@@ -128,7 +128,9 @@ namespace SonarLint.VisualStudio.Integration.Persistence
 
             return configFile;
         }
-        
+
+        public abstract void DeleteBinding();
+
         private BoundSonarQubeProject ReadBindingInformation(string configFile)
         {
             BoundSonarQubeProject bound = this.SafeDeserializeConfigFile(configFile);
@@ -203,7 +205,7 @@ namespace SonarLint.VisualStudio.Integration.Persistence
             return null;
         }
 
-        private bool SafePerformFileSystemOperation(Action operation)
+        protected bool SafePerformFileSystemOperation(Action operation)
         {
             Debug.Assert(operation != null);
 

--- a/src/Integration/Persistence/ISolutionBindingSerializer.cs
+++ b/src/Integration/Persistence/ISolutionBindingSerializer.cs
@@ -36,5 +36,10 @@ namespace SonarLint.VisualStudio.Integration.Persistence
         /// <param name="sccFileSystem">Required</param>
         /// <returns>The file path to the binding file</returns>
         string WriteSolutionBinding(BoundSonarQubeProject binding);
+
+        /// <summary>
+        /// Deletes the current binding
+        /// </summary>
+        void DeleteBinding();
     }
 }

--- a/src/Integration/Persistence/SolutionBindingSerializer.cs
+++ b/src/Integration/Persistence/SolutionBindingSerializer.cs
@@ -62,6 +62,12 @@ namespace SonarLint.VisualStudio.Integration.Persistence
             get { return WriteMode.Queued; }
         }
 
+        public override void DeleteBinding()
+        {
+            // Deleting binding is not supported for legacy mode
+            throw new InvalidOperationException();
+        }
+
         protected override bool OnSuccessfulFileWrite(string filePath)
         {
             this.AddSolutionItemFile(filePath);

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -1298,6 +1298,51 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deleting binding configuration....
+        /// </summary>
+        public static string Unbind_DeletingBinding {
+            get {
+                return ResourceManager.GetString("Unbind_DeletingBinding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disconnecting from the server....
+        /// </summary>
+        public static string Unbind_DisconnectingFromSonarQube {
+            get {
+                return ResourceManager.GetString("Unbind_DisconnectingFromSonarQube", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unbinding operation failed..
+        /// </summary>
+        public static string Unbind_State_Failed {
+            get {
+                return ResourceManager.GetString("Unbind_State_Failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unbinding started....
+        /// </summary>
+        public static string Unbind_State_Started {
+            get {
+                return ResourceManager.GetString("Unbind_State_Started", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unbinding operation completed succesfully..
+        /// </summary>
+        public static string Unbind_State_Succeeded {
+            get {
+                return ResourceManager.GetString("Unbind_State_Succeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}: Unexpected error: {1}. You can help us improve by reporting this bug at {2}..
         /// </summary>
         public static string UnexpectedErrorMessageFormat {

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -1298,6 +1298,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unbind.
+        /// </summary>
+        public static string Unbind_Command_DisplayText {
+            get {
+                return ResourceManager.GetString("Unbind_Command_DisplayText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unbinds the solution from the SonarQube project and closes the connection to the SonarQube server.
+        /// </summary>
+        public static string Unbind_Command_Tooltip {
+            get {
+                return ResourceManager.GetString("Unbind_Command_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting binding configuration....
         /// </summary>
         public static string Unbind_DeletingBinding {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -734,4 +734,19 @@ This is the general format to use when writing errors to output window or when t
   <data name="Bind_UpdatingNewStyleBinding" xml:space="preserve">
     <value>Updating binding...</value>
   </data>
+  <data name="Unbind_DeletingBinding" xml:space="preserve">
+    <value>Deleting binding configuration...</value>
+  </data>
+  <data name="Unbind_DisconnectingFromSonarQube" xml:space="preserve">
+    <value>Disconnecting from the server...</value>
+  </data>
+  <data name="Unbind_State_Failed" xml:space="preserve">
+    <value>Unbinding operation failed.</value>
+  </data>
+  <data name="Unbind_State_Started" xml:space="preserve">
+    <value>Unbinding started...</value>
+  </data>
+  <data name="Unbind_State_Succeeded" xml:space="preserve">
+    <value>Unbinding operation completed succesfully.</value>
+  </data>
 </root>

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -749,4 +749,12 @@ This is the general format to use when writing errors to output window or when t
   <data name="Unbind_State_Succeeded" xml:space="preserve">
     <value>Unbinding operation completed succesfully.</value>
   </data>
+  <data name="Unbind_Command_DisplayText" xml:space="preserve">
+    <value>Unbind</value>
+    <comment>Menu item display text</comment>
+  </data>
+  <data name="Unbind_Command_Tooltip" xml:space="preserve">
+    <value>Unbinds the solution from the SonarQube project and closes the connection to the SonarQube server</value>
+    <comment>Menu item tool tip</comment>
+  </data>
 </root>

--- a/src/Integration/State/StateManager.cs
+++ b/src/Integration/State/StateManager.cs
@@ -287,7 +287,8 @@ namespace SonarLint.VisualStudio.Integration.State
             });
 
             var unbindCommand = new ContextualCommandViewModel(serverVM, this.Host.ActiveSection.UnbindCommand);
-            unbindCommand.DisplayText = "Unbind";
+            unbindCommand.DisplayText = Strings.Unbind_Command_DisplayText;
+            unbindCommand.Tooltip = Strings.Unbind_Command_Tooltip;
             unbindCommand.Icon = new IconViewModel(KnownMonikers.Disconnect);
 
             // Note: the Disconnect command is not on the context menu, although it is
@@ -335,16 +336,6 @@ namespace SonarLint.VisualStudio.Integration.State
 
                 projectVM.Commands.Add(bindContextCommand);
                 projectVM.Commands.Add(openProjectDashboardCommand);
-
-                // Only add the Unbind command to the currently bound project
-                if (projectVM.IsBound)
-                {
-                    var unbindCommand = new ContextualCommandViewModel(projectVM,
-                        this.Host.ActiveSection.UnbindCommand);
-                    unbindCommand.DisplayText = "Unbind";
-                    unbindCommand.Icon = new IconViewModel(KnownMonikers.Disconnect);
-                    projectVM.Commands.Add(unbindCommand);
-                }
             }
         }
         #endregion

--- a/src/Integration/State/StateManager.cs
+++ b/src/Integration/State/StateManager.cs
@@ -286,11 +286,16 @@ namespace SonarLint.VisualStudio.Integration.State
                 return ctx?.ShowAllProjects ?? false ? Strings.HideUnboundProjectsCommandText : Strings.ShowAllProjectsCommandText;
             });
 
+            var unbindCommand = new ContextualCommandViewModel(serverVM, this.Host.ActiveSection.UnbindCommand);
+            unbindCommand.DisplayText = "Unbind";
+            unbindCommand.Icon = new IconViewModel(KnownMonikers.Disconnect);
+
             // Note: the Disconnect command is not on the context menu, although it is
             // called directly from code e.g. when the solution unloads
             serverVM.Commands.Add(refreshContextualCommand);
             serverVM.Commands.Add(browseServerContextualCommand);
             serverVM.Commands.Add(toggleShowAllProjectsCommand);
+            serverVM.Commands.Add(unbindCommand);
         }
 
         private void SetServerProjectsVMCommands(ServerViewModel serverVM)
@@ -330,6 +335,16 @@ namespace SonarLint.VisualStudio.Integration.State
 
                 projectVM.Commands.Add(bindContextCommand);
                 projectVM.Commands.Add(openProjectDashboardCommand);
+
+                // Only add the Unbind command to the currently bound project
+                if (projectVM.IsBound)
+                {
+                    var unbindCommand = new ContextualCommandViewModel(projectVM,
+                        this.Host.ActiveSection.UnbindCommand);
+                    unbindCommand.DisplayText = "Unbind";
+                    unbindCommand.Icon = new IconViewModel(KnownMonikers.Disconnect);
+                    projectVM.Commands.Add(unbindCommand);
+                }
             }
         }
         #endregion

--- a/src/Integration/TeamExplorer/ISectionController.cs
+++ b/src/Integration/TeamExplorer/ISectionController.cs
@@ -57,6 +57,11 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         ICommand<BindCommandArgs> BindCommand { get; }
 
+        /// <summary>
+        /// Unbind the currently bound project
+        /// </summary>
+        ICommand UnbindCommand { get; }
+
         ICommand<string> BrowseToUrlCommand { get; }
 
         ICommand<ProjectViewModel> BrowseToProjectDashboardCommand { get; }

--- a/src/Integration/TeamExplorer/ProjectViewModel.cs
+++ b/src/Integration/TeamExplorer/ProjectViewModel.cs
@@ -31,9 +31,6 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         private readonly ContextualCommandsCollection commands = new ContextualCommandsCollection();
         private bool isBound;
 
-        // Ordinal comparer should be good enough: http://docs.sonarqube.org/display/SONAR/Project+Administration#ProjectAdministration-AddingaProject
-        public static readonly StringComparer KeyComparer = StringComparer.Ordinal;
-
         public ProjectViewModel(ServerViewModel owner, SonarQubeProject projectInformation)
         {
             if (owner == null)

--- a/src/Integration/TeamExplorer/SectionController.cs
+++ b/src/Integration/TeamExplorer/SectionController.cs
@@ -29,6 +29,7 @@ using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
 using Microsoft.VisualStudio.ComponentModelHost;
 using SonarLint.VisualStudio.Integration.Binding;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.WPF;
 using SonarQube.Client.Models;
@@ -191,6 +192,12 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             private set;
         }
 
+        public ICommand UnbindCommand
+        {
+            get;
+            private set;
+        }
+
         public ICommand<string> BrowseToUrlCommand
         {
             get;
@@ -260,6 +267,9 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.ToggleShowAllProjectsCommand = new RelayCommand<ServerViewModel>(this.ToggleShowAllProjects, this.CanToggleShowAllProjects);
             this.BrowseToUrlCommand = new RelayCommand<string>(this.ExecBrowseToUrl, this.CanExecBrowseToUrl);
             this.BrowseToProjectDashboardCommand = new RelayCommand<ProjectViewModel>(this.ExecBrowseToProjectDashboard, this.CanExecBrowseToProjectDashboard);
+
+            var unbindCommand = new NewConnectedMode.UnbindCommand(this.Host);
+            this.UnbindCommand = new RelayCommand(unbindCommand.Execute, unbindCommand.CanExecute);
         }
 
         private void CleanProvidedCommands()
@@ -268,6 +278,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.ToggleShowAllProjectsCommand = null;
             this.BrowseToUrlCommand = null;
             this.BrowseToProjectDashboardCommand = null;
+            this.UnbindCommand = null;
         }
 
         private void SyncCommands()

--- a/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
@@ -62,7 +62,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public bool WriteResultToReturn { get; set; }
         public BindingConfiguration SavedConfiguration { get; set; }
 
-        public int DeleteCallCount { get; set; }
+        public int DeleteCallCount { get; private set; }
 
         #endregion Test helpers
 

--- a/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
@@ -48,6 +48,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return this.WriteResultToReturn;
         }
 
+        public void DeleteConfiguration()
+        {
+            DeleteCallCount++;
+        }
+
         #region Test helpers
 
         public BoundSonarQubeProject ProjectToReturn { get; set; }
@@ -56,6 +61,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public bool WriteResultToReturn { get; set; }
         public BindingConfiguration SavedConfiguration { get; set; }
+
+        public int DeleteCallCount { get; set; }
 
         #endregion Test helpers
 

--- a/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
@@ -37,6 +37,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             set;
         }
 
+        public ICommand UnbindCommand
+        {
+            get;
+            set;
+        }
+
         public ICommand ConnectCommand
         {
             get;
@@ -109,6 +115,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             section.ProgressHost = new ConfigurableProgressControlHost();
             section.UserNotifications = new ConfigurableUserNotification();
             section.BindCommand = new RelayCommand<BindCommandArgs>(args => { });
+            section.UnbindCommand = new RelayCommand(() => { });
             section.ConnectCommand = new RelayCommand(() => { });
             section.DisconnectCommand = new RelayCommand(() => { });
             section.RefreshCommand = new RelayCommand<ConnectionInformation>(c => { });

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionBindingSerializer.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionBindingSerializer.cs
@@ -27,6 +27,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     internal class ConfigurableSolutionBindingSerializer : ISolutionBindingSerializer
     {
         internal int WrittenFilesCount { get; private set; }
+        internal int DeleteCallCount { get; private set; }
 
         #region ISolutionBindingSerializer
 
@@ -44,6 +45,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.WrittenFilesCount++;
 
             return filePath;
+        }
+
+        void ISolutionBindingSerializer.DeleteBinding()
+        {
+            this.DeleteCallCount++;
         }
 
         #endregion ISolutionBindingSerializer


### PR DESCRIPTION
* added new _delete_ methods to _IConfigurationProvider_ and _ISolutionBoundSerializer_
* added a new server-level UI _Unbind_ command (i.e. appears on the SQ server context menu, not on the project-level menu). The new command only works for connected mode. It's visible but disabled in other modes.
* added tests