### PR TITLE
Refactor: removed IConflictsManager as a local service

### DIFF
--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -49,7 +49,6 @@ namespace SonarLint.VisualStudio.Integration
                 typeof(IProjectSystemHelper),
                 typeof(ISourceControlledFileSystem),
                 typeof(IFileSystem),
-                typeof(IConflictsManager),
                 typeof(IRuleSetInspector),
                 typeof(IRuleSetConflictsController),
                 typeof(IProjectSystemFilter),
@@ -307,9 +306,8 @@ namespace SonarLint.VisualStudio.Integration
                 return new ConfigurationProvider(legacySerializer, newConfigSerializer);
             }));
             this.localServices.Add(typeof(IProjectSystemHelper), new Lazy<ILocalService>(() => new ProjectSystemHelper(this)));
-            this.localServices.Add(typeof(IConflictsManager), new Lazy<ILocalService>(() => new ConflictsManager(this, Logger)));
             this.localServices.Add(typeof(IRuleSetInspector), new Lazy<ILocalService>(() => new RuleSetInspector(this, Logger)));
-            this.localServices.Add(typeof(IRuleSetConflictsController), new Lazy<ILocalService>(() => new RuleSetConflictsController(this)));
+            this.localServices.Add(typeof(IRuleSetConflictsController), new Lazy<ILocalService>(() => new RuleSetConflictsController(this, new ConflictsManager(this, Logger))));
             this.localServices.Add(typeof(IProjectSystemFilter), new Lazy<ILocalService>(() => new ProjectSystemFilter(this)));
             this.localServices.Add(typeof(IErrorListInfoBarController), new Lazy<ILocalService>(() => new ErrorListInfoBarController(this, new SolutionBindingInformationProvider(this))));
 

--- a/src/Integration/ProfileConflicts/IConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/IConflictsManager.cs
@@ -25,7 +25,7 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
     /// <summary>
     /// Handlers conflict resolution at the solution level
     /// </summary>
-    public interface IConflictsManager : ILocalService
+    public interface IConflictsManager
     {
         /// <summary>
         /// Checks the current solution for conflicts

--- a/src/Integration/ProfileConflicts/RuleSetConflictsController.cs
+++ b/src/Integration/ProfileConflicts/RuleSetConflictsController.cs
@@ -36,15 +36,21 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
         private const string Indent = "\t";
 
         private readonly IHost host;
+        private readonly IConflictsManager conflictsManager;
 
-        public RuleSetConflictsController(IHost host)
+        public RuleSetConflictsController(IHost host, IConflictsManager conflictsManager)
         {
             if (host == null)
             {
                 throw new ArgumentNullException(nameof(host));
             }
+            if (conflictsManager == null)
+            {
+                throw new ArgumentNullException(nameof(conflictsManager));
+            }
 
             this.host = host;
+            this.conflictsManager = conflictsManager;
             this.FixConflictsCommand = new RelayCommand<IEnumerable<ProjectRuleSetConflict>>(this.OnFixConflicts, this.OnFixConflictsStatus);
         }
 
@@ -55,7 +61,6 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
         {
             Debug.Assert(this.host.UIDispatcher.CheckAccess(), "Expected to be called from the UI thread");
 
-            var conflictsManager = this.host.GetService<IConflictsManager>();
             var conflicts = conflictsManager.GetCurrentConflicts();
 
             if (conflicts.Count > 0)


### PR DESCRIPTION
The ConflictsManager was only used by the RulesSetConflictsController.
All of the remaining local services are consumed by multiple other classes
the interfaces that just exist to help with testing are no longer exposed as "local services"