### PR TITLE
Fix #835: initialisation should be on the UI thread

### DIFF
--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -336,7 +336,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         private void InitializeSolutionBindingOnUIThread(IProgressStepExecutionEvents notificationEvents)
         {
-            Debug.Assert(System.Windows.Application.Current?.Dispatcher.CheckAccess() ?? false, "Expected to run on UI thread");
+            Debug.Assert(host.UIDispatcher.CheckAccess(), "Expected to run on UI thread");
 
             notificationEvents.ProgressChanged(Strings.RuleSetGenerationProgressMessage);
 
@@ -351,7 +351,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         private void FinishSolutionBindingOnUIThread(IProgressController controller, CancellationToken token)
         {
-            Debug.Assert(System.Windows.Application.Current?.Dispatcher.CheckAccess() ?? false, "Expected to run on UI thread");
+            Debug.Assert(host.UIDispatcher.CheckAccess(), "Expected to run on UI thread");
 
             if (!this.solutionBindingOperation.CommitSolutionBinding())
             {

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -114,7 +114,9 @@ namespace SonarLint.VisualStudio.Integration
         // possible use #if DEBUG instead.
         private void AssertOnUIThread()
         {
-            Debug.Assert(this.host.UIDispatcher.CheckAccess(), "The controller needs to run on the UI thread");
+            // Note: "this.host.UIDispatcher.CheckAccess()" does not return the correct result when 
+            // VS is shutting down. However, ThreadHelper.CheckAccess() does.
+            Debug.Assert(ThreadHelper.CheckAccess(), "The controller needs to run on the UI thread");
         }
 
         private bool IsActiveSolutionBound

--- a/src/Integration/WPF/RelayCommandBase.cs
+++ b/src/Integration/WPF/RelayCommandBase.cs
@@ -32,7 +32,7 @@ namespace SonarLint.VisualStudio.Integration.WPF
         {
             if (System.Windows.Application.Current != null)
             {
-                Debug.Assert(System.Windows.Application.Current.Dispatcher.CheckAccess(), "RequeryCanExecute should be called from the UI thread");
+                Debug.Assert(Microsoft.VisualStudio.Shell.ThreadHelper.CheckAccess(), "RequeryCanExecute should be called from the UI thread");
             }
 
             this.canExecuteChanged?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
Fixed #835 

The refactoring of the Team Explorer plugins to a separate assembly changed the order of initialisation of components, which led to some of the UI-related components being created on background threads in some circumstances (i.e. timing related)