### PR TITLE
Updated SolutionRulesetsInformationProvider to handle new and legacy …

### DIFF
--- a/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
@@ -290,7 +290,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private void SetValidSolutionRuleSet(RuleSet ruleSet)
         {
-            string expectedSolutionRuleSet = ((ISolutionRuleSetsInformationProvider)this.ruleSetInfoProvider).CalculateSolutionSonarQubeRuleSetFilePath("projectKey", Language.CSharp);
+            string expectedSolutionRuleSet = ((ISolutionRuleSetsInformationProvider)this.ruleSetInfoProvider)
+                .CalculateSolutionSonarQubeRuleSetFilePath("projectKey", Language.CSharp, SonarLintMode.LegacyConnected);
             ruleSet.FilePath = expectedSolutionRuleSet;
 
             this.ruleSetSerializer.RegisterRuleSet(ruleSet);

--- a/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
+++ b/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
@@ -147,7 +147,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             testSubject.GetCurrentConflicts().Should().BeEmpty("Not expecting any conflicts since the solution baseline is missing");
             this.outputWindowPane.AssertOutputStrings(1);
             this.outputWindowPane.AssertMessageContainsAllWordsCaseSensitive(0,
-                words: new[] { Constants.SonarQubeManagedFolderName },
+                words: new[] { ConfigurableSolutionRuleSetsInformationProvider.DummyLegacyModeFolderName },
                 splitter: new[] { Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar });
         }
 
@@ -308,7 +308,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             {
                 string solutionRuleSet = rsInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     this.configProvider.ProjectToReturn.ProjectKey,
-                    Language.ForProject(project));
+                    Language.ForProject(project),
+                    SonarLintMode.LegacyConnected);
                 this.fileSystem.RegisterFile(solutionRuleSet);
             }
         }

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -81,7 +81,9 @@ namespace SonarLint.VisualStudio.Integration.Binding
             this.solutionBindingOperation = new SolutionBindingOperation(
                     this.host,
                     this.bindingArgs.Connection,
-                    this.bindingArgs.ProjectKey);
+                    this.bindingArgs.ProjectKey,
+                    //TODO: duncanp pick the correct mode
+                    NewConnectedMode.SonarLintMode.LegacyConnected);
             this.nugetBindingOperation = nugetBindingOperation;
         }
 

--- a/src/Integration/Helpers/Constants.cs
+++ b/src/Integration/Helpers/Constants.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -33,9 +33,14 @@ namespace SonarLint.VisualStudio.Integration
         public const string CodeAnalysisRuleSetDirectoriesPropertyKey = "CodeAnalysisRuleSetDirectories";
 
         /// <summary>
-        /// The directory name of the SonarQube specific files that are being created
+        /// The directory name of the SonarQube specific files that are being created in legacy connected mode
         /// </summary>
-        public const string SonarQubeManagedFolderName = "SonarQube";
+        public const string LegacySonarQubeManagedFolderName = "SonarQube";
+
+        /// <summary>
+        /// The directory name of the SonarQube specific files that are being created in legacy connected mode
+        /// </summary>
+        public const string SonarlintManagedFolderName = ".sonarlint";
 
         /// <summary>
         /// The generated rule set name

--- a/src/Integration/LocalServices/ISolutionRuleSetsInformationProvider.cs
+++ b/src/Integration/LocalServices/ISolutionRuleSetsInformationProvider.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Generic;
 using EnvDTE;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
 
 namespace SonarLint.VisualStudio.Integration
 {
@@ -41,8 +42,9 @@ namespace SonarLint.VisualStudio.Integration
         /// </summary>
         /// <param name="ProjectKey">Required</param>
         /// <param name="language">The language this rule set corresponds to</param>
+        /// <param name="bindingMode">The binding mode (legacy or new)</param>
         /// <returns>Full file path. The file may not actually exist on disk</returns>
-        string CalculateSolutionSonarQubeRuleSetFilePath(string ProjectKey, Language language);
+        string CalculateSolutionSonarQubeRuleSetFilePath(string ProjectKey, Language language, SonarLintMode bindingMode);
 
         /// <summary>
         /// Will return a calculated file path to the expected project RuleSet
@@ -58,6 +60,7 @@ namespace SonarLint.VisualStudio.Integration
         /// Returns the path to solution level rulesets.
         /// When the solution is closed returns null.
         /// </summary>
-        string GetSolutionSonarQubeRulesFolder();
+        /// <param name="bindingMode">The binding mode (legacy or new)</param>
+        string GetSolutionSonarQubeRulesFolder(SonarLintMode bindingMode);
     }
 }

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -127,7 +127,9 @@ namespace SonarLint.VisualStudio.Integration
 
             string expectedSolutionRuleSet = ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                          binding.ProjectKey,
-                         Language.ForProject(project));
+                         Language.ForProject(project),
+                         // TODO: duncanp decide whether to support new connected mode
+                         SonarLintMode.LegacyConnected);
 
             RuleSet solutionRuleSet;
             if (!cache.TryGetValue(expectedSolutionRuleSet, out solutionRuleSet))

--- a/src/Integration/NewConnectedMode/ConfigurationSerializer.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationSerializer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -74,7 +74,8 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 
             var solutionFolder = Path.GetDirectoryName(solutionFilePath);
             var solutionName = Path.GetFileNameWithoutExtension(solutionFilePath);
-
+            
+            // TODO: duncanp modify to use the ISolutionRulesetsInformationProvider
             return Path.Combine(solutionFolder, ".sonarlint", $"{solutionName}.sqconfig");
         }
 

--- a/src/Integration/Persistence/SolutionBindingSerializer.cs
+++ b/src/Integration/Persistence/SolutionBindingSerializer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -27,6 +27,9 @@ using SonarLint.VisualStudio.Integration.Helpers;
 
 namespace SonarLint.VisualStudio.Integration.Persistence
 {
+    /// <summary>
+    /// Serializer for legacy connected mode
+    /// </summary>
     internal class SolutionBindingSerializer : FileBindingSerializer
     {
         private readonly IServiceProvider serviceProvider;
@@ -76,7 +79,7 @@ namespace SonarLint.VisualStudio.Integration.Persistence
             var projectSystemHelper = this.serviceProvider.GetService<IProjectSystemHelper>();
             projectSystemHelper.AssertLocalServiceIsNotNull();
 
-            Project solutionItemsProject = projectSystemHelper.GetSolutionFolderProject(Constants.SonarQubeManagedFolderName, true);
+            Project solutionItemsProject = projectSystemHelper.GetSolutionFolderProject(Constants.LegacySonarQubeManagedFolderName, true);
             if (solutionItemsProject == null)
             {
                 Debug.Fail("Could not find the solution items project"); // Should never happen
@@ -106,7 +109,7 @@ namespace SonarLint.VisualStudio.Integration.Persistence
         protected override string GetFullConfigurationFilePath()
         {
             var solutionRuleSetsInfoProvider = this.serviceProvider.GetService<ISolutionRuleSetsInformationProvider>();
-            string rootFolder = solutionRuleSetsInfoProvider.GetSolutionSonarQubeRulesFolder();
+            string rootFolder = solutionRuleSetsInfoProvider.GetSolutionSonarQubeRulesFolder(NewConnectedMode.SonarLintMode.LegacyConnected);
 
             // When the solution is closed return null
             if (rootFolder == null)

--- a/src/Integration/ProfileConflicts/ConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/ConflictsManager.cs
@@ -139,7 +139,9 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
             {
                 string baselineRuleSet = ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     bindingInfo.ProjectKey,
-                    Language.ForProject(project));
+                    Language.ForProject(project),
+                    // TODO: duncanp decide whether to support new connected mode
+                    SonarLintMode.LegacyConnected);
 
                 if (!fileSystem.FileExist(baselineRuleSet))
                 {


### PR DESCRIPTION
…connected modes

The new-new connected mode writes the shared rulesets and config file to a different solution-level folder.
This change updates the _ISolutionRuleSetsInformationProvider_ so it can handle the different modes.