### PR TITLE
Added v3 format version of the manifest for VS2015

### DIFF
--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -2,9 +2,15 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Executive summary:
-       * to build the VS2015 visx, build from the VS2015 command prompt/from inside VS2015.
-       * to build the VS2017 visx, build from the VS2017 command prompt/from inside VS2017.
-       * to build the VS2019 visx, build from the VS2019 command prompt/from inside VS2019.
+       * to build the VS2015 vsix, build from inside VS2015.
+       * to build the VS2017 vsix, build from inside VS2017.
+       * to build the VS2019 vsix, build from inside VS2019.
+       
+       or
+       
+       * build from a VS2017/2019 command line, and specify the version of VS to target by
+         setting the vsTargetVersion property to 2015, 2017 or 2019 e.g.
+           /p:vsTargetVersion=2017
 
        Background:
        We want to be able to use the same set of projects to develop in multiple versions of VS (currently VS2015
@@ -522,7 +528,6 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="Resources\sonarlint_32px.ico" />
-    <None Include="Manifests\VS$(VersionSpecificSuffix)\source.extension.vsixmanifest" />
     <Content Include="Resources\sonarlint_wave_128px.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -537,6 +542,22 @@
       <SubType>Designer</SubType>
     </VSCTCompile>
   </ItemGroup>
+
+  <!-- ***************************************** -->
+  <!-- Select the manifest to use -->
+  <!-- In most cases we can just select the folder using the $(VersionSpecificSuffic) property.
+         The one special case is if we are targetting VS2015 but not building in VS2015. In that case,
+         we need to use the v3 version of the manifest (used by VS2017+), otherwise the VSSDK build
+         targets will complain. -->
+  <PropertyGroup>
+    <ManifestFolder>Manifests\VS$(VersionSpecificSuffix)\</ManifestFolder>
+    <ManifestFolder Condition=" $(VSTargetVersion) == '2015' AND $(VisualStudioVersion) != '14.0' " >Manifests\VS2015_v3Manifest\</ManifestFolder>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(ManifestFolder)source.extension.vsixmanifest" />
+  </ItemGroup>
+  <!-- ***************************************** -->
+  
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>

--- a/src/Integration.Vsix/Manifests/VS2015_v3Manifest/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2015_v3Manifest/source.extension.vsixmanifest
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <!-- This file is exactly the same as the one in the ..\VS2015_v3Manifest\ folder, except that this folder does not
-       have a Prerequisites element.
-       This version can only be build with VS2015.
+  <!-- This file is exactly the same as the one in the ..\VS2015\ folder, except for the addition of the Prerequisites
+       element, required make the file valid with version 3 of the VSIX manifest (yes, this is a version 3-format file,
+       even though the version number in the root element is still 2.0.0).
+       This version cannot be built with VS2015.
   -->
   <Metadata>
     <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
@@ -34,4 +35,7 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="File" Path="Google.Protobuf.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Integration.TeamExplorer" Path="|Integration.TeamExplorer|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0.25420.00,15.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/SonarLint.VSSpecificAssemblies.props
+++ b/src/SonarLint.VSSpecificAssemblies.props
@@ -63,11 +63,7 @@
     <!-- Check build constraints -->
     <Error
       Condition=" $(VisualStudioVersion) == '14.0' AND $(VersionSpecificSuffix) != '2015' "
-      Text="MSBuild 14.0/VS2015 can only build the VS2015 VSIX. Target version specified: X$(VsTargetVersion)X   Y$(VersionSpecificSuffix)Y"/>
-
-    <Error
-      Condition=" $(VisualStudioVersion) != '14.0' AND $(VersionSpecificSuffix) == '2015' "
-      Text="Only MSBuild 14.0 / VS2015 can build the VS2105 VSIX. Current VS version: $(VisualStudioVersion)"/>
+      Text="MSBuild 14.0/VS2015 can only build the VS2015 VSIX. Target version specified: '$(VsTargetVersion)', Version specific suffix: '$(VersionSpecificSuffix)'"/>
 
   </Target>
 


### PR DESCRIPTION
... which allows the VS2015 vsix to be built using VS2017 or VS2019