### PR TITLE
[DO NOT SQUASH]  Request suppressed issues by type

### DIFF
--- a/src/SonarQube.Client.Tests/Api/DefaultConfiguration_Configure.cs
+++ b/src/SonarQube.Client.Tests/Api/DefaultConfiguration_Configure.cs
@@ -56,7 +56,7 @@ namespace SonarQube.Client.Tests.Api
                     "Registered SonarQube.Client.Api.Requests.V6_60.GetNotificationsRequest for 6.6",
                     "Registered SonarQube.Client.Api.Requests.V6_60.GetRoslynExportProfileRequest for 6.6",
                     "Registered SonarQube.Client.Api.Requests.V7_00.GetOrganizationsRequest for 7.0",
-                    "Registered SonarQube.Client.Api.Requests.V7_20.GetIssuesRequest for 7.2",
+                    "Registered SonarQube.Client.Api.Requests.V7_20.GetIssuesRequestWrapper for 7.2",
                 });
         }
     }

--- a/src/SonarQube.Client.Tests/Api/SonarQubeService_GetSuppressedIssuesAsync.cs
+++ b/src/SonarQube.Client.Tests/Api/SonarQubeService_GetSuppressedIssuesAsync.cs
@@ -73,7 +73,7 @@ namespace SonarQube.Client.Tests.Api
         {
             await ConnectToSonarQube("7.2.0.0");
 
-            SetupRequest("api/issues/search?projects=shared&statuses=RESOLVED&p=1&ps=500", @"
+            SetupRequest("api/issues/search?projects=shared&statuses=RESOLVED&types=CODE_SMELL&p=1&ps=500", @"
 {
   ""total"": 5,
   ""p"": 1,
@@ -104,7 +104,22 @@ namespace SonarQube.Client.Tests.Api
       ""updateDate"": ""2019-01-11T11:28:22+0100"",
       ""type"": ""CODE_SMELL"",
       ""organization"": ""default-organization""
-    },
+    }
+  ],
+  ""components"": [ ]
+}
+");
+            SetupRequest("api/issues/search?projects=shared&statuses=RESOLVED&types=BUG&p=1&ps=500", @"
+{
+  ""total"": 5,
+  ""p"": 1,
+  ""ps"": 100,
+  ""paging"": {
+    ""pageIndex"": 1,
+    ""pageSize"": 100,
+    ""total"": 5
+  },
+  ""issues"": [
     {
       ""key"": ""AWg8adcV_JurIR2zdSvR"",
       ""rule"": ""csharpsquid:S1118"",
@@ -132,9 +147,36 @@ namespace SonarQube.Client.Tests.Api
       ],
       ""creationDate"": ""2019-01-11T11:16:30+0100"",
       ""updateDate"": ""2019-01-11T11:26:39+0100"",
-      ""type"": ""CODE_SMELL"",
+      ""type"": ""BUG"",
       ""organization"": ""default-organization""
-    },
+    }
+  ],
+  ""components"": [
+    {
+      ""organization"": ""default-organization"",
+      ""key"": ""shared:shared:2B470B7D-D47B-4E41-B105-D3938E196082:Program.cs"",
+      ""uuid"": ""AWg8adNk_JurIR2zdSvM"",
+      ""enabled"": true,
+      ""qualifier"": ""FIL"",
+      ""name"": ""Program.cs"",
+      ""longName"": ""Program.cs"",
+      ""path"": ""Program.cs""
+    }
+  ]
+}
+");
+
+            SetupRequest("api/issues/search?projects=shared&statuses=RESOLVED&types=VULNERABILITY&p=1&ps=500", @"
+{
+  ""total"": 5,
+  ""p"": 1,
+  ""ps"": 100,
+  ""paging"": {
+    ""pageIndex"": 1,
+    ""pageSize"": 100,
+    ""total"": 5
+  },
+  ""issues"": [
     {
       ""key"": ""AWg9DV27DpKqrfA7luen"",
       ""rule"": ""csharpsquid:S1451"",
@@ -151,7 +193,7 @@ namespace SonarQube.Client.Tests.Api
       ""tags"": [],
       ""creationDate"": ""2019-01-11T13:18:25+0100"",
       ""updateDate"": ""2019-01-11T14:15:53+0100"",
-      ""type"": ""CODE_SMELL"",
+      ""type"": ""VULNERABILITY"",
       ""organization"": ""default-organization"",
       ""fromHotspot"": false
     },
@@ -181,7 +223,7 @@ namespace SonarQube.Client.Tests.Api
       ],
       ""creationDate"": ""2019-01-11T11:16:30+0100"",
       ""updateDate"": ""2019-01-11T11:26:55+0100"",
-      ""type"": ""CODE_SMELL"",
+      ""type"": ""VULNERABILITY"",
       ""organization"": ""default-organization""
     }
   ],
@@ -195,16 +237,6 @@ namespace SonarQube.Client.Tests.Api
       ""name"": ""SharedClass1.cs"",
       ""longName"": ""SharedProject1/SharedClass1.cs"",
       ""path"": ""SharedProject1/SharedClass1.cs""
-    },
-    {
-      ""organization"": ""default-organization"",
-      ""key"": ""shared:shared:2B470B7D-D47B-4E41-B105-D3938E196082:Program.cs"",
-      ""uuid"": ""AWg8adNk_JurIR2zdSvM"",
-      ""enabled"": true,
-      ""qualifier"": ""FIL"",
-      ""name"": ""Program.cs"",
-      ""longName"": ""Program.cs"",
-      ""path"": ""Program.cs""
     }
   ]
 }
@@ -256,7 +288,7 @@ namespace SonarQube.Client.Tests.Api
         {
             await ConnectToSonarQube("7.2.0.0");
 
-            SetupRequest("api/issues/search?projects=project1&statuses=RESOLVED&p=1&ps=500", "", HttpStatusCode.NotFound);
+            SetupRequest("api/issues/search?projects=project1&statuses=RESOLVED&types=CODE_SMELL&p=1&ps=500", "", HttpStatusCode.NotFound);
 
             Func<Task<IList<SonarQubeIssue>>> func = async () =>
                 await service.GetSuppressedIssuesAsync("project1", CancellationToken.None);
@@ -272,7 +304,7 @@ namespace SonarQube.Client.Tests.Api
         {
             await ConnectToSonarQube("7.2.0.0");
 
-            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&p=1&ps=500", $@"
+            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&types=CODE_SMELL&p=1&ps=500", $@"
 {{
   ""paging"": {{
     ""pageIndex"": 1,
@@ -287,7 +319,7 @@ namespace SonarQube.Client.Tests.Api
   ]
 }}");
 
-            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&p=2&ps=500", $@"
+            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&types=CODE_SMELL&p=2&ps=500", $@"
 {{
   ""paging"": {{
     ""pageIndex"": 2,
@@ -302,7 +334,7 @@ namespace SonarQube.Client.Tests.Api
   ]
 }}");
 
-            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&p=3&ps=500", $@"
+            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&types=CODE_SMELL&p=3&ps=500", $@"
 {{
   ""paging"": {{
     ""pageIndex"": 3,
@@ -317,6 +349,27 @@ namespace SonarQube.Client.Tests.Api
   ]
 }}");
 
+            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&types=BUG&p=1&ps=500", $@"
+{{
+  ""paging"": {{
+    ""pageIndex"": 1,
+    ""pageSize"": 500,
+    ""total"": 3
+  }},
+  ""issues"": [ ],
+  ""components"": [ ]
+}}");
+
+            SetupRequest("api/issues/search?projects=simplcom&statuses=RESOLVED&types=VULNERABILITY&p=1&ps=500", $@"
+{{
+  ""paging"": {{
+    ""pageIndex"": 1,
+    ""pageSize"": 500,
+    ""total"": 3
+  }},
+  ""issues"": [ ],
+  ""components"": [ ]
+}}");
 
             var result = await service.GetSuppressedIssuesAsync("simplcom", CancellationToken.None);
 

--- a/src/SonarQube.Client.Tests/Api/SonarQubeService_GetSuppressedIssuesAsync.cs
+++ b/src/SonarQube.Client.Tests/Api/SonarQubeService_GetSuppressedIssuesAsync.cs
@@ -73,7 +73,7 @@ namespace SonarQube.Client.Tests.Api
         {
             await ConnectToSonarQube("7.2.0.0");
 
-            SetupRequest("api/issues/search?projects=com.github.kevinsawicki:http-request&statuses=RESOLVED&p=1&ps=500", @"
+            SetupRequest("api/issues/search?projects=shared&statuses=RESOLVED&p=1&ps=500", @"
 {
   ""total"": 5,
   ""p"": 1,
@@ -84,26 +84,6 @@ namespace SonarQube.Client.Tests.Api
     ""total"": 5
   },
   ""issues"": [
-    {
-      ""key"": ""AWg8bjekFPFMeKWzHZ_6"",
-      ""rule"": ""csharpsquid:S3990"",
-      ""severity"": ""MAJOR"",
-      ""component"": ""shared:shared:D111C902-E7B1-4665-927E-A52E1443B8C1"",
-      ""project"": ""shared"",
-      ""flows"": [],
-      ""status"": ""OPEN"",
-      ""message"": ""Mark this assembly with 'System.CLSCompliantAttribute'"",
-      ""effort"": ""1min"",
-      ""debt"": ""1min"",
-      ""author"": """",
-      ""tags"": [
-        ""api-design""
-      ],
-      ""creationDate"": ""2019-01-11T11:21:20+0100"",
-      ""updateDate"": ""2019-01-11T11:21:20+0100"",
-      ""type"": ""CODE_SMELL"",
-      ""organization"": ""default-organization""
-    },
     {
       ""key"": ""AWg8bjfdFPFMeKWzHZ_7"",
       ""rule"": ""csharpsquid:S3990"",
@@ -152,34 +132,6 @@ namespace SonarQube.Client.Tests.Api
       ],
       ""creationDate"": ""2019-01-11T11:16:30+0100"",
       ""updateDate"": ""2019-01-11T11:26:39+0100"",
-      ""type"": ""CODE_SMELL"",
-      ""organization"": ""default-organization""
-    },
-    {
-      ""key"": ""AWg8adc9_JurIR2zdSvS"",
-      ""rule"": ""csharpsquid:S1118"",
-      ""severity"": ""MAJOR"",
-      ""component"": ""shared:SharedProject1/SharedClass1.cs"",
-      ""project"": ""shared"",
-      ""line"": 3,
-      ""hash"": ""b19753e3bb1df2c64cb2fe930a8a16a9"",
-      ""textRange"": {
-        ""startLine"": 3,
-        ""endLine"": 3,
-        ""startOffset"": 10,
-        ""endOffset"": 22
-      },
-      ""flows"": [],
-      ""status"": ""OPEN"",
-      ""message"": ""Add a 'protected' constructor or the 'static' keyword to the class declaration."",
-      ""effort"": ""10min"",
-      ""debt"": ""10min"",
-      ""author"": """",
-      ""tags"": [
-        ""design""
-      ],
-      ""creationDate"": ""2019-01-11T11:16:30+0100"",
-      ""updateDate"": ""2019-01-11T11:16:30+0100"",
       ""type"": ""CODE_SMELL"",
       ""organization"": ""default-organization""
     },
@@ -246,16 +198,6 @@ namespace SonarQube.Client.Tests.Api
     },
     {
       ""organization"": ""default-organization"",
-      ""key"": ""shared:shared:D111C902-E7B1-4665-927E-A52E1443B8C1"",
-      ""uuid"": ""AWg8adNi_JurIR2zdSvH"",
-      ""enabled"": true,
-      ""qualifier"": ""BRC"",
-      ""name"": ""ClassLibrary1"",
-      ""longName"": ""ClassLibrary1"",
-      ""path"": ""ClassLibrary1""
-    },
-    {
-      ""organization"": ""default-organization"",
       ""key"": ""shared:shared:2B470B7D-D47B-4E41-B105-D3938E196082:Program.cs"",
       ""uuid"": ""AWg8adNk_JurIR2zdSvM"",
       ""enabled"": true,
@@ -263,31 +205,12 @@ namespace SonarQube.Client.Tests.Api
       ""name"": ""Program.cs"",
       ""longName"": ""Program.cs"",
       ""path"": ""Program.cs""
-    },
-    {
-      ""organization"": ""default-organization"",
-      ""key"": ""shared:shared:2B470B7D-D47B-4E41-B105-D3938E196082"",
-      ""uuid"": ""AWg8adNk_JurIR2zdSvK"",
-      ""enabled"": true,
-      ""qualifier"": ""BRC"",
-      ""name"": ""ConsoleApp1"",
-      ""longName"": ""ConsoleApp1"",
-      ""path"": ""ConsoleApp1""
-    },
-    {
-      ""organization"": ""default-organization"",
-      ""key"": ""shared"",
-      ""uuid"": ""AWg8aLQfhQTYUbm7ZplB"",
-      ""enabled"": true,
-      ""qualifier"": ""TRK"",
-      ""name"": ""shared"",
-      ""longName"": ""shared""
     }
   ]
 }
 ");
 
-            var result = await service.GetSuppressedIssuesAsync("com.github.kevinsawicki:http-request", CancellationToken.None);
+            var result = await service.GetSuppressedIssuesAsync("shared", CancellationToken.None);
 
             result.Should().HaveCount(4);
 

--- a/src/SonarQube.Client/Api/DefaultConfiguration.cs
+++ b/src/SonarQube.Client/Api/DefaultConfiguration.cs
@@ -44,7 +44,7 @@ namespace SonarQube.Client.Api.Requests
                 .RegisterRequest<IGetNotificationsRequest, V6_60.GetNotificationsRequest>("6.6")
                 .RegisterRequest<IGetRoslynExportProfileRequest, V6_60.GetRoslynExportProfileRequest>("6.6")
                 .RegisterRequest<IGetOrganizationsRequest, V7_00.GetOrganizationsRequest>("7.0")
-                .RegisterRequest<IGetIssuesRequest, V7_20.GetIssuesRequest>("7.2")
+                .RegisterRequest<IGetIssuesRequest, V7_20.GetIssuesRequestWrapper>("7.2")
                 ;
             return requestFactory;
         }

--- a/src/SonarQube.Client/Api/Requests/IGetIssuesRequest.cs
+++ b/src/SonarQube.Client/Api/Requests/IGetIssuesRequest.cs
@@ -26,5 +26,7 @@ namespace SonarQube.Client.Api
     {
         string ProjectKey { get; set; }
         string Statuses { get; set; }
+
+        // Update <see cref="V7_20.GetIssuesRequestWrapper"/> when adding properties here.
     }
 }

--- a/src/SonarQube.Client/Api/Requests/V7_20/GetIssuesRequest.cs
+++ b/src/SonarQube.Client/Api/Requests/V7_20/GetIssuesRequest.cs
@@ -34,6 +34,11 @@ namespace SonarQube.Client.Api.Requests.V7_20
         [JsonProperty("statuses")]
         public string Statuses { get; set; }
 
+        // This property is not present in the IGetIssuesRequest interface, it is meant to be
+        // set by the GetIssuesRequestWrapper to add additional parameters to the API calls.
+        [JsonProperty("types")]
+        public string Types { get; set; }
+
         protected override string Path => "api/issues/search";
 
         protected override SonarQubeIssue[] ParseResponse(string response)

--- a/src/SonarQube.Client/Api/Requests/V7_20/GetIssuesRequestWrapper.cs
+++ b/src/SonarQube.Client/Api/Requests/V7_20/GetIssuesRequestWrapper.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * SonarQube Client
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using SonarQube.Client.Helpers;
+using SonarQube.Client.Models;
+
+namespace SonarQube.Client.Api.Requests.V7_20
+{
+    /// <summary>
+    /// The SonarQube 10k API result limit problem (https://github.com/SonarSource/sonarlint-visualstudio/issues/776):
+    /// SonarQube will return the first 10k results from any query.The suppressed issues in large
+    /// projects could be more than 10k and SLVS will not hide those which are not returned by the
+    /// server.
+    ///
+    /// To reduce the effects of this limitation we will retrieve issues in batches by issue type.
+    /// The same approach is used in the other flavours of SonarLint.
+    ///
+    /// This class should be removed if/when SonarQube removes the 10k API result limitation.
+    /// </summary>
+    public class GetIssuesRequestWrapper : IGetIssuesRequest
+    {
+        private readonly GetIssuesRequest innerRequest = new GetIssuesRequest();
+
+        public string ProjectKey { get; set; }
+
+        public string Statuses { get; set; }
+
+        public ILogger Logger { get; set; }
+
+        public async Task<SonarQubeIssue[]> InvokeAsync(HttpClient httpClient, CancellationToken token)
+        {
+            // Transfer all IGetIssuesRequest properties to the inner request. If more properties are
+            // added to IGetIssuesRequest, this block should set them.
+            innerRequest.ProjectKey = ProjectKey;
+            innerRequest.Statuses = Statuses;
+            innerRequest.Logger = Logger;
+
+            ResetInnerRequest();
+            innerRequest.Types = "CODE_SMELL";
+            var codeSmells = await innerRequest.InvokeAsync(httpClient, token);
+            WarnForApiLimit(codeSmells);
+
+            ResetInnerRequest();
+            innerRequest.Types = "BUG";
+            var bugs = await innerRequest.InvokeAsync(httpClient, token);
+            WarnForApiLimit(bugs);
+
+            ResetInnerRequest();
+            innerRequest.Types = "VULNERABILITY";
+            var vulnerabilities = await innerRequest.InvokeAsync(httpClient, token);
+            WarnForApiLimit(vulnerabilities);
+
+            return codeSmells
+                .Concat(bugs)
+                .Concat(vulnerabilities)
+                .ToArray();
+        }
+
+        private void WarnForApiLimit(SonarQubeIssue[] issues)
+        {
+            if (issues.Length == 10000)
+            {
+                Logger.Warning($"The SonarQube maximum API response limit reached. Some issues might not be suppressed.");
+            }
+        }
+
+        /// <summary>
+        /// For paged requests the Page property is automatically changed on each invocation.
+        /// We are resetting it so that our invocations for different issue types could start
+        /// from the first page.
+        /// </summary>
+        private void ResetInnerRequest()
+        {
+            innerRequest.Page = 1;
+        }
+    }
+}

--- a/src/SonarQube.Client/Api/SonarQubeService.cs
+++ b/src/SonarQube.Client/Api/SonarQubeService.cs
@@ -251,19 +251,14 @@ namespace SonarQube.Client.Api
                 },
                 token);
 
-        public async Task<IList<SonarQubeIssue>> GetSuppressedIssuesAsync(string projectKey, CancellationToken token)
-        {
-            const string statusResolved = "RESOLVED";
-            var result = await InvokeRequestAsync<IGetIssuesRequest, SonarQubeIssue[]>(
+        public async Task<IList<SonarQubeIssue>> GetSuppressedIssuesAsync(string projectKey, CancellationToken token) =>
+            await InvokeRequestAsync<IGetIssuesRequest, SonarQubeIssue[]>(
                 request =>
                 {
                     request.ProjectKey = projectKey;
-                    request.Statuses = statusResolved;
+                    request.Statuses = "RESOLVED"; // Resolved issues will be hidden in SLVS
                 },
                 token);
-
-            return result.Where(x => x.IsResolved).ToList(); // Post-filter for old API
-        }
 
         public async Task<IList<SonarQubeNotification>> GetNotificationEventsAsync(string projectKey, DateTimeOffset eventsSince,
             CancellationToken token) =>


### PR DESCRIPTION
Fix #776

In general I am not sure if this change brings large benefit, because we will start doing three times more requests for each sync.

Two commits, a bit related:
- Moving the suppressed issues filtering from the service to the request - this is request-specific, so there is no need to filter already filtered data and potentially put pressure on the memory and CPU when copying large collections.
- Request suppressed issues by type.