### PR TITLE
Fixed #859

### DIFF
--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -120,6 +120,33 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string Bind_NuGetAnalyzersNoLongerInstalled {
             get {
                 return ResourceManager.GetString("Bind_NuGetAnalyzersNoLongerInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ruleset binding: all projects need to be updated reference the generated ruleset..
+        /// </summary>
+        public static string Bind_Ruleset_AllProjectsNeedToBeUpdated {
+            get {
+                return ResourceManager.GetString("Bind_Ruleset_AllProjectsNeedToBeUpdated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ruleset binding: initial binding. All projects need to be updated to reference the generated ruleset..
+        /// </summary>
+        public static string Bind_Ruleset_InitialBinding {
+            get {
+                return ResourceManager.GetString("Bind_Ruleset_InitialBinding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ruleset binding: the following projects already reference the generated ruleset:.
+        /// </summary>
+        public static string Bind_Ruleset_SomeProjectsDoNotNeedToBeUpdated {
+            get {
+                return ResourceManager.GetString("Bind_Ruleset_SomeProjectsDoNotNeedToBeUpdated", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -759,4 +759,13 @@ This is the general format to use when writing errors to output window or when t
     <value>Failed to check out files for saving. Error code: {0}</value>
     <comment>Output window message showing the tagVSQuerySaveResult enum value</comment>
   </data>
+  <data name="Bind_Ruleset_InitialBinding" xml:space="preserve">
+    <value>Ruleset binding: initial binding. All projects need to be updated to reference the generated ruleset.</value>
+  </data>
+  <data name="Bind_Ruleset_AllProjectsNeedToBeUpdated" xml:space="preserve">
+    <value>Ruleset binding: all projects need to be updated reference the generated ruleset.</value>
+  </data>
+  <data name="Bind_Ruleset_SomeProjectsDoNotNeedToBeUpdated" xml:space="preserve">
+    <value>Ruleset binding: the following projects already reference the generated ruleset:</value>
+  </data>
 </root>

--- a/src/TestInfrastructure/Framework/TestLogger.cs
+++ b/src/TestInfrastructure/Framework/TestLogger.cs
@@ -46,6 +46,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 actualValue.Contains(expectedValue));
         }
 
+        public void AssertOutputStringExists(string expected)
+        {
+            this.outputStrings.Should().Contain(expected + Environment.NewLine); // All messages are postfixed by a newline
+        }
+
+        public void AssertPartialOutputStringExists(params string[] expected)
+        {
+            this.outputStrings.Should()
+                .Contain(msg => expected.All(partial => msg.Contains(partial)));
+        }
+
         public void AssertNoOutputMessages()
         {
             outputStrings.Should().HaveCount(0);


### PR DESCRIPTION
* ruleset binding should not add project-level rulesets if the generated ruleset is already referenced