### PR TITLE
Minor refactoring to remove ISolutionBindingSerializer service

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -38,7 +38,6 @@ using NuGet;
 using NuGet.VisualStudio;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Helpers;
-using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarQube.Client.Messages;
 using SonarQube.Client.Models;
@@ -71,11 +70,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             var sccFileSystem = new ConfigurableSourceControlledFileSystem();
             var ruleSerializer = new ConfigurableRuleSetSerializer(sccFileSystem);
-            var solutionBinding = new ConfigurableSolutionBindingSerializer();
 
             this.serviceProvider.RegisterService(typeof(ISourceControlledFileSystem), sccFileSystem);
             this.serviceProvider.RegisterService(typeof(IRuleSetSerializer), ruleSerializer);
-            this.serviceProvider.RegisterService(typeof(ISolutionBindingSerializer), solutionBinding);
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystemHelper);
 
             this.host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarQube.Client.Models;
 
@@ -234,8 +235,8 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
             Debug.Assert(this.qualityProfileMap != null, "Initialize was expected to be called first");
 
-            var binding = this.serviceProvider.GetService<ISolutionBindingSerializer>();
-            binding.AssertLocalServiceIsNotNull();
+            var bindingSerializer = this.serviceProvider.GetService<IConfigurationProvider>();
+            bindingSerializer.AssertLocalServiceIsNotNull();
 
             BasicAuthCredentials credentials = connection.UserName == null ? null : new BasicAuthCredentials(connInfo.UserName, connInfo.Password);
 
@@ -254,7 +255,8 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 connInfo.Organization);
             bound.Profiles = map;
 
-            binding.WriteSolutionBinding(bound);
+            var config = new BindingConfiguration(bound, SonarLintMode.LegacyConnected);
+            bindingSerializer.WriteConfiguration(config);
         }
 
         private void AddFileToSolutionItems(string fullFilePath)

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -46,7 +46,6 @@ namespace SonarLint.VisualStudio.Integration
         {
                 typeof(ISolutionRuleSetsInformationProvider),
                 typeof(IRuleSetSerializer),
-                typeof(ISolutionBindingSerializer),
                 typeof(IProjectSystemHelper),
                 typeof(ISourceControlledFileSystem),
                 typeof(IFileSystem),
@@ -297,12 +296,11 @@ namespace SonarLint.VisualStudio.Integration
         {
             this.localServices.Add(typeof(ISolutionRuleSetsInformationProvider), new Lazy<ILocalService>(() => new SolutionRuleSetsInformationProvider(this, Logger)));
             this.localServices.Add(typeof(IRuleSetSerializer), new Lazy<ILocalService>(() => new RuleSetSerializer(this)));
-            this.localServices.Add(typeof(ISolutionBindingSerializer), new Lazy<ILocalService>(() => new SolutionBindingSerializer(this)));
             this.localServices.Add(typeof(IConfigurationProvider), new Lazy<ILocalService>(() =>
             {
                 var solution = this.GetService<SVsSolution, IVsSolution>();
                 var store = new SecretStore(SolutionBindingSerializer.StoreNamespace);
-                var legacySerializer = this.GetService<ISolutionBindingSerializer>();
+                var legacySerializer = new SolutionBindingSerializer(this);
                 // The SCC wrapper maintains a queue of file writes. For the new provider we want to the file write to be
                 // executed immediately, so we want our own SCC wrapper rather than sharing the one used by the legacy mode.
                 var sccFileSystem = new SourceControlledFileSystem(this); 

--- a/src/Integration/Persistence/ISolutionBindingSerializer.cs
+++ b/src/Integration/Persistence/ISolutionBindingSerializer.cs
@@ -21,7 +21,7 @@
 namespace SonarLint.VisualStudio.Integration.Persistence
 {
     // Test interface
-    internal interface ISolutionBindingSerializer : ILocalService
+    internal interface ISolutionBindingSerializer
     {
         /// <summary>
         /// Retrieves solution binding information


### PR DESCRIPTION
Simplified the legacy serialization slightly by removing _ISolutionBindingSerializer_ as a local service.
It is now only used by the _ConfigurationProvider_.

Relates to #554 
