### PR TITLE
Changed in-memory config provider to record legacy mode

### DIFF
--- a/src/Integration.UnitTests/NewConnectedMode/InMemoryConfigurationProviderTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/InMemoryConfigurationProviderTests.cs
@@ -58,8 +58,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 read.Should().NotBeNull();
                 read.Project.Should().BeNull();
                 read.Mode.Should().Be(SonarLintMode.Standalone);
-            }
 
+                // 3. Write a different mode then read
+                var newConfig = BindingConfiguration.CreateBoundConfiguration(new BoundSonarQubeProject(), isLegacy: true);
+                testSubject.WriteConfiguration(newConfig);
+                read = testSubject.GetConfiguration();
+
+                // Assert
+                read.Should().NotBeNull();
+                read.Project.Should().NotBeNull();
+                read.Mode.Should().Be(SonarLintMode.LegacyConnected);
+            }
             finally
             {
                 InMemoryConfigurationProvider.Instance.WriteConfiguration(previous);


### PR DESCRIPTION
Previously the in-memory config would not be updated in legacy mode so it would think it was still in standalone mode.
This lead to misleading messages in the SonarLint output window.