### PR TITLE
Updating publisher in vsix to match publisher login name

### DIFF
--- a/src/Integration.Vsix/Manifests/VS2015/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2015/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
-    <Identity Id="SonarLint.8c442ec8-0208-4840-b83f-acd24f41acf7" Version="4.9.0.0" Language="en-US" Publisher="SonarSource SA" />
+    <Identity Id="SonarLint.8c442ec8-0208-4840-b83f-acd24f41acf7" Version="4.9.0.0" Language="en-US" Publisher="SonarSource" />
     <DisplayName>SonarLint for Visual Studio 2015</DisplayName>
     <Description xml:space="preserve">Roslyn based static code analysis: Find and instantly fix nasty bugs and code smells in C#, VB.Net, C, C++ and JS.</Description>
     <MoreInfo>http://vs.sonarlint.org</MoreInfo>

--- a/src/Integration.Vsix/Manifests/VS2017/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2017/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
-        <Identity Id="SonarLint.36871a7b-4853-481f-bb52-1835a874e81b" Version="4.9.0.0" Language="en-US" Publisher="SonarSource SA" />
+        <Identity Id="SonarLint.36871a7b-4853-481f-bb52-1835a874e81b" Version="4.9.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarLint for Visual Studio 2017</DisplayName>
         <Description xml:space="preserve">Roslyn based static code analysis: Find and instantly fix nasty bugs and code smells in C#, VB.Net, C, C++ and JS.</Description>
         <MoreInfo>http://vs.sonarlint.org</MoreInfo>

--- a/src/Integration.Vsix/Manifests/VS2019/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2019/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
-        <Identity Id="SonarLint.b986f788-6a16-4a3a-a68b-c757f6b1b7d5" Version="4.9.0.0" Language="en-US" Publisher="SonarSource SA" />
+        <Identity Id="SonarLint.b986f788-6a16-4a3a-a68b-c757f6b1b7d5" Version="4.9.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarLint for Visual Studio 2019</DisplayName>
         <Description xml:space="preserve">Roslyn based static code analysis: Find and instantly fix nasty bugs and code smells in C#, VB.Net, C, C++ and JS.</Description>
         <MoreInfo>http://vs.sonarlint.org</MoreInfo>


### PR DESCRIPTION
...otherwise we can't publish a new marketplace offering for VS2019