### PR TITLE
Revert build property changes to VS2015 projects

### DIFF
--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -16,7 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <VsCommonIdeDirectory>$(DevEnvDir)</VsCommonIdeDirectory>
+    <VsCommonIdeDirectory>$(VS140COMNTOOLS)..\IDE\</VsCommonIdeDirectory>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/Integration.Vsix.UnitTests/Integration.Vsix.UnitTests.csproj
+++ b/src/Integration.Vsix.UnitTests/Integration.Vsix.UnitTests.csproj
@@ -16,7 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <VsCommonIdeDirectory>$(DevEnvDir)</VsCommonIdeDirectory>
+    <VsCommonIdeDirectory>$(VS140COMNTOOLS)..\IDE\</VsCommonIdeDirectory>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -23,7 +23,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-    <VsCommonIdeDirectory>$(DevEnvDir)</VsCommonIdeDirectory>
+    <VsCommonIdeDirectory>$(VS140COMNTOOLS)..\IDE\</VsCommonIdeDirectory>
     <StartAction>Program</StartAction>
     <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <VsCommonIdeDirectory>$(DevEnvDir)</VsCommonIdeDirectory>
+    <VsCommonIdeDirectory>$(VS140COMNTOOLS)..\IDE\</VsCommonIdeDirectory>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <VsCommonIdeDirectory>$(DevEnvDir)</VsCommonIdeDirectory>
+    <VsCommonIdeDirectory>$(VS140COMNTOOLS)..\IDE\</VsCommonIdeDirectory>
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
* using $(DevEnvDir) works locally for VS2015. However, the VSIX built by the cix slave selects v12 TeamFoundation dlls, not v14 dlls.