### PR TITLE
Show more meaningful message when SonarC# is not installed on SonarQube

### DIFF
--- a/src/Integration.UnitTests/Rules/SonarQubeQualityProfileProviderTests.cs
+++ b/src/Integration.UnitTests/Rules/SonarQubeQualityProfileProviderTests.cs
@@ -95,7 +95,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Rules
             // Arrange
             serviceMock
                 .Setup(x => x.GetQualityProfileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SonarQubeLanguage>(), It.IsAny<CancellationToken>()))
-                .Throws(new InvalidOperationException("SonarC# is not installed on the server."));
+                .Throws(new InvalidOperationException("The SonarC# plugin is not installed on the connected SonarQube."));
 
             var testSubject = new SonarQubeQualityProfileProvider(serviceMock.Object, loggerMock.Object);
 
@@ -104,8 +104,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Rules
 
             // Assert
             result.Should().BeNull();
-            loggerMock
-                .Verify(x => x.WriteLine("SonarQube request failed: {0} {1}", "SonarC# is not installed on the server.", null), Times.Once);
+            loggerMock.Verify(
+                x => x.WriteLine("SonarQube request failed: {0} {1}", "The SonarC# plugin is not installed on the connected SonarQube.", null),
+                Times.Once());
         }
 
         [TestMethod]

--- a/src/Integration.UnitTests/Rules/SonarQubeQualityProfileProviderTests.cs
+++ b/src/Integration.UnitTests/Rules/SonarQubeQualityProfileProviderTests.cs
@@ -93,14 +93,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Rules
         public void GetQualityProfile_WhenHasNoQualityProfile_ReturnsNull()
         {
             // Arrange
-            SetupServiceResponses(null, new RoslynExportProfileResponse());
+            serviceMock
+                .Setup(x => x.GetQualityProfileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SonarQubeLanguage>(), It.IsAny<CancellationToken>()))
+                .Throws(new InvalidOperationException("SonarC# is not installed on the server."));
+
             var testSubject = new SonarQubeQualityProfileProvider(serviceMock.Object, loggerMock.Object);
 
             // Act
-            var result = testSubject.GetQualityProfile(new BoundSonarQubeProject(), Language.Unknown);
+            var result = testSubject.GetQualityProfile(new BoundSonarQubeProject(), Language.CSharp);
 
             // Assert
             result.Should().BeNull();
+            loggerMock
+                .Verify(x => x.WriteLine("SonarQube request failed: {0} {1}", "SonarC# is not installed on the server.", null), Times.Once);
         }
 
         [TestMethod]

--- a/src/SonarQube.Client.Tests/Api/SonarQubeService_GetQualityProfileAsync.cs
+++ b/src/SonarQube.Client.Tests/Api/SonarQubeService_GetQualityProfileAsync.cs
@@ -420,5 +420,95 @@ namespace SonarQube.Client.Tests.Api
             result.Name.Should().Be("Sonar way");
             result.TimeStamp.Should().Be(DateTime.Parse("2015-02-23T17:58:39+0100"));
         }
+
+        [TestMethod]
+        public async Task GetQualityProfile_New_NoQualityProfile_Eg_NoSonarCSharpInstalled()
+        {
+            await ConnectToSonarQube("6.5.0.0");
+
+            // Only a java Quality Profile is returned
+            SetupRequest("api/qualityprofiles/search?project=my_project&organization=my_organization", @"{
+  ""profiles"": [
+    {
+      ""key"": ""AU-TpxcA-iU5OvuD2FL1"",
+      ""name"": ""My BU Profile"",
+      ""language"": ""java"",
+      ""languageName"": ""Java"",
+      ""isInherited"": true,
+      ""isBuiltIn"": false,
+      ""parentKey"": ""iU5OvuD2FLz"",
+      ""parentName"": ""My Company Profile"",
+      ""activeRuleCount"": 15,
+      ""activeDeprecatedRuleCount"": 5,
+      ""isDefault"": false,
+      ""projectCount"": 7,
+      ""ruleUpdatedAt"": ""2016-12-20T19:10:03+0100"",
+      ""lastUsed"": ""2016-12-21T16:10:03+0100"",
+      ""userUpdatedAt"": ""2016-06-28T21:57:01+0200"",
+      ""actions"": {
+        ""edit"": true,
+        ""setAsDefault"": false,
+        ""copy"": false
+      }
+    }
+  ],
+  ""actions"": {
+    ""create"": false
+  }
+}");
+
+            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+                CancellationToken.None));
+
+            action.Should().ThrowExactly<InvalidOperationException>().And
+                .Message.Should().Be("SonarC# is not installed on the server.");
+
+            messageHandler.VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task GetQualityProfile_Old_NoQualityProfile_Eg_NoSonarCSharpInstalled()
+        {
+            await ConnectToSonarQube();
+
+            // Only a java Quality Profile is returned
+            SetupRequest("api/qualityprofiles/search?projectKey=my_project&organization=my_organization", @"{
+  ""profiles"": [
+    {
+      ""key"": ""AU-TpxcA-iU5OvuD2FL1"",
+      ""name"": ""My BU Profile"",
+      ""language"": ""java"",
+      ""languageName"": ""Java"",
+      ""isInherited"": true,
+      ""isBuiltIn"": false,
+      ""parentKey"": ""iU5OvuD2FLz"",
+      ""parentName"": ""My Company Profile"",
+      ""activeRuleCount"": 15,
+      ""activeDeprecatedRuleCount"": 5,
+      ""isDefault"": false,
+      ""projectCount"": 7,
+      ""ruleUpdatedAt"": ""2016-12-20T19:10:03+0100"",
+      ""lastUsed"": ""2016-12-21T16:10:03+0100"",
+      ""userUpdatedAt"": ""2016-06-28T21:57:01+0200"",
+      ""actions"": {
+        ""edit"": true,
+        ""setAsDefault"": false,
+        ""copy"": false
+      }
+    }
+  ],
+  ""actions"": {
+    ""create"": false
+  }
+}");
+
+            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+                CancellationToken.None));
+
+            action.Should().ThrowExactly<InvalidOperationException>().And
+                .Message.Should().Be("SonarC# is not installed on the server.");
+
+            messageHandler.VerifyAll();
+        }
     }
 }

--- a/src/SonarQube.Client.Tests/Api/SonarQubeService_GetQualityProfileAsync.cs
+++ b/src/SonarQube.Client.Tests/Api/SonarQubeService_GetQualityProfileAsync.cs
@@ -461,7 +461,7 @@ namespace SonarQube.Client.Tests.Api
                 CancellationToken.None));
 
             action.Should().ThrowExactly<InvalidOperationException>().And
-                .Message.Should().Be("SonarC# is not installed on the server.");
+                .Message.Should().Be("The SonarC# plugin is not installed on the connected SonarQube.");
 
             messageHandler.VerifyAll();
         }
@@ -506,7 +506,7 @@ namespace SonarQube.Client.Tests.Api
                 CancellationToken.None));
 
             action.Should().ThrowExactly<InvalidOperationException>().And
-                .Message.Should().Be("SonarC# is not installed on the server.");
+                .Message.Should().Be("The SonarC# plugin is not installed on the connected SonarQube.");
 
             messageHandler.VerifyAll();
         }

--- a/src/SonarQube.Client.Tests/Api/SonarQubeService_GetQualityProfileAsync.cs
+++ b/src/SonarQube.Client.Tests/Api/SonarQubeService_GetQualityProfileAsync.cs
@@ -510,5 +510,28 @@ namespace SonarQube.Client.Tests.Api
 
             messageHandler.VerifyAll();
         }
+
+        [TestMethod]
+        public async Task GetQualityProfile_Old_NoQualityProfile_Eg_NoSonarVBNETInstalled()
+        {
+            await ConnectToSonarQube();
+
+            // Only a java Quality Profile is returned
+            SetupRequest("api/qualityprofiles/search?projectKey=my_project&organization=my_organization", @"{
+  ""profiles"": [
+  ],
+  ""actions"": {
+    ""create"": false
+  }
+}");
+
+            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.VbNet,
+                CancellationToken.None));
+
+            action.Should().ThrowExactly<InvalidOperationException>().And
+                .Message.Should().Be("The SonarVB plugin is not installed on the connected SonarQube.");
+
+            messageHandler.VerifyAll();
+        }
     }
 }

--- a/src/SonarQube.Client/Api/SonarQubeService.cs
+++ b/src/SonarQube.Client/Api/SonarQubeService.cs
@@ -194,7 +194,7 @@ namespace SonarQube.Client.Api
 
             if (profilesWithGivenLanguage.Count == 0)
             {
-                throw new InvalidOperationException("SonarC# is not installed on the server.");
+                throw new InvalidOperationException($"The {language.PluginName} plugin is not installed on the connected SonarQube.");
             }
 
             var qualityProfile = profilesWithGivenLanguage.Count > 1

--- a/src/SonarQube.Client/Api/SonarQubeService.cs
+++ b/src/SonarQube.Client/Api/SonarQubeService.cs
@@ -192,6 +192,11 @@ namespace SonarQube.Client.Api
             // Consider adding the language filter to the request configuration above and removing this line
             var profilesWithGivenLanguage = qualityProfiles.Where(x => x.Language == language.Key).ToList();
 
+            if (profilesWithGivenLanguage.Count == 0)
+            {
+                throw new InvalidOperationException("SonarC# is not installed on the server.");
+            }
+
             var qualityProfile = profilesWithGivenLanguage.Count > 1
                 ? profilesWithGivenLanguage.Single(x => x.IsDefault)
                 : profilesWithGivenLanguage.Single();

--- a/src/SonarQube.Client/Models/SonarQubeLanguage.cs
+++ b/src/SonarQube.Client/Models/SonarQubeLanguage.cs
@@ -22,14 +22,16 @@ namespace SonarQube.Client.Models
 {
     public class SonarQubeLanguage
     {
-        public static readonly SonarQubeLanguage CSharp = new SonarQubeLanguage("cs");
-        public static readonly SonarQubeLanguage VbNet = new SonarQubeLanguage("vbnet");
+        public static readonly SonarQubeLanguage CSharp = new SonarQubeLanguage("cs", "SonarC#");
+        public static readonly SonarQubeLanguage VbNet = new SonarQubeLanguage("vbnet", "SonarVB");
 
         public string Key { get; }
+        public string PluginName { get; }
 
-        private SonarQubeLanguage(string key)
+        private SonarQubeLanguage(string key, string pluginName)
         {
             Key = key;
+            PluginName = pluginName;
         }
     }
 }


### PR DESCRIPTION
The service method is called in three places - workflow, golden bar and quality profile provider. All methods are generally testable, but apart from checking that the exception message is logged, there is nothing else to do...

Fix #662 