### PR TITLE
Added isSolutionOpen argument to solution tracking event arg

### DIFF
--- a/src/Integration.UnitTests/MefServices/ActiveSolutionBoundTrackerTests.cs
+++ b/src/Integration.UnitTests/MefServices/ActiveSolutionBoundTrackerTests.cs
@@ -147,9 +147,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // cause a Debug.Assert in the product code that we need to suppress
             using (new AssertIgnoreScope())
             {
-                this.activeSolutionTracker.SimulateActiveSolutionChanged();
-                this.activeSolutionTracker.SimulateActiveSolutionChanged();
-                this.activeSolutionTracker.SimulateActiveSolutionChanged();
+                this.activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
+                this.activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
+                this.activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
             }
 
             // Assert
@@ -209,7 +209,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Case 3: Bound solution unloaded -> disconnect
             ConfigureSolutionBinding(null);
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
 
             // Assert
             testSubject.CurrentConfiguration.Mode.Should().Be(SonarLintMode.Standalone, "Should respond to solution change event and report unbound");
@@ -224,7 +224,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Case 4: Load a bound solution
             ConfigureSolutionBinding(boundProject);
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert
             testSubject.CurrentConfiguration.Mode.Should().Be(SonarLintMode.LegacyConnected, "Bound respond to solution change event and report bound");
@@ -239,7 +239,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Case 5: Close a bound solution
             ConfigureSolutionBinding(null);
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
 
             // Assert
             // TODO: this.errorListController.RefreshCalledCount.Should().Be(4);
@@ -331,7 +331,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigureSolutionBinding(null);
 
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert
             VerifyServiceConnect(Times.Never());
@@ -348,7 +348,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigureSolutionBinding(new BoundSonarQubeProject(new Uri("http://foo"), "projectKey"));
 
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert
             VerifyServiceConnect(Times.Once());
@@ -365,7 +365,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigureSolutionBinding(null);
 
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert
             VerifyServiceConnect(Times.Never());
@@ -387,7 +387,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigureSolutionBinding(new BoundSonarQubeProject(new Uri("http://foo"), "projectKey"));
 
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert
             VerifyServiceConnect(Times.Once());
@@ -417,7 +417,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigureSolutionBinding(null);
 
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
 
             // Assert
             VerifyServiceConnect(Times.Never());
@@ -446,7 +446,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigureSolutionBinding(null);
 
             // Act
-            activeSolutionTracker.SimulateActiveSolutionChanged();
+            activeSolutionTracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
 
             // Assert
             VerifyServiceConnect(Times.Never());

--- a/src/Integration.UnitTests/MefServices/ActiveSolutionTrackerTests.cs
+++ b/src/Integration.UnitTests/MefServices/ActiveSolutionTrackerTests.cs
@@ -60,14 +60,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             int counter = 0;
+            bool isSolutionOpenArg = false;
             var testSubject = new ActiveSolutionTracker(this.serviceProvider);
-            testSubject.ActiveSolutionChanged += (o, e) => counter++;
+            testSubject.ActiveSolutionChanged += (o, e) => { counter++; isSolutionOpenArg = e; };
 
             // Act
             this.solutionMock.SimulateSolutionOpen();
 
             // Assert
             counter.Should().Be(1, nameof(testSubject.ActiveSolutionChanged) + " was expected to be raised");
+            isSolutionOpenArg.Should().BeTrue();
         }
 
         [TestMethod]
@@ -75,14 +77,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             int counter = 0;
+            bool isSolutionOpenEventArg = true;
             var testSubject = new ActiveSolutionTracker(this.serviceProvider);
-            testSubject.ActiveSolutionChanged += (o, e) => counter++;
+            testSubject.ActiveSolutionChanged += (o, e) => { counter++; isSolutionOpenEventArg = e; };
 
             // Act
             this.solutionMock.SimulateSolutionClose();
 
             // Assert
             counter.Should().Be(1, nameof(testSubject.ActiveSolutionChanged) + " was expected to be raised");
+            isSolutionOpenEventArg.Should().BeFalse();
         }
 
         [TestMethod]

--- a/src/Integration.UnitTests/MefServices/ActiveSolutionTrackerTests.cs
+++ b/src/Integration.UnitTests/MefServices/ActiveSolutionTrackerTests.cs
@@ -62,7 +62,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             int counter = 0;
             bool isSolutionOpenArg = false;
             var testSubject = new ActiveSolutionTracker(this.serviceProvider);
-            testSubject.ActiveSolutionChanged += (o, e) => { counter++; isSolutionOpenArg = e; };
+            testSubject.ActiveSolutionChanged += (o, e) => { counter++; isSolutionOpenArg = e.IsSolutionOpen; };
 
             // Act
             this.solutionMock.SimulateSolutionOpen();
@@ -79,7 +79,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             int counter = 0;
             bool isSolutionOpenEventArg = true;
             var testSubject = new ActiveSolutionTracker(this.serviceProvider);
-            testSubject.ActiveSolutionChanged += (o, e) => { counter++; isSolutionOpenEventArg = e; };
+            testSubject.ActiveSolutionChanged += (o, e) => { counter++; isSolutionOpenEventArg = e.IsSolutionOpen; };
 
             // Act
             this.solutionMock.SimulateSolutionClose();

--- a/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
@@ -266,7 +266,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.stepRunner.AbortAllNumberOfCalls.Should().Be(0);
 
             // Act
-            tracker.SimulateActiveSolutionChanged();
+            tracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
 
             // Assert
             this.stepRunner.AbortAllNumberOfCalls.Should().Be(1);
@@ -288,7 +288,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.stepRunner.AbortAllNumberOfCalls.Should().Be(0);
 
             // Act (simulate solution opened event)
-            tracker.SimulateActiveSolutionChanged();
+            tracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert that nothing has changed (should defer all the work to when the section is connected)
             this.stepRunner.AbortAllNumberOfCalls.Should().Be(1);
@@ -326,7 +326,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.stepRunner.AbortAllNumberOfCalls.Should().Be(0);
 
             // Act (simulate solution opened event)
-            tracker.SimulateActiveSolutionChanged();
+            tracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
 
             // Assert
             this.stepRunner.AbortAllNumberOfCalls.Should().Be(1);
@@ -357,7 +357,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             // Act (i.e. simulate loading a different solution)
             using (new AssertIgnoreScope()) // Ignore exception assert
             {
-                tracker.SimulateActiveSolutionChanged();
+                tracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
             }
 
             // Assert

--- a/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
@@ -80,7 +80,7 @@ namespace SonarLint.VisualStudio.Integration
             CurrentConfiguration = this.configurationProvider.GetConfiguration();
         }
 
-        private async void OnActiveSolutionChanged(object sender, bool isSolutionOpen)
+        private async void OnActiveSolutionChanged(object sender, ActiveSolutionTrackerEventArgs args)
         {
             // An exception here will crash VS
             try
@@ -90,7 +90,7 @@ namespace SonarLint.VisualStudio.Integration
                 this.RaiseAnalyzersChangedIfBindingChanged();
                 this.errorListInfoBarController.Refresh();
             }
-            catch(Exception ex) when (!Microsoft.VisualStudio.ErrorHandler.IsCriticalException(ex))
+            catch (Exception ex) when (!Microsoft.VisualStudio.ErrorHandler.IsCriticalException(ex))
             {
                 logger.WriteLine($"Error handling solution change: {ex.Message}");
             }

--- a/src/Integration/MefServices/ActiveSolutionTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionTracker.cs
@@ -38,7 +38,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// <see cref="IActiveSolutionTracker.ActiveSolutionChanged"/>
         /// </summary>
-        public event EventHandler<bool> ActiveSolutionChanged;
+        public event EventHandler<ActiveSolutionTrackerEventArgs> ActiveSolutionChanged;
 
         [ImportingConstructor]
         public ActiveSolutionTracker([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
@@ -50,7 +50,7 @@ namespace SonarLint.VisualStudio.Integration
 
         private void OnActiveSolutionChanged(bool isSolutionOpen)
         {
-            this.ActiveSolutionChanged?.Invoke(this, isSolutionOpen);
+            this.ActiveSolutionChanged?.Invoke(this, new ActiveSolutionTrackerEventArgs(isSolutionOpen));
         }
 
         #region IVsSolutionEvents

--- a/src/Integration/MefServices/ActiveSolutionTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionTracker.cs
@@ -38,7 +38,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// <see cref="IActiveSolutionTracker.ActiveSolutionChanged"/>
         /// </summary>
-        public event EventHandler ActiveSolutionChanged;
+        public event EventHandler<bool> ActiveSolutionChanged;
 
         [ImportingConstructor]
         public ActiveSolutionTracker([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
@@ -48,9 +48,9 @@ namespace SonarLint.VisualStudio.Integration
             ErrorHandler.ThrowOnFailure(this.solution.AdviseSolutionEvents(this, out this.cookie));
         }
 
-        private void OnActiveSolutionChanged()
+        private void OnActiveSolutionChanged(bool isSolutionOpen)
         {
-            this.ActiveSolutionChanged?.Invoke(this, EventArgs.Empty);
+            this.ActiveSolutionChanged?.Invoke(this, isSolutionOpen);
         }
 
         #region IVsSolutionEvents
@@ -88,7 +88,7 @@ namespace SonarLint.VisualStudio.Integration
         {
             // Note: if lightweight solution load is enabled then the solution might not
             // be fully opened at this point
-            this.OnActiveSolutionChanged();
+            this.OnActiveSolutionChanged(true);
             return VSConstants.S_OK;
         }
 
@@ -104,7 +104,7 @@ namespace SonarLint.VisualStudio.Integration
 
         int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
         {
-            this.OnActiveSolutionChanged();
+            this.OnActiveSolutionChanged(false);
 
             return VSConstants.S_OK;
         }

--- a/src/Integration/MefServices/ActiveSolutionTrackerEventArgs.cs
+++ b/src/Integration/MefServices/ActiveSolutionTrackerEventArgs.cs
@@ -22,13 +22,13 @@ using System;
 
 namespace SonarLint.VisualStudio.Integration
 {
-    internal interface IActiveSolutionTracker
+    public class ActiveSolutionTrackerEventArgs : EventArgs
     {
-        /// <summary>
-        /// The active solution has changed (either opened or closed).
-        /// </summary>
-        /// <remarks>The solution might not be fully loaded when this event is raised.
-        /// The event argument value will be true if a solution is open and false otherwise.</remarks>
-        event EventHandler<ActiveSolutionTrackerEventArgs> ActiveSolutionChanged;
+        public ActiveSolutionTrackerEventArgs(bool isSolutionOpen)
+        {
+            IsSolutionOpen = isSolutionOpen;
+        }
+
+        public bool IsSolutionOpen { get; }
     }
 }

--- a/src/Integration/MefServices/IActiveSolutionTracker.cs
+++ b/src/Integration/MefServices/IActiveSolutionTracker.cs
@@ -27,7 +27,8 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// The active solution has changed (either opened or closed).
         /// </summary>
-        /// <remarks>The solution might not be fully loaded when this event is raised.</remarks>
-        event EventHandler ActiveSolutionChanged;
+        /// <remarks>The solution might not be fully loaded when this event is raised.
+        /// The event argument value will be true if a solution is open and false otherwise.</remarks>
+        event EventHandler<bool> ActiveSolutionChanged;
     }
 }

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -58,7 +58,7 @@ namespace SonarLint.VisualStudio.Integration
         };
 
         private readonly IServiceProvider serviceProvider;
-        private readonly IActiveSolutionTracker solutionTacker;
+        private readonly IActiveSolutionTracker solutionTracker;
         private readonly IProgressStepRunnerWrapper progressStepRunner;
         private readonly Dictionary<Type, Lazy<ILocalService>> localServices = new Dictionary<Type, Lazy<ILocalService>>();
 
@@ -111,8 +111,8 @@ namespace SonarLint.VisualStudio.Integration
             this.progressStepRunner = progressStepRunner ?? this;
             this.UIDispatcher = uiDispatcher;
             this.SonarQubeService = sonarQubeService;
-            this.solutionTacker = solutionTacker;
-            this.solutionTacker.ActiveSolutionChanged += this.OnActiveSolutionChanged;
+            this.solutionTracker = solutionTacker;
+            this.solutionTracker.ActiveSolutionChanged += this.OnActiveSolutionChanged;
             this.Logger = logger;
 
             this.RegisterLocalServices();
@@ -207,7 +207,7 @@ namespace SonarLint.VisualStudio.Integration
         #endregion
 
         #region Active solution changed event handler
-        private void OnActiveSolutionChanged(object sender, EventArgs e)
+        private void OnActiveSolutionChanged(object sender, bool isSolutionOpen)
         {
             // Reset, and abort workflows
             this.ResetBinding(abortCurrentlyRunningWorklows: true);
@@ -352,7 +352,7 @@ namespace SonarLint.VisualStudio.Integration
             {
                 if (disposing)
                 {
-                    this.solutionTacker.ActiveSolutionChanged -= this.OnActiveSolutionChanged;
+                    this.solutionTracker.ActiveSolutionChanged -= this.OnActiveSolutionChanged;
 
                     this.localServices.Values
                         .Where(v => v.IsValueCreated)

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -207,7 +207,7 @@ namespace SonarLint.VisualStudio.Integration
         #endregion
 
         #region Active solution changed event handler
-        private void OnActiveSolutionChanged(object sender, bool isSolutionOpen)
+        private void OnActiveSolutionChanged(object sender, ActiveSolutionTrackerEventArgs args)
         {
             // Reset, and abort workflows
             this.ResetBinding(abortCurrentlyRunningWorklows: true);

--- a/src/TestInfrastructure/Framework/ConfigurableActiveSolutionTracker.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableActiveSolutionTracker.cs
@@ -24,13 +24,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     internal class ConfigurableActiveSolutionTracker : IActiveSolutionTracker
     {
-        public event EventHandler ActiveSolutionChanged;
+        public event EventHandler<bool> ActiveSolutionChanged;
 
         #region Test helpers
 
-        public void SimulateActiveSolutionChanged()
+        public void SimulateActiveSolutionChanged(bool isSolutionOpen)
         {
-            this.ActiveSolutionChanged?.Invoke(this, EventArgs.Empty);
+            this.ActiveSolutionChanged?.Invoke(this, isSolutionOpen);
         }
 
         #endregion Test helpers

--- a/src/TestInfrastructure/Framework/ConfigurableActiveSolutionTracker.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableActiveSolutionTracker.cs
@@ -24,13 +24,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     internal class ConfigurableActiveSolutionTracker : IActiveSolutionTracker
     {
-        public event EventHandler<bool> ActiveSolutionChanged;
+        public event EventHandler<ActiveSolutionTrackerEventArgs> ActiveSolutionChanged;
 
         #region Test helpers
 
         public void SimulateActiveSolutionChanged(bool isSolutionOpen)
         {
-            this.ActiveSolutionChanged?.Invoke(this, isSolutionOpen);
+            this.ActiveSolutionChanged?.Invoke(this, new ActiveSolutionTrackerEventArgs(isSolutionOpen));
         }
 
         #endregion Test helpers


### PR DESCRIPTION
Added a boolean event arg to indicate there is an open solution or not.

This change will be required by the changes to save the binding data in the .suo file (we'll be storing the binding state in memory so we'll need to know when a solution is closed to reset it. Currently we're relying on deleting files on disk which gives us a stateful way to accurately detect which mode a solution is in).