### PR TITLE
Refactored binding workflow to extract NuGet code

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -314,10 +314,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var bindingArgs = new BindCommandArgs("projectKey", "projectName", new ConnectionInformation(new Uri("http://connected")));
 
             Mock<INuGetBindingOperation> nugetMock = new Mock<INuGetBindingOperation>();
-            nugetMock.Setup(x => x.InstallPackages(It.IsAny<IProgressController>(),
-                It.IsAny<CancellationToken>(),
+            nugetMock.Setup(x => x.InstallPackages(It.IsAny<ISet<Project>>(),
+                It.IsAny<IProgressController>(),
                 It.IsAny<IProgressStepExecutionEvents>(),
-                It.IsAny<ISet<Project>>())).Returns(true);
+                It.IsAny<CancellationToken>())).Returns(true);
 
             var testSubject = new BindingWorkflow(this.host, bindingArgs, nugetMock.Object);
 
@@ -331,7 +331,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             testSubject.BindingOperationSucceeded = false;
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents);
+            testSubject.InstallPackages(new ConfigurableProgressController(), progressEvents, cts.Token);
 
             // Assert
             testSubject.BindingOperationSucceeded.Should().BeTrue();
@@ -344,10 +344,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var bindingArgs = new BindCommandArgs("projectKey", "projectName", new ConnectionInformation(new Uri("http://connected")));
 
             Mock<INuGetBindingOperation> nugetMock = new Mock<INuGetBindingOperation>();
-            nugetMock.Setup(x => x.InstallPackages(It.IsAny<IProgressController>(),
-                It.IsAny<CancellationToken>(),
+            nugetMock.Setup(x => x.InstallPackages(It.IsAny<ISet<Project>>(),
+                It.IsAny<IProgressController>(),
                 It.IsAny<IProgressStepExecutionEvents>(),
-                It.IsAny<ISet<Project>>())).Returns(false);
+                It.IsAny<CancellationToken>())).Returns(false);
 
             var testSubject = new BindingWorkflow(this.host, bindingArgs, nugetMock.Object);
 
@@ -361,7 +361,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             testSubject.BindingOperationSucceeded = true;
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents);
+            testSubject.InstallPackages(new ConfigurableProgressController(), progressEvents, cts.Token);
 
             // Assert
             testSubject.BindingOperationSucceeded.Should().BeFalse();

--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -30,15 +30,14 @@ using EnvDTE;
 using FluentAssertions;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NuGet;
-using NuGet.VisualStudio;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Helpers;
 using SonarLint.VisualStudio.Integration.Resources;
+using SonarLint.VisualStudio.Progress.Controller;
 using SonarQube.Client.Messages;
 using SonarQube.Client.Models;
 using SonarQube.Client.Services;
@@ -94,7 +93,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Arrange
             const string QualityProfileName = "SQQualityProfileName";
             const string ProjectName = "SQProjectName";
-            BindingWorkflow testSubject = this.CreateTestSubject("key", ProjectName);
+
+            // Record all of the calls to NuGetBindingOperation.ProcessExport
+            var actualProfiles = new List<Tuple<Language, RoslynExportProfileResponse>>();
+            Mock<INuGetBindingOperation> nuGetOpMock = new Mock<INuGetBindingOperation>();
+            nuGetOpMock.Setup(x => x.ProcessExport(It.IsAny<Language>(), It.IsAny<RoslynExportProfileResponse>()))
+                .Callback<Language, RoslynExportProfileResponse>((l, r) => actualProfiles.Add(new Tuple<Language, RoslynExportProfileResponse>(l, r)))
+                .Returns(true);
+
+            BindingWorkflow testSubject = this.CreateTestSubject("key", ProjectName, nuGetOpMock.Object);
+
+
             ConfigurableProgressController controller = new ConfigurableProgressController();
             var notifications = new ConfigurableProgressStepExecutionEvents();
 
@@ -117,7 +126,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Assert
             RuleSetAssert.AreEqual(expectedRuleSet, testSubject.Rulesets[language], "Unexpected rule set");
             testSubject.QualityProfiles[language].Should().Be(profile);
-            VerifyNuGetPackgesDownloaded(nugetPackages, testSubject, language);
+            VerifyNuGetPackgesDownloaded(nugetPackages, language, actualProfiles);
+
             controller.NumberOfAbortRequests.Should().Be(0);
             notifications.AssertProgress(0.0, 1.0);
             notifications.AssertProgressMessages(Strings.DownloadingQualityProfileProgressMessage, string.Empty);
@@ -298,184 +308,63 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void BindingWorkflow_InstallPackages_WhenAllProjectsAreCSharp_Succeed()
-        {
-            BindingWorkflow_InstallPackages_Succeed(ProjectSystemHelper.CSharpProjectKind, Language.CSharp);
-        }
-
-        [TestMethod]
-        public void BindingWorkflow_InstallPackages_WhenAllProjectsAreVbNet_Succeed()
-        {
-            BindingWorkflow_InstallPackages_Succeed(ProjectSystemHelper.VbProjectKind, Language.VBNET);
-        }
-
-        private void BindingWorkflow_InstallPackages_Succeed(string projectKind, Language language)
+        public void BindingWorkflow_InstallPackages_Succeeds_SuccessPropertyIsTrue()
         {
             // Arrange
-            var testSubject = this.CreateTestSubject();
-            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+            var bindingArgs = new BindCommandArgs("projectKey", "projectName", new ConnectionInformation(new Uri("http://connected")));
 
-            ProjectMock project1 = new ProjectMock("project1") { ProjectKind = projectKind };
-            ProjectMock project2 = new ProjectMock("project2") { ProjectKind = projectKind };
+            Mock<INuGetBindingOperation> nugetMock = new Mock<INuGetBindingOperation>();
+            nugetMock.Setup(x => x.InstallPackages(It.IsAny<IProgressController>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IProgressStepExecutionEvents>(),
+                It.IsAny<ISet<Project>>())).Returns(true);
 
-            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
-            var packages = new Dictionary<Language, IEnumerable<PackageName>>();
-            packages.Add(language, new[] { nugetPackage });
-
-            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, packages, project1, project2);
-
-            // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents);
-
-            // Assert
-            packageInstaller.AssertInstalledPackages(project1, new[] { nugetPackage });
-            packageInstaller.AssertInstalledPackages(project2, new[] { nugetPackage });
-            this.outputWindowPane.AssertOutputStrings(4);
-            this.outputWindowPane.AssertOutputStrings(
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, ((Project)project1).Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, ((Project)project1).Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, ((Project)project2).Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, ((Project)project2).Name))
-                );
-            progressEvents.AssertProgress(.5, 1.0);
-        }
-
-        [TestMethod]
-        public void BindingWorkflow_InstallPackages_MoreNugetPackagesThanLanguageCount()
-        {
-            // Arrange
-            var testSubject = this.CreateTestSubject();
-            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+            var testSubject = new BindingWorkflow(this.host, bindingArgs, nugetMock.Object);
 
             ProjectMock project1 = new ProjectMock("project1") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            testSubject.BindingProjects.Clear();
+            testSubject.BindingProjects.Add(project1);
 
-            var nugetPackage1 = new PackageName("mypackage1", new SemanticVersion("1.1.0"));
-            var nugetPackage2 = new PackageName("mypackage2", new SemanticVersion("1.1.1"));
-            var nugetPackages = new[] { nugetPackage1, nugetPackage2 };
-            var packages = new Dictionary<Language, IEnumerable<PackageName>>();
-            packages.Add(Language.CSharp, nugetPackages);
-
-            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, packages, project1);
-
-            // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents);
-
-            // Assert
-            packageInstaller.AssertInstalledPackages(project1, nugetPackages);
-            this.outputWindowPane.AssertOutputStrings(4);
-            this.outputWindowPane.AssertOutputStrings(
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackages[0].Id, ((Project)project1).Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackages[0].Id, ((Project)project1).Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackages[1].Id, ((Project)project1).Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackages[1].Id, ((Project)project1).Name))
-                );
-            progressEvents.AssertProgress(.5, 1.0);
-        }
-
-        [TestMethod]
-        public void BindingWorkflow_InstallPackages_Cancellation()
-        {
-            // Arrange
-            var testSubject = this.CreateTestSubject();
             var progressEvents = new ConfigurableProgressStepExecutionEvents();
             var cts = new CancellationTokenSource();
 
-            ProjectMock project1 = new ProjectMock("project1") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
-            ProjectMock project2 = new ProjectMock("project2") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
-
-            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
-            var packages = new[] { nugetPackage };
-            var nugetPackagesByLanguage = new Dictionary<Language, IEnumerable<PackageName>>();
-            nugetPackagesByLanguage.Add(Language.CSharp, packages);
-
-            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackagesByLanguage, project1, project2);
-            packageInstaller.InstallPackageAction = (p) =>
-            {
-                cts.Cancel(); // Cancel the next one (should complete the first one)
-            };
+            testSubject.BindingOperationSucceeded = false;
 
             // Act
             testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents);
 
             // Assert
-            packageInstaller.AssertInstalledPackages(project1, packages);
-            packageInstaller.AssertNoInstalledPackages(project2);
+            testSubject.BindingOperationSucceeded.Should().BeTrue();
         }
 
         [TestMethod]
-        public void BindingWorkflow_InstallPackages_FailureOnOneProject_Continues()
+        public void BindingWorkflow_InstallPackages_Succeeds_SuccessPropertyIsFalse()
         {
             // Arrange
-            const string failureMessage = "Failure for project1";
-            const string project1Name = "project1";
-            const string project2Name = "project2";
+            var bindingArgs = new BindCommandArgs("projectKey", "projectName", new ConnectionInformation(new Uri("http://connected")));
 
-            var testSubject = this.CreateTestSubject();
+            Mock<INuGetBindingOperation> nugetMock = new Mock<INuGetBindingOperation>();
+            nugetMock.Setup(x => x.InstallPackages(It.IsAny<IProgressController>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IProgressStepExecutionEvents>(),
+                It.IsAny<ISet<Project>>())).Returns(false);
+
+            var testSubject = new BindingWorkflow(this.host, bindingArgs, nugetMock.Object);
+
+            ProjectMock project1 = new ProjectMock("project1") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            testSubject.BindingProjects.Clear();
+            testSubject.BindingProjects.Add(project1);
+
             var progressEvents = new ConfigurableProgressStepExecutionEvents();
             var cts = new CancellationTokenSource();
 
-            ProjectMock project1 = new ProjectMock(project1Name) { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
-            ProjectMock project2 = new ProjectMock(project2Name) { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
-
-            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
-            var packages = new[] { nugetPackage };
-            var nugetPackages = new Dictionary<Language, IEnumerable<PackageName>>();
-            nugetPackages.Add(Language.CSharp, packages);
-
-            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackages, project1, project2);
-            packageInstaller.InstallPackageAction = (p) =>
-            {
-                packageInstaller.InstallPackageAction = null;
-                throw new Exception(failureMessage);
-            };
+            testSubject.BindingOperationSucceeded = true;
 
             // Act
             testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents);
 
             // Assert
-            packageInstaller.AssertNoInstalledPackages(project1);
-            packageInstaller.AssertInstalledPackages(project2, packages);
-            this.outputWindowPane.AssertOutputStrings(4);
-            this.outputWindowPane.AssertOutputStrings(
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, project1Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.FailedDuringNuGetPackageInstall, nugetPackage.Id, project1Name, failureMessage)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, project2Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, project2Name))
-                );
-        }
-
-        [TestMethod]
-        public void BindingWorkflow_InstallPackages_WhenProjectLanguageDoesNotExist_PrintMessageAndContinue()
-        {
-            // Arrange
-            const string project1Name = "project1";
-            const string project2Name = "project2";
-
-            var testSubject = this.CreateTestSubject();
-            var progressEvents = new ConfigurableProgressStepExecutionEvents();
-
-            ProjectMock project1 = new ProjectMock(project1Name); // No project kind so no nuget package will be installed
-            ProjectMock project2 = new ProjectMock(project2Name) { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
-
-            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
-            var packages = new[] { nugetPackage };
-            var nugetPackages = new Dictionary<Language, IEnumerable<PackageName>>();
-            nugetPackages.Add(Language.CSharp, packages);
-
-            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackages, project1, project2);
-
-            // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents);
-
-            // Assert
-            packageInstaller.AssertNoInstalledPackages(project1);
-            packageInstaller.AssertInstalledPackages(project2, packages);
-            this.outputWindowPane.AssertOutputStrings(3);
-            this.outputWindowPane.AssertOutputStrings(
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.BindingProjectLanguageNotMatchingAnyQualityProfileLanguage, project1Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, project2Name)),
-                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, project2Name))
-                );
+            testSubject.BindingOperationSucceeded.Should().BeFalse();
         }
 
         [TestMethod]
@@ -485,12 +374,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = this.CreateTestSubject();
 
             // Test case 1: Default state is 'true'
-            testSubject.AllNuGetPackagesInstalled.Should().BeTrue($"Initial state of {nameof(BindingWorkflow.AllNuGetPackagesInstalled)} should be true");
+            testSubject.BindingOperationSucceeded.Should().BeTrue($"Initial state of {nameof(BindingWorkflow.BindingOperationSucceeded)} should be true");
 
             // Test case 2: All packages installed
             // Arrange
             var notificationsOk = new ConfigurableProgressStepExecutionEvents();
-            testSubject.AllNuGetPackagesInstalled = true;
+            testSubject.BindingOperationSucceeded = true;
 
             // Act
             testSubject.EmitBindingCompleteMessage(notificationsOk);
@@ -501,7 +390,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Test case 3: Not all packages installed
             // Arrange
             var notificationsFail = new ConfigurableProgressStepExecutionEvents();
-            testSubject.AllNuGetPackagesInstalled = false;
+            testSubject.BindingOperationSucceeded = false;
 
             // Act
             testSubject.EmitBindingCompleteMessage(notificationsFail);
@@ -760,31 +649,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Helpers
 
-        private BindingWorkflow CreateTestSubject(string projectKey = "anykey", string projectName = "anyname")
+        private BindingWorkflow CreateTestSubject(string projectKey = "anykey", string projectName = "anyname", 
+            INuGetBindingOperation nuGetBindingOperation = null)
         {
             this.host.SonarQubeService = this.sonarQubeServiceMock.Object;
 
             var bindingArgs = new BindCommandArgs(projectKey, projectName, new ConnectionInformation(new Uri("http://connected")));
 
-            return new BindingWorkflow(this.host, bindingArgs);
-        }
-
-        private ConfigurablePackageInstaller PrepareInstallPackagesTest(BindingWorkflow testSubject, Dictionary<Language, IEnumerable<PackageName>> nugetPackagesByLanguage, params Project[] projects)
-        {
-            testSubject.BindingProjects.Clear();
-            testSubject.BindingProjects.AddRange(projects);
-
-            foreach (var nugetPackagesForLanguage in nugetPackagesByLanguage)
+            if (nuGetBindingOperation == null)
             {
-                testSubject.NuGetPackages.Add(nugetPackagesForLanguage.Key,
-                    nugetPackagesForLanguage.Value.Select(x => new NuGetPackageInfoResponse { Id = x.Id, Version = x.Version.ToNormalizedString() }).ToList());
+                return new BindingWorkflow(this.host, bindingArgs);
             }
-
-            ConfigurablePackageInstaller packageInstaller = new ConfigurablePackageInstaller(nugetPackagesByLanguage.Values.SelectMany(x => x));
-            this.serviceProvider.RegisterService(typeof(SComponentModel),
-                ConfigurableComponentModel.CreateWithExports(MefTestHelpers.CreateExport<IVsPackageInstaller>(packageInstaller)));
-
-            return packageInstaller;
+            return new BindingWorkflow(this.host, bindingArgs, nuGetBindingOperation);
         }
 
         private SonarQubeQualityProfile ConfigureProfileExport(RoslynExportProfileResponse export, Language language, string profileName)
@@ -800,16 +676,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return profile;
         }
 
-        private static void VerifyNuGetPackgesDownloaded(IEnumerable<PackageName> expectedPackages, BindingWorkflow testSubject, Language language)
+        private static void VerifyNuGetPackgesDownloaded(IEnumerable<PackageName> expectedPackages,
+            Language language,
+            IList<Tuple<Language, RoslynExportProfileResponse>> actualProfiles)
         {
-            var expected = expectedPackages.ToArray();
+            actualProfiles.All(p => p.Item1 == language).Should().BeTrue();
 
-            testSubject.NuGetPackages.Should().ContainKey(language);
+            var actualPackages = actualProfiles.SelectMany(p => p.Item2?.Deployment?.NuGetPackages.Select(
+                ngp => new PackageName(ngp.Id, new SemanticVersion(ngp.Version))));
 
-            var actual = testSubject.NuGetPackages[language].Select(x => new PackageName(x.Id, new SemanticVersion(x.Version))).ToArray();
-
-            actual.Should().HaveSameCount(expected, "Different number of packages.");
-            actual.Select(x => x.ToString()).Should().Equal(expected.Select(x => x.ToString()));
+            actualPackages.Should().BeEquivalentTo(expectedPackages);
+            actualPackages.Should().HaveSameCount(expectedPackages, "Different number of packages.");
+            actualPackages.Select(x => x.ToString()).Should().Equal(expectedPackages.Select(x => x.ToString()));
         }
 
         #endregion Helpers

--- a/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
@@ -1,0 +1,270 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using EnvDTE;
+using FluentAssertions;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet;
+using NuGet.VisualStudio;
+using SonarLint.VisualStudio.Integration.Binding;
+using SonarLint.VisualStudio.Integration.Resources;
+using SonarQube.Client.Messages;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class NuGetBindingOperationTests
+    {
+        private ConfigurableServiceProvider serviceProvider;
+        private TestLogger logger;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            serviceProvider = new ConfigurableServiceProvider();
+            logger = new TestLogger();
+        }
+
+        #region Tests
+
+        [TestMethod]
+        public void InstallPackages_WhenAllProjectsAreCSharp_Succeed()
+        {
+            InstallPackages_Succeed(ProjectSystemHelper.CSharpProjectKind, Language.CSharp);
+        }
+
+        [TestMethod]
+        public void InstallPackages_WhenAllProjectsAreVbNet_Succeed()
+        {
+            InstallPackages_Succeed(ProjectSystemHelper.VbProjectKind, Language.VBNET);
+        }
+
+        private void InstallPackages_Succeed(string projectKind, Language language)
+        {
+            // Arrange
+            var testSubject = this.CreateTestSubject();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            ProjectMock project1 = new ProjectMock("project1") { ProjectKind = projectKind };
+            ProjectMock project2 = new ProjectMock("project2") { ProjectKind = projectKind };
+            var projectsToBind = new HashSet<Project> { project1, project2 };
+
+            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
+            var packages = new Dictionary<Language, IEnumerable<PackageName>>();
+            packages.Add(language, new[] { nugetPackage });
+
+            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, packages);
+
+            // Act
+            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents, projectsToBind);
+
+            // Assert
+            packageInstaller.AssertInstalledPackages(project1, new[] { nugetPackage });
+            packageInstaller.AssertInstalledPackages(project2, new[] { nugetPackage });
+            this.logger.AssertOutputStrings(4);
+            this.logger.AssertOutputStrings(
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, ((Project)project1).Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, ((Project)project1).Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, ((Project)project2).Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, ((Project)project2).Name))
+                );
+            progressEvents.AssertProgress(.5, 1.0);
+        }
+
+        [TestMethod]
+        public void InstallPackages_MoreNugetPackagesThanLanguageCount()
+        {
+            // Arrange
+            var testSubject = this.CreateTestSubject();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            var project1 = new ProjectMock("project1") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            var projectsToBind = new HashSet<Project> { project1 };
+
+            var nugetPackage1 = new PackageName("mypackage1", new SemanticVersion("1.1.0"));
+            var nugetPackage2 = new PackageName("mypackage2", new SemanticVersion("1.1.1"));
+            var nugetPackages = new[] { nugetPackage1, nugetPackage2 };
+            var packages = new Dictionary<Language, IEnumerable<PackageName>>();
+            packages.Add(Language.CSharp, nugetPackages);
+
+            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, packages);
+
+            // Act
+            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents, projectsToBind);
+
+            // Assert
+            packageInstaller.AssertInstalledPackages(project1, nugetPackages);
+            this.logger.AssertOutputStrings(4);
+            this.logger.AssertOutputStrings(
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackages[0].Id, ((Project)project1).Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackages[0].Id, ((Project)project1).Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackages[1].Id, ((Project)project1).Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackages[1].Id, ((Project)project1).Name))
+                );
+            progressEvents.AssertProgress(.5, 1.0);
+        }
+
+        [TestMethod]
+        public void InstallPackages_Cancellation()
+        {
+            // Arrange
+            var testSubject = this.CreateTestSubject();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+            var cts = new CancellationTokenSource();
+
+            var project1 = new ProjectMock("project1") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            var project2 = new ProjectMock("project2") { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            var projectsToBind = new HashSet<Project> { project1, project2 };
+
+            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
+            var packages = new[] { nugetPackage };
+            var nugetPackagesByLanguage = new Dictionary<Language, IEnumerable<PackageName>>();
+            nugetPackagesByLanguage.Add(Language.CSharp, packages);
+
+            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackagesByLanguage);
+            packageInstaller.InstallPackageAction = (p) =>
+            {
+                cts.Cancel(); // Cancel the next one (should complete the first one)
+            };
+
+            // Act
+            testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents, projectsToBind);
+
+            // Assert
+            packageInstaller.AssertInstalledPackages(project1, packages);
+            packageInstaller.AssertNoInstalledPackages(project2);
+        }
+
+        [TestMethod]
+        public void InstallPackages_FailureOnOneProject_Continues()
+        {
+            // Arrange
+            const string failureMessage = "Failure for project1";
+            const string project1Name = "project1";
+            const string project2Name = "project2";
+
+            var testSubject = this.CreateTestSubject();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+            var cts = new CancellationTokenSource();
+
+            ProjectMock project1 = new ProjectMock(project1Name) { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            ProjectMock project2 = new ProjectMock(project2Name) { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            var projectsToBind = new HashSet<Project> { project1, project2 };
+
+            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
+            var packages = new[] { nugetPackage };
+            var nugetPackages = new Dictionary<Language, IEnumerable<PackageName>>();
+            nugetPackages.Add(Language.CSharp, packages);
+
+            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackages);
+            packageInstaller.InstallPackageAction = (p) =>
+            {
+                packageInstaller.InstallPackageAction = null;
+                throw new Exception(failureMessage);
+            };
+
+            // Act
+            testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents, projectsToBind);
+
+            // Assert
+            packageInstaller.AssertNoInstalledPackages(project1);
+            packageInstaller.AssertInstalledPackages(project2, packages);
+            this.logger.AssertOutputStrings(4);
+            this.logger.AssertOutputStrings(
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, project1Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.FailedDuringNuGetPackageInstall, nugetPackage.Id, project1Name, failureMessage)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, project2Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, project2Name))
+                );
+        }
+
+        [TestMethod]
+        public void InstallPackages_WhenProjectLanguageDoesNotExist_PrintMessageAndContinue()
+        {
+            // Arrange
+            const string project1Name = "project1";
+            const string project2Name = "project2";
+
+            var testSubject = this.CreateTestSubject();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            ProjectMock project1 = new ProjectMock(project1Name); // No project kind so no nuget package will be installed
+            ProjectMock project2 = new ProjectMock(project2Name) { ProjectKind = ProjectSystemHelper.CSharpProjectKind };
+            var projectsToBind = new HashSet<Project> { project1, project2 };
+
+            var nugetPackage = new PackageName("mypackage", new SemanticVersion("1.1.0"));
+            var packages = new[] { nugetPackage };
+            var nugetPackages = new Dictionary<Language, IEnumerable<PackageName>>();
+            nugetPackages.Add(Language.CSharp, packages);
+
+            ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackages);
+
+            // Act
+            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents, projectsToBind);
+
+            // Assert
+            packageInstaller.AssertNoInstalledPackages(project1);
+            packageInstaller.AssertInstalledPackages(project2, packages);
+            this.logger.AssertOutputStrings(3);
+            this.logger.AssertOutputStrings(
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.BindingProjectLanguageNotMatchingAnyQualityProfileLanguage, project1Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.EnsuringNugetPackagesProgressMessage, nugetPackage.Id, project2Name)),
+                string.Format(Strings.SubTextPaddingFormat, string.Format(Strings.SuccessfullyInstalledNugetPackageForProject, nugetPackage.Id, project2Name))
+                );
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private NuGetBindingOperation CreateTestSubject()
+        {
+            var testSubject = new NuGetBindingOperation(this.serviceProvider, this.logger);
+            return testSubject;
+        }
+
+        private ConfigurablePackageInstaller PrepareInstallPackagesTest(NuGetBindingOperation testSubject, Dictionary<Language, IEnumerable<PackageName>> nugetPackagesByLanguage)
+        {
+            var exportResponse = new RoslynExportProfileResponse();
+            exportResponse.Deployment = new DeploymentResponse();
+            exportResponse.Deployment.NuGetPackages = new List<NuGetPackageInfoResponse>();
+
+            foreach (var nugetPackagesForLanguage in nugetPackagesByLanguage)
+            {
+                testSubject.NuGetPackages.Add(nugetPackagesForLanguage.Key,
+                    nugetPackagesForLanguage.Value.Select(x => new NuGetPackageInfoResponse { Id = x.Id, Version = x.Version.ToNormalizedString() }).ToList());
+            }
+
+
+            ConfigurablePackageInstaller packageInstaller = new ConfigurablePackageInstaller(nugetPackagesByLanguage.Values.SelectMany(x => x));
+            this.serviceProvider.RegisterService(typeof(SComponentModel),
+                ConfigurableComponentModel.CreateWithExports(MefTestHelpers.CreateExport<IVsPackageInstaller>(packageInstaller)));
+
+            return packageInstaller;
+        }
+
+        #endregion
+    }
+}

--- a/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
@@ -78,7 +78,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, packages);
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents, projectsToBind);
+            testSubject.InstallPackages(projectsToBind, new ConfigurableProgressController(), progressEvents, CancellationToken.None);
 
             // Assert
             packageInstaller.AssertInstalledPackages(project1, new[] { nugetPackage });
@@ -112,7 +112,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, packages);
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents, projectsToBind);
+            testSubject.InstallPackages(projectsToBind, new ConfigurableProgressController(), progressEvents, CancellationToken.None);
 
             // Assert
             packageInstaller.AssertInstalledPackages(project1, nugetPackages);
@@ -150,7 +150,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             };
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents, projectsToBind);
+            testSubject.InstallPackages(projectsToBind, new ConfigurableProgressController(), progressEvents, cts.Token);
 
             // Assert
             packageInstaller.AssertInstalledPackages(project1, packages);
@@ -186,7 +186,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             };
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), cts.Token, progressEvents, projectsToBind);
+            testSubject.InstallPackages(projectsToBind, new ConfigurableProgressController(), progressEvents, cts.Token);
 
             // Assert
             packageInstaller.AssertNoInstalledPackages(project1);
@@ -222,7 +222,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigurablePackageInstaller packageInstaller = this.PrepareInstallPackagesTest(testSubject, nugetPackages);
 
             // Act
-            testSubject.InstallPackages(new ConfigurableProgressController(), CancellationToken.None, progressEvents, projectsToBind);
+            testSubject.InstallPackages(projectsToBind, new ConfigurableProgressController(), progressEvents, CancellationToken.None);
 
             // Assert
             packageInstaller.AssertNoInstalledPackages(project1);

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -174,7 +174,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
                 // Install the appropriate package for each project
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
-                        (token, notifications) => this.InstallPackages(controller, token, notifications)),
+                        (token, notifications) => this.InstallPackages(controller, notifications, token)),
 
                 //*****************************************************************
                 // Solution update phase
@@ -360,9 +360,9 @@ namespace SonarLint.VisualStudio.Integration.Binding
             this.nugetBindingOperation.PrepareOnUIThread();
         }
 
-        internal /*for testing purposes*/ void InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents)
+        internal /*for testing purposes*/ void InstallPackages(IProgressController controller, IProgressStepExecutionEvents notificationEvents, CancellationToken token)
         {
-            this.BindingOperationSucceeded = this.nugetBindingOperation.InstallPackages(controller, token, notificationEvents, this.BindingProjects);
+            this.BindingOperationSucceeded = this.nugetBindingOperation.InstallPackages(this.BindingProjects, controller, notificationEvents, token);
         }
 
         internal /*for testing purposes*/ void SilentSaveSolutionIfDirty()

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -33,7 +32,6 @@ using SonarLint.VisualStudio.Integration.Helpers;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarLint.VisualStudio.Progress.Controller;
-using SonarQube.Client.Messages;
 using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.Binding
@@ -51,8 +49,16 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly BindCommandArgs bindingArgs;
         private readonly IProjectSystemHelper projectSystem;
         private readonly SolutionBindingOperation solutionBindingOperation;
+        private readonly INuGetBindingOperation nugetBindingOperation;
 
         public BindingWorkflow(IHost host, BindCommandArgs bindingArgs)
+            : this(host, bindingArgs, new NuGetBindingOperation(host, host?.Logger))
+        {
+        }
+
+        internal /* for testing */ BindingWorkflow(IHost host,
+            BindCommandArgs bindingArgs,
+            INuGetBindingOperation nugetBindingOperation)
         {
             if (host == null)
             {
@@ -76,6 +82,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     this.host,
                     this.bindingArgs.Connection,
                     this.bindingArgs.ProjectKey);
+            this.nugetBindingOperation = nugetBindingOperation;
         }
 
         #region Workflow state
@@ -90,11 +97,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
             get;
         } = new Dictionary<Language, RuleSet>();
 
-        public Dictionary<Language, List<NuGetPackageInfoResponse>> NuGetPackages
-        {
-            get;
-        } = new Dictionary<Language, List<NuGetPackageInfoResponse>>();
-
         public Dictionary<Language, string> SolutionRulesetPaths
         {
             get;
@@ -105,7 +107,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             get;
         } = new Dictionary<Language, SonarQubeQualityProfile>();
 
-        internal /*for testing purposes*/ bool AllNuGetPackagesInstalled
+        internal /*for testing purposes*/ bool BindingOperationSucceeded
         {
             get;
             set;
@@ -168,7 +170,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 //*****************************************************************
                 // Initialize the VS NuGet installer service
                 new ProgressStepDefinition(null, HiddenIndeterminateNonImpactingNonCancellableUIStep,
-                        (token, notifications) => { NuGetHelper.LoadService(this.host); /*The service needs to be loaded on UI thread*/ }),
+                        (token, notifications) => { this.PrepareToInstallPackages(); }),
 
                 // Install the appropriate package for each project
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
@@ -293,16 +295,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     return;
                 }
 
-                //### NUGET
-                if (roslynProfileExporter.Deployment.NuGetPackages.Count == 0)
+                if (!this.nugetBindingOperation.ProcessExport(language, roslynProfileExporter))
                 {
-                    this.host.Logger.WriteLine(string.Format(Strings.SubTextPaddingFormat,
-                        string.Format(Strings.NoNuGetPackageForQualityProfile, language.Name)));
                     this.AbortWorkflow(controller, cancellationToken);
                     return;
                 }
-
-                this.NuGetPackages.Add(language, roslynProfileExporter.Deployment.NuGetPackages);
 
                 // Remove/Move/Refactor code when XML ruleset file is no longer downloaded but the proper API is used to retrieve rules
                 UpdateDownloadedSonarQubeQualityProfile(ruleSet, qualityProfileInfo);
@@ -358,67 +355,14 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
         }
 
-        /// <summary>
-        /// Will install the NuGet packages for the current managed projects.
-        /// The packages that will be installed will be based on the information from <see cref="Analyzer.GetRequiredNuGetPackages"/>
-        /// and is specific to the <see cref="RuleSet"/>.
-        /// </summary>
+        internal /*for testing purposes*/ void PrepareToInstallPackages()
+        {
+            this.nugetBindingOperation.PrepareOnUIThread();
+        }
+
         internal /*for testing purposes*/ void InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents)
         {
-            if (!this.NuGetPackages.Any())
-            {
-                return;
-            }
-
-            Debug.Assert(this.NuGetPackages.Count == this.NuGetPackages.Distinct().Count(), "Duplicate NuGet packages specified");
-
-            if (!this.BindingProjects.Any())
-            {
-                Debug.Fail("Not expected to be called when there are no projects");
-                return;
-            }
-
-            var projectNugets = this.BindingProjects
-                .SelectMany(bindingProject =>
-                {
-                    var projectLanguage = Language.ForProject(bindingProject);
-
-                    List<NuGetPackageInfoResponse> nugetPackages;
-                    if (!this.NuGetPackages.TryGetValue(projectLanguage, out nugetPackages))
-                    {
-                        var message = string.Format(Strings.BindingProjectLanguageNotMatchingAnyQualityProfileLanguage, bindingProject.Name);
-                        this.host.Logger.WriteLine(Strings.SubTextPaddingFormat, message);
-                        nugetPackages = new List<NuGetPackageInfoResponse>();
-                    }
-
-                    return nugetPackages.Select(nugetPackage => new { Project = bindingProject, NugetPackage = nugetPackage });
-                })
-                .ToArray();
-
-            DeterminateStepProgressNotifier progressNotifier = new DeterminateStepProgressNotifier(notificationEvents, projectNugets.Length);
-            foreach (var projectNuget in projectNugets)
-            {
-                if (token.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                string message = string.Format(CultureInfo.CurrentCulture, Strings.EnsuringNugetPackagesProgressMessage, projectNuget.NugetPackage.Id, projectNuget.Project.Name);
-                this.host.Logger.WriteLine(Strings.SubTextPaddingFormat, message);
-
-                var isNugetInstallSuccessful = NuGetHelper.TryInstallPackage(this.host, projectNuget.Project, projectNuget.NugetPackage.Id, projectNuget.NugetPackage.Version);
-
-                if (isNugetInstallSuccessful) // NuGetHelper.TryInstallPackage already displayed the error message so only take care of the success message
-                {
-                    message = string.Format(CultureInfo.CurrentCulture, Strings.SuccessfullyInstalledNugetPackageForProject, projectNuget.NugetPackage.Id, projectNuget.Project.Name);
-                    this.host.Logger.WriteLine(Strings.SubTextPaddingFormat, message);
-                }
-
-                // TODO: SVS-33 (https://jira.sonarsource.com/browse/SVS-33) Trigger a Team Explorer warning notification to investigate the partial binding in the output window.
-                this.AllNuGetPackagesInstalled &= isNugetInstallSuccessful;
-
-                progressNotifier.NotifyIncrementedProgress(string.Empty);
-            }
+            this.BindingOperationSucceeded = this.nugetBindingOperation.InstallPackages(controller, token, notificationEvents, this.BindingProjects);
         }
 
         internal /*for testing purposes*/ void SilentSaveSolutionIfDirty()
@@ -429,7 +373,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         internal /*for testing purposes*/ void EmitBindingCompleteMessage(IProgressStepExecutionEvents notifications)
         {
-            var message = this.AllNuGetPackagesInstalled
+            var message = this.BindingOperationSucceeded
                 ? Strings.FinishedSolutionBindingWorkflowSuccessful
                 : Strings.FinishedSolutionBindingWorkflowNotAllPackagesInstalled;
             notifications.ProgressChanged(message);

--- a/src/Integration/Binding/INuGetBindingOperation.cs
+++ b/src/Integration/Binding/INuGetBindingOperation.cs
@@ -36,7 +36,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <summary>
         /// Returns true if the operation completed succcessfully, otherwise false
         /// </summary>
-        bool InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents, ISet<Project> projectsToBind);
+        bool InstallPackages(ISet<Project> projectsToBind, IProgressController controller, IProgressStepExecutionEvents notificationEvents, CancellationToken token);
 
         /// <summary>
         /// Extracts any required information from the supplied Roslyn export profile

--- a/src/Integration/Binding/INuGetBindingOperation.cs
+++ b/src/Integration/Binding/INuGetBindingOperation.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Threading;
+using EnvDTE;
+using SonarLint.VisualStudio.Progress.Controller;
+using SonarQube.Client.Messages;
+
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    /// <summary>
+    /// Encapsulate the workflow steps to install NuGet packages during binding
+    /// </summary>
+    public interface INuGetBindingOperation
+    {
+        void PrepareOnUIThread();
+
+        /// <summary>
+        /// Returns true if the operation completed succcessfully, otherwise false
+        /// </summary>
+        bool InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents, ISet<Project> projectsToBind);
+
+        /// <summary>
+        /// Extracts any required information from the supplied Roslyn export profile
+        /// </summary>
+        /// <returns>True if processing was successful, otherwise false</returns>
+        bool ProcessExport(Language language, RoslynExportProfileResponse exportProfileResponse);
+    }
+}

--- a/src/Integration/Binding/NuGetBindingOperation.cs
+++ b/src/Integration/Binding/NuGetBindingOperation.cs
@@ -34,7 +34,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
 {
     internal class NuGetBindingOperation : INuGetBindingOperation
     {
-
         private readonly ILogger logger;
         private readonly IServiceProvider serviceProvider;
 
@@ -71,16 +70,16 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// The packages that will be installed will be based on the information from <see cref="Analyzer.GetRequiredNuGetPackages"/>
         /// and is specific to the <see cref="RuleSet"/>.
         /// </summary>
-        public bool InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents, ISet<Project> projectsToBind)
+        public bool InstallPackages(ISet<Project> projectsToBind, IProgressController controller, IProgressStepExecutionEvents notificationEvents, CancellationToken token)
         {
-            if (!this.NuGetPackages.Any())
+            if (this.NuGetPackages.Count == 0)
             {
                 return true;
             }
 
             Debug.Assert(this.NuGetPackages.Count == this.NuGetPackages.Distinct().Count(), "Duplicate NuGet packages specified");
 
-            if (projectsToBind == null || !projectsToBind.Any())
+            if (projectsToBind == null || projectsToBind.Count == 0)
             {
                 Debug.Fail("Not expected to be called when there are no projects");
                 return true;

--- a/src/Integration/Binding/NuGetBindingOperation.cs
+++ b/src/Integration/Binding/NuGetBindingOperation.cs
@@ -1,0 +1,148 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Integration.Resources;
+using SonarLint.VisualStudio.Progress.Controller;
+using SonarQube.Client.Messages;
+
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    internal class NuGetBindingOperation : INuGetBindingOperation
+    {
+
+        private readonly ILogger logger;
+        private readonly IServiceProvider serviceProvider;
+
+        public NuGetBindingOperation(IServiceProvider serviceProvider, ILogger logger)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            this.serviceProvider = serviceProvider;
+            this.logger = logger;
+        }
+
+        internal /*for testing*/ Dictionary<Language, List<NuGetPackageInfoResponse>> NuGetPackages
+        {
+            get;
+        } = new Dictionary<Language, List<NuGetPackageInfoResponse>>();
+
+
+        public void PrepareOnUIThread()
+        {
+            Debug.Assert(ThreadHelper.CheckAccess(), "Expected step to be run on the UI thread");
+            NuGetHelper.LoadService(this.serviceProvider); /*The service needs to be loaded on UI thread*/
+        }
+
+        /// <summary>
+        /// Will install the NuGet packages for the current managed projects.
+        /// The packages that will be installed will be based on the information from <see cref="Analyzer.GetRequiredNuGetPackages"/>
+        /// and is specific to the <see cref="RuleSet"/>.
+        /// </summary>
+        public bool InstallPackages(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents, ISet<Project> projectsToBind)
+        {
+            if (!this.NuGetPackages.Any())
+            {
+                return true;
+            }
+
+            Debug.Assert(this.NuGetPackages.Count == this.NuGetPackages.Distinct().Count(), "Duplicate NuGet packages specified");
+
+            if (projectsToBind == null || !projectsToBind.Any())
+            {
+                Debug.Fail("Not expected to be called when there are no projects");
+                return true;
+            }
+
+            var projectNugets = projectsToBind
+                .SelectMany(bindingProject =>
+                {
+                    var projectLanguage = Language.ForProject(bindingProject);
+
+                    List<NuGetPackageInfoResponse> nugetPackages;
+                    if (!this.NuGetPackages.TryGetValue(projectLanguage, out nugetPackages))
+                    {
+                        var message = string.Format(Strings.BindingProjectLanguageNotMatchingAnyQualityProfileLanguage, bindingProject.Name);
+                        this.logger.WriteLine(Strings.SubTextPaddingFormat, message);
+                        nugetPackages = new List<NuGetPackageInfoResponse>();
+                    }
+
+                    return nugetPackages.Select(nugetPackage => new { Project = bindingProject, NugetPackage = nugetPackage });
+                })
+                .ToArray();
+
+            bool overallSuccess = true;
+
+            DeterminateStepProgressNotifier progressNotifier = new DeterminateStepProgressNotifier(notificationEvents, projectNugets.Length);
+            foreach (var projectNuget in projectNugets)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                string message = string.Format(CultureInfo.CurrentCulture, Strings.EnsuringNugetPackagesProgressMessage, projectNuget.NugetPackage.Id, projectNuget.Project.Name);
+                this.logger.WriteLine(Strings.SubTextPaddingFormat, message);
+
+                var isNugetInstallSuccessful = NuGetHelper.TryInstallPackage(this.serviceProvider, this.logger, projectNuget.Project, projectNuget.NugetPackage.Id, projectNuget.NugetPackage.Version);
+
+                if (isNugetInstallSuccessful) // NuGetHelper.TryInstallPackage already displayed the error message so only take care of the success message
+                {
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.SuccessfullyInstalledNugetPackageForProject, projectNuget.NugetPackage.Id, projectNuget.Project.Name);
+                    this.logger.WriteLine(Strings.SubTextPaddingFormat, message);
+                }
+
+                // TODO: SVS-33 (https://jira.sonarsource.com/browse/SVS-33) Trigger a Team Explorer warning notification to investigate the partial binding in the output window.
+                overallSuccess &= isNugetInstallSuccessful;
+
+                progressNotifier.NotifyIncrementedProgress(string.Empty);
+            }
+            return overallSuccess;
+        }
+
+        public bool ProcessExport(Language language, RoslynExportProfileResponse exportProfileResponse)
+        {
+            if (exportProfileResponse.Deployment.NuGetPackages.Count == 0)
+            {
+                this.logger.WriteLine(string.Format(Strings.SubTextPaddingFormat,
+                    string.Format(Strings.NoNuGetPackageForQualityProfile, language.Name)));
+                return false;
+            }
+
+            this.NuGetPackages.Add(language, exportProfileResponse.Deployment.NuGetPackages);
+            return true;
+        }
+    }
+}

--- a/src/Integration/Binding/NuGetHelper.cs
+++ b/src/Integration/Binding/NuGetHelper.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -39,11 +39,16 @@ namespace SonarLint.VisualStudio.Integration.Binding
             return installer;
         }
 
-        public static bool TryInstallPackage(IServiceProvider serviceProvider, Project project, string packageId, string version = null)
+        public static bool TryInstallPackage(IServiceProvider serviceProvider, ILogger logger, Project project, string packageId, string version = null)
         {
             if (serviceProvider == null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
             }
 
             if (project == null)
@@ -80,7 +85,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 }
 
                 var message = string.Format(Strings.FailedDuringNuGetPackageInstall, packageId, project.Name, ex.Message);
-                VsShellUtils.WriteToSonarLintOutputPane(serviceProvider, Strings.SubTextPaddingFormat, message);
+                logger.WriteLine(Strings.SubTextPaddingFormat, message);
                 return false;
             }
         }

--- a/src/TestInfrastructure/Framework/TestLogger.cs
+++ b/src/TestInfrastructure/Framework/TestLogger.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    public class TestLogger : ILogger
+    {
+        private IList<string> outputStrings = new List<string>();
+
+        public void AssertOutputStrings(int expectedOutputMessages)
+        {
+            this.outputStrings.Should().HaveCount(expectedOutputMessages);
+        }
+
+        public void AssertOutputStrings(params string[] orderedOutputMessages)
+        {
+            string[] expected = orderedOutputMessages.Select(o => o + Environment.NewLine).ToArray(); // All messages are postfixed by a newline
+            this.outputStrings.Should().Equal(expected);
+        }
+
+        #region ILogger methods
+
+        public void WriteLine(string message)
+        {
+            outputStrings.Add(message + Environment.NewLine);
+        }
+
+        public void WriteLine(string messageFormat, params object[] args)
+        {
+            outputStrings.Add(string.Format(System.Globalization.CultureInfo.CurrentCulture, messageFormat, args) + Environment.NewLine);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
I suggest starting with the _BindingWorkflow.cs_ file. I extracted code from that into a new _NuGetBindingOperation_ file, and then moved the tests into a new file too.
I'll call out all of the changed code.