### PR TITLE
Reverting the V7.0 GetOrganizationsRequest revert; the request is reg…

### DIFF
--- a/src/SonarQube.Client.Tests/Api/SonarQubeService_GetAllOrganizationsAsync.cs
+++ b/src/SonarQube.Client.Tests/Api/SonarQubeService_GetAllOrganizationsAsync.cs
@@ -149,17 +149,16 @@ namespace SonarQube.Client.Tests.Api
                 .Message.Should().Be("Could not find compatible implementation of 'IGetOrganizationsRequest' for SonarQube 6.1.0.0.");
         }
 
-        // The implementation of this request is commented out, for more info see:
-        // https://github.com/SonarSource/sonarlint-visualstudio/issues/446
-        [Ignore]
         [TestMethod]
         public async Task GetOrganizations_V7_00_ExampleFromSonarQube()
         {
             await ConnectToSonarQube("7.0.0.0");
 
             // The only differnce between this and the previous version is the "member=true" query string parameter
-            // which when specified, should get only the organizations that the current user is member of
-            SetupRequest("api/organizations/search?member=true&p=1&ps=500",
+            // which when specified, should get only the organizations that the current user is member of.
+            // Currently "member=true" is not sent, it should be added for the implementation of
+            // https://github.com/SonarSource/sonarlint-visualstudio/issues/446
+            SetupRequest("api/organizations/search?p=1&ps=500",
                 @"
 {
   ""paging"": {

--- a/src/SonarQube.Client/Api/DefaultConfiguration.cs
+++ b/src/SonarQube.Client/Api/DefaultConfiguration.cs
@@ -42,8 +42,7 @@ namespace SonarQube.Client.Api.Requests
                 .RegisterRequest<IGetQualityProfilesRequest, V6_50.GetQualityProfilesRequest>("6.5")
                 .RegisterRequest<IGetNotificationsRequest, V6_60.GetNotificationsRequest>("6.6")
                 .RegisterRequest<IGetRoslynExportProfileRequest, V6_60.GetRoslynExportProfileRequest>("6.6")
-                // Uncomment code below for https://github.com/SonarSource/sonarlint-visualstudio/issues/446
-                //.RegisterRequest<IGetOrganizationsRequest, V7_00.GetOrganizationsRequest>("7.0")
+                .RegisterRequest<IGetOrganizationsRequest, V7_00.GetOrganizationsRequest>("7.0")
                 ;
             return requestFactory;
         }

--- a/src/SonarQube.Client/Api/Requests/V7_00/GetOrganizationsRequest.cs
+++ b/src/SonarQube.Client/Api/Requests/V7_00/GetOrganizationsRequest.cs
@@ -22,6 +22,7 @@ namespace SonarQube.Client.Api.Requests.V7_00
 {
     public class GetOrganizationsRequest : V6_20.GetOrganizationsRequest
     {
-        public override bool OnlyUserOrganizations { get; set; }
+        // Uncomment code below for https://github.com/SonarSource/sonarlint-visualstudio/issues/446
+        ////public override bool OnlyUserOrganizations { get; set; }
     }
 }


### PR DESCRIPTION
…istered, but is not sending the "member=true" argument to keep the old behavior.

Basically this is to fix the QG failure because of the newly ignored test.