### PR TITLE
Changed notifications package to be asynchronous

### DIFF
--- a/src/Integration.Vsix/Resources/Strings.Designer.cs
+++ b/src/Integration.Vsix/Resources/Strings.Designer.cs
@@ -203,5 +203,68 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Resources {
                 return ResourceManager.GetString("InvalidVisualStudioVersion", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Connected: checking for notifications.
+        /// </summary>
+        internal static string Notifications_Connected {
+            get {
+                return ResourceManager.GetString("Notifications_Connected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notifications: error occurred: {0}.
+        /// </summary>
+        internal static string Notifications_ERROR {
+            get {
+                return ResourceManager.GetString("Notifications_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finished initializing the notifications package.
+        /// </summary>
+        internal static string Notifications_InitializationComplete {
+            get {
+                return ResourceManager.GetString("Notifications_InitializationComplete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Initializing the notifications package....
+        /// </summary>
+        internal static string Notifications_Initializing {
+            get {
+                return ResourceManager.GetString("Notifications_Initializing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading notifcations settings....
+        /// </summary>
+        internal static string Notifications_LoadingSettings {
+            get {
+                return ResourceManager.GetString("Notifications_LoadingSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not connected: not checking for notifications.
+        /// </summary>
+        internal static string Notifications_NotConnected {
+            get {
+                return ResourceManager.GetString("Notifications_NotConnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Saving notifcations settings....
+        /// </summary>
+        internal static string Notifications_SavingSettings {
+            get {
+                return ResourceManager.GetString("Notifications_SavingSettings", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Integration.Vsix/Resources/Strings.resx
+++ b/src/Integration.Vsix/Resources/Strings.resx
@@ -169,4 +169,32 @@
     <value>Invalid VisualStudio version, expecting '14.0' or '15.0' got '{0}'.</value>
     <comment>Error message in output window when the VisualStudio version is not the expected one. {0} Actual VisualStudio version</comment>
   </data>
+  <data name="Notifications_Connected" xml:space="preserve">
+    <value>Connected: checking for notifications</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="Notifications_ERROR" xml:space="preserve">
+    <value>Notifications: error occurred: {0}</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="Notifications_InitializationComplete" xml:space="preserve">
+    <value>Finished initializing the notifications package</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="Notifications_Initializing" xml:space="preserve">
+    <value>Initializing the notifications package...</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="Notifications_LoadingSettings" xml:space="preserve">
+    <value>Loading notifcations settings...</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="Notifications_NotConnected" xml:space="preserve">
+    <value>Not connected: not checking for notifications</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="Notifications_SavingSettings" xml:space="preserve">
+    <value>Saving notifcations settings...</value>
+    <comment>Output window message</comment>
+  </data>
 </root>

--- a/src/Integration/Notifications/SonarQubeNotificationService.cs
+++ b/src/Integration/Notifications/SonarQubeNotificationService.cs
@@ -22,6 +22,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using SonarLint.VisualStudio.Integration.Resources;
 using SonarQube.Client.Services;
 using CancellationTokenSource = System.Threading.CancellationTokenSource;
 
@@ -31,7 +32,7 @@ namespace SonarLint.VisualStudio.Integration.Notifications
     {
         private readonly ITimer timer;
         private readonly ISonarQubeService sonarQubeService;
-        private readonly ILogger sonarLintOutput;
+        private readonly ILogger logger;
 
         private CancellationTokenSource cancellation;
         private DateTimeOffset lastCheckDate;
@@ -47,12 +48,12 @@ namespace SonarLint.VisualStudio.Integration.Notifications
             };
 
         public SonarQubeNotificationService(ISonarQubeService sonarQubeService, INotificationIndicatorViewModel model,
-            ITimer timer, ILogger sonarLintOutput)
+            ITimer timer, ILogger logger)
         {
             this.sonarQubeService = sonarQubeService;
             this.timer = timer;
             this.timer.Elapsed += OnTimerElapsed;
-            this.sonarLintOutput = sonarLintOutput;
+            this.logger = logger;
 
             Model = model;
         }
@@ -97,6 +98,7 @@ namespace SonarLint.VisualStudio.Integration.Notifications
                 if (events == null)
                 {
                     // Notifications are not supported on SonarQube
+                    logger.WriteLine(Strings.Notifications_NotSupported);
                     Stop();
                     return;
                 }
@@ -117,7 +119,7 @@ namespace SonarLint.VisualStudio.Integration.Notifications
             }
             catch (Exception ex)
             {
-                sonarLintOutput.WriteLine($"Failed to fetch notifications: {ex.Message}");
+                logger.WriteLine($"Failed to fetch notifications: {ex.Message}");
             }
         }
 

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -784,6 +784,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Notifications are not supported on this version of SonarQube.
+        /// </summary>
+        public static string Notifications_NotSupported {
+            get {
+                return ResourceManager.GetString("Notifications_NotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This SonarQube server only supported plugin language ({0}) does not match any of this solution projects&apos; languages..
         /// </summary>
         public static string OnlySupportedPluginHasNoProjectInSolution {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -646,10 +646,6 @@ This is the general format to use when writing errors to output window or when t
     <value>Detecting server plugins</value>
     <comment>Output window message printed before accessing to server plugins.</comment>
   </data>
-  <data name="OnlySupportedPluginHasNoProjectInSolution" xml:space="preserve">
-    <value>This SonarQube server only supported plugin language ({0}) does not match any of this solution projects' languages.</value>
-    <comment>Output window message printed when the only supported plugin has no matching project types in the current solution. {0} the name of the language.</comment>
-  </data>
   <data name="SolutionContainsNoSupportedProject" xml:space="preserve">
     <value>This solution contains no supported project language (C#, VB.Net). Please create at least one project of the supported language and then try to reconnect.</value>
     <comment>Output window message printed when some server plugin are supported but the current solution contains no supported project (based on project type GUID).</comment>
@@ -722,5 +718,13 @@ This is the general format to use when writing errors to output window or when t
   </data>
   <data name="Bind_NuGetAnalyzersNoLongerInstalled" xml:space="preserve">
     <value>INFO: SonarLint connected mode no longer installs the analyzers NuGet packages. The analyzers embedded in the VSIX are used instead.</value>
+  </data>
+  <data name="Notifications_NotSupported" xml:space="preserve">
+    <value>Notifications are not supported on this version of SonarQube</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="OnlySupportedPluginHasNoProjectInSolution" xml:space="preserve">
+    <value>This SonarQube server only supported plugin language ({0}) does not match any of this solution projects' languages.</value>
+    <comment>Output window message printed when the only supported plugin has no matching project types in the current solution. {0} the name of the language.</comment>
   </data>
 </root>


### PR DESCRIPTION
Resolved #679 

I followed the pattern Mads used for the [SonarLintDaemonPackage](https://github.com/SonarSource/sonarlint-visualstudio/blob/master/src/Integration.Vsix/SonarLintDaemonPackage.cs#L49) and the MSDN guidance [here](https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-diagnose-extension-performance).

I've manually tested with VS2015 and VS2017 and the notification package no longer appears in the _Visual Studio Performance_ entries in the activity log.
However, the telemetry package does, so that's next.