### PR TITLE
Fixed #760: shared projects should be excluded from binding

### DIFF
--- a/src/Integration.UnitTests/LocalServices/ProjectSystemFilterTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ProjectSystemFilterTests.cs
@@ -340,23 +340,28 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectSystemFilter_IsAccepted_UnrecognisedProjectType_ReturnsFalse()
         {
             // Arrange
+            var testSubject = this.CreateTestSubject();
             var project = new ProjectMock("unsupported.vcxproj");
             project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "False"); // Should not matter
 
             // Act and Assert
-            CheckProjectIsNotAccepted(project);
+            testSubject.IsAccepted(project).Should().BeFalse();
         }
 
         [TestMethod]
         public void ProjectSystemFilter_IsAccepted_SharedProject_ReturnsFalse()
         {
+            // Arrange
+            var testSubject = this.CreateTestSubject();
+
             var project = new ProjectMock("shared1.shproj");
             project.SetCSProjectKind();
-            CheckProjectIsNotAccepted(project);
 
             project = new ProjectMock("shared1.SHPROJ");
             project.SetCSProjectKind();
-            CheckProjectIsNotAccepted(project);
+
+            // Act and Assert
+            testSubject.IsAccepted(project).Should().BeFalse();
         }
 
         #endregion Tests
@@ -367,15 +372,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             var host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);
             return new ProjectSystemFilter(host);
-        }
-
-        private void CheckProjectIsNotAccepted(ProjectMock project)
-        {
-            var testSubject = this.CreateTestSubject();
-
-            var result = testSubject.IsAccepted(project);
-
-            result.Should().BeFalse();
         }
 
         #endregion Helpers

--- a/src/Integration.UnitTests/LocalServices/ProjectSystemFilterTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ProjectSystemFilterTests.cs
@@ -336,6 +336,29 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             Exceptions.Expect<ArgumentNullException>(() => testSubject.SetTestRegex(null));
         }
 
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_UnrecognisedProjectType_ReturnsFalse()
+        {
+            // Arrange
+            var project = new ProjectMock("unsupported.vcxproj");
+            project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "False"); // Should not matter
+
+            // Act and Assert
+            CheckProjectIsNotAccepted(project);
+        }
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_SharedProject_ReturnsFalse()
+        {
+            var project = new ProjectMock("shared1.shproj");
+            project.SetCSProjectKind();
+            CheckProjectIsNotAccepted(project);
+
+            project = new ProjectMock("shared1.SHPROJ");
+            project.SetCSProjectKind();
+            CheckProjectIsNotAccepted(project);
+        }
+
         #endregion Tests
 
         #region Helpers
@@ -344,6 +367,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             var host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);
             return new ProjectSystemFilter(host);
+        }
+
+        private void CheckProjectIsNotAccepted(ProjectMock project)
+        {
+            var testSubject = this.CreateTestSubject();
+
+            var result = testSubject.IsAccepted(project);
+
+            result.Should().BeFalse();
         }
 
         #endregion Helpers

--- a/src/Integration/LocalServices/ProjectSystemFilter.cs
+++ b/src/Integration/LocalServices/ProjectSystemFilter.cs
@@ -71,6 +71,11 @@ namespace SonarLint.VisualStudio.Integration
                 return false;
             }
 
+            if (IsSharedProject(project))
+            {
+                return false;
+            }
+
             if (IsExcludedViaProjectProperty(project))
             {
                 return false;
@@ -138,6 +143,14 @@ namespace SonarLint.VisualStudio.Integration
             bool? sonarExclude = this.propertyManager.GetBooleanProperty(dteProject, Constants.SonarQubeExcludeBuildPropertyKey);
             return sonarExclude.HasValue && sonarExclude.Value;
         }
+
+        private static bool IsSharedProject(DteProject project) =>
+            // Note: VB and C# shared projects don't have a project property that identifies them as a shared project.
+            // They do have common imports that we could search for, but we'll rely on the fact that they both have
+            // ".shproj" file extensions.
+            // C++ shared projects use a different file extension, but we don't currently support C++ projects in
+            // connected mode.
+            System.IO.Path.GetExtension(project.FileName).Equals(".shproj", StringComparison.OrdinalIgnoreCase);
 
         #endregion
     }


### PR DESCRIPTION
There is a separate issue with regard to test projects not being correctly recognized.
I've created #785 to track that bug, and I'm investigating another test project issue.