### PR TITLE
Workaround for hang when binding .NET SDK projects in VS2019

### DIFF
--- a/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
@@ -292,7 +292,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         }
 
         [TestMethod]
-        public void ProjectBindingOperation_Commit()
+        public void ProjectBindingOperation_Commit_NewProjectSystem_AddsFile()
         {
             // Arrange
             ProjectBindingOperation testSubject = this.CreateTestSubject();
@@ -301,6 +301,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);
+
+            this.projectSystemHelper.SetIsLegacyProjectSystem(false);
 
             // Act
             using (new AssertIgnoreScope()) // Ignore that the file is not on disk
@@ -311,7 +313,32 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Assert
             string expectedFile = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
             prop.Value.ToString().Should().Be(Path.GetFileName(expectedFile), "Should update the property value");
-            this.projectMock.Files.ContainsKey(expectedFile).Should().BeTrue("Should be added to the project");
+            this.projectMock.Files.ContainsKey(expectedFile).Should().BeFalse("Should not add the file to the project for the new project system");
+        }
+
+        [TestMethod]
+        public void ProjectBindingOperation_Commit_LegacyProjectSystem_DoesNotAddFile()
+        {
+            // Arrange
+            ProjectBindingOperation testSubject = this.CreateTestSubject();
+            this.projectMock.SetCSProjectKind();
+            this.ruleStore.RegisterRuleSetPath(Language.CSharp, @"c:\Solution\sln.ruleset");
+            PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
+            testSubject.Initialize();
+            testSubject.Prepare(CancellationToken.None);
+
+            this.projectSystemHelper.SetIsLegacyProjectSystem(true);
+
+            // Act
+            using (new AssertIgnoreScope()) // Ignore that the file is not on disk
+            {
+                testSubject.Commit();
+            }
+
+            // Assert
+            string projectFile = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
+            prop.Value.ToString().Should().Be(Path.GetFileName(projectFile), "Should update the property value");
+            this.projectMock.Files.ContainsKey(projectFile).Should().BeTrue("Should add the file to the project for the legacy project system");
         }
 
         #endregion Tests

--- a/src/Integration.UnitTests/LocalServices/ProjectSystemFilterTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ProjectSystemFilterTests.cs
@@ -160,7 +160,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             var testSubject = this.CreateTestSubject();
 
-            var project = new ProjectMock("supported" + projectExtension);
+            var project = new LegacyProjectMock("supported" + projectExtension);
             project.SetCSProjectKind();
             project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "false"); // Should evaluate test projects even if false
 
@@ -226,7 +226,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             var testSubject = this.CreateTestSubject();
 
-            var project = new ProjectMock("knownproject" + projectExtension);
+            var project = new LegacyProjectMock("knownproject" + projectExtension);
             project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "false"); // Should evaluate test projects even if false
             project.SetCSProjectKind();
 
@@ -285,7 +285,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Arrange
             var testSubject = this.CreateTestSubject();
-            var project = new ProjectMock("foobarfoobar" + projectExtension);
+            var project = new LegacyProjectMock("foobarfoobar" + projectExtension);
             project.SetCSProjectKind();
 
             // Case 1: Regex match

--- a/src/Integration.UnitTests/LocalServices/ProjectSystemHelperExtensionsTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ProjectSystemHelperExtensionsTests.cs
@@ -56,7 +56,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         public void IProjectSystemHelperExtensions_IsKnownTestProject_IsTestProject_ReturnsTrue()
         {
             // Arrange
-            var vsProject = new ProjectMock("myproject.proj");
+            var vsProject = new LegacyProjectMock("myproject.proj");
             vsProject.SetAggregateProjectTypeGuids(ProjectSystemHelper.TestProjectKindGuid);
 
             // Act + Assert
@@ -67,7 +67,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         public void IProjectSystemHelperExtensions_IsKnownTestProject_IsNotTestProject_ReturnsFalse()
         {
             // Arrange
-            var vsProject = new ProjectMock("myproject.proj");
+            var vsProject = new LegacyProjectMock("myproject.proj");
 
             // Act + Assert
             IProjectSystemHelperExtensions.IsKnownTestProject(this.projectSystem, vsProject).Should().BeFalse("Expected project without test project kind NOT to be known test project");

--- a/src/Integration.UnitTests/LocalServices/ProjectSystemHelperTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ProjectSystemHelperTests.cs
@@ -548,7 +548,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ProjectSystemHelper_GetAggregateProjectKinds_NoGuids_ReturnsEmpty()
         {
             // Arrange
-            var project = new ProjectMock("my.project");
+            var project = new LegacyProjectMock("my.project");
             project.SetAggregateProjectTypeString(string.Empty);
 
             // Act
@@ -569,7 +569,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 new Guid("0BA323B301614B1C80D74607B7EB7F5A"),
             };
 
-            var project = new ProjectMock("my.project");
+            var project = new LegacyProjectMock("my.project");
             project.SetAggregateProjectTypeString(guidString);
 
             // Act
@@ -616,6 +616,32 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Assert
             result.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void ProjectSystemHelper_IsLegacyProject_NotLegacy_ReturnsFalse()
+        {
+            // Arrange
+            var mockProject = this.solutionMock.AddOrGetProject("dummy.proj", isLegacy: false);
+
+            // Act
+            var result = this.testSubject.IsLegacyProjectSystem(mockProject);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void ProjectSystemHelper_IsLegacyProject_Legacy_ReturnsTrue()
+        {
+            // Arrange
+            var mockProject  = this.solutionMock.AddOrGetProject("dummy.proj", isLegacy: true);
+
+            // Act
+            var result = this.testSubject.IsLegacyProjectSystem(mockProject);
+
+            // Assert
+            result.Should().BeTrue();
         }
 
         #endregion Tests

--- a/src/Integration/Binding/ProjectBindingOperation.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.cs
@@ -172,7 +172,10 @@ namespace SonarLint.VisualStudio.Integration.Binding
             var projectSystem = this.serviceProvider.GetService<IProjectSystemHelper>();
             projectSystem.AssertLocalServiceIsNotNull();
 
-            if (!projectSystem.IsFileInProject(project, fullFilePath))
+            // Workaround for bug https://github.com/SonarSource/sonarlint-visualstudio/issues/881
+            // #881: hang when binding in VS2019
+            if (projectSystem.IsLegacyProjectSystem(project) &&
+                !projectSystem.IsFileInProject(project, fullFilePath))
             {
                 projectSystem.AddFileToProject(project, fullFilePath);
             }

--- a/src/Integration/LocalServices/IProjectSystemHelper.cs
+++ b/src/Integration/LocalServices/IProjectSystemHelper.cs
@@ -132,5 +132,12 @@ namespace SonarLint.VisualStudio.Integration
         /// Returns a flag indicating whether there is fully-opened solution or not.
         /// </summary>
         bool IsSolutionFullyOpened();
+
+        /// <summary>
+        /// Returns true if the project is implemented by the old C#/VB project system, otherwise false
+        /// </summary>
+        /// <returns>There are occasions when we need to code round differences between the old and new
+        /// project systems.</returns>
+        bool IsLegacyProjectSystem(Project dteProject);
     }
 }

--- a/src/Integration/LocalServices/ProjectSystemHelper.cs
+++ b/src/Integration/LocalServices/ProjectSystemHelper.cs
@@ -32,6 +32,7 @@ namespace SonarLint.VisualStudio.Integration
 {
     internal class ProjectSystemHelper : IProjectSystemHelper
     {
+        // See https://github.com/dotnet/project-system/blob/master/docs/opening-with-new-project-system.md
         internal const string VbProjectKind = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
         internal const string CSharpProjectKind = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
         internal const string VbCoreProjectKind = "{778DAE3C-4631-46EA-AA77-85C1314464D9}";
@@ -449,6 +450,26 @@ namespace SonarLint.VisualStudio.Integration
                 return (bool)isLoaded;
             }
             return false;
+        }
+
+        public bool IsLegacyProjectSystem(Project dteProject)
+        {
+            // We can't rely on the project type guid to differentiate between the old
+            // and C#/VB project systems as they can both return the legacy guids: see
+            // https://github.com/dotnet/project-system/blob/master/docs/opening-with-new-project-system.md.
+
+            // There doesn't seem to be a documented way to determine which project system
+            // is being used, and I couldn't find a suitable property or capability.
+
+            // Instead, we'll look for an interface we know is implemented by the old
+            // project system but not the new project system. This isn't perfect, but
+            // it's very unlikely that the new project system will ever implement this
+            // interface since the interface-based project aggregation mechanism has
+            // been replaced by a newer MEF-based/capability extensibility mechanism.
+
+            var hierarchy = GetIVsHierarchy(dteProject);
+
+            return hierarchy != null && hierarchy is IVsAggregatableProjectCorrected;
         }
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -172,10 +172,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public IEnumerable<Guid> GetAggregateProjectKinds(IVsHierarchy hierarchy)
         {
-            ProjectMock dteProject = hierarchy as ProjectMock;
+            LegacyProjectMock dteProject = hierarchy as LegacyProjectMock;
             if (dteProject == null)
             {
-                FluentAssertions.Execution.Execute.Assertion.FailWith($"Only expecting {nameof(ProjectMock)} type");
+                FluentAssertions.Execution.Execute.Assertion.FailWith($"Only expecting {nameof(LegacyProjectMock)} type");
             }
 
             return dteProject.GetAggregateProjectTypeGuids();

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -31,6 +31,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     {
         private readonly IServiceProvider serviceProvider;
         private bool isSolutionFullyOpened;
+        private bool isLegacyProjectSystem = true; // assume is legacy by default
 
         public ConfigurableVsProjectSystemHelper(IServiceProvider serviceProvider)
         {
@@ -185,6 +186,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return this.isSolutionFullyOpened;
         }
 
+        public bool IsLegacyProjectSystem(Project dteProject)
+        {
+            return this.isLegacyProjectSystem;
+        }
+
         #endregion IVsProjectSystemHelper
 
         #region Test helpers
@@ -206,6 +212,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void SetIsSolutionFullyOpened(bool isFullyOpened)
         {
             this.isSolutionFullyOpened = isFullyOpened;
+        }
+
+        public void SetIsLegacyProjectSystem(bool isLegacyProjectSystem)
+        {
+            this.isLegacyProjectSystem = isLegacyProjectSystem;
         }
 
         #endregion Test helpers

--- a/src/TestInfrastructure/VsObjectModelMocks/LegacyProjectMock.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/LegacyProjectMock.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Flavor;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    /// <summary>
+    /// Mock for managed projects that use the legacy C#/VB project system
+    /// </summary>
+    public class LegacyProjectMock : ProjectMock, IVsAggregatableProjectCorrected
+    {
+        private string aggregateProjectTypeGuids = string.Empty;
+
+        public LegacyProjectMock(string projectFile)
+            :base(projectFile)
+        {
+        }
+
+        #region IVsAggregatableProjectCorrected
+
+        int IVsAggregatableProjectCorrected.SetInnerProject(IntPtr punkInnerIUnknown)
+        {
+            throw new NotImplementedException();
+        }
+
+        int IVsAggregatableProjectCorrected.InitializeForOuter(string pszFilename, string pszLocation, string pszName, uint grfCreateFlags, ref Guid iidProject, out IntPtr ppvProject, out int pfCanceled)
+        {
+            throw new NotImplementedException();
+        }
+
+        int IVsAggregatableProjectCorrected.OnAggregationComplete()
+        {
+            throw new NotImplementedException();
+        }
+
+        int IVsAggregatableProjectCorrected.GetAggregateProjectTypeGuids(out string pbstrProjTypeGuids)
+        {
+            pbstrProjTypeGuids = this.aggregateProjectTypeGuids;
+            return VSConstants.S_OK;
+        }
+
+        int IVsAggregatableProjectCorrected.SetAggregateProjectTypeGuids(string lpstrProjTypeGuids)
+        {
+            this.aggregateProjectTypeGuids = lpstrProjTypeGuids;
+            return VSConstants.S_OK;
+        }
+
+        #endregion IVsAggregatableProjectCorrected
+
+        public void SetAggregateProjectTypeString(string str)
+        {
+            this.aggregateProjectTypeGuids = str;
+        }
+
+        public void SetAggregateProjectTypeGuids(params Guid[] guids)
+        {
+            this.aggregateProjectTypeGuids = string.Join(";", guids.Select(x => x.ToString("N"))) ?? string.Empty;
+        }
+
+        public IEnumerable<Guid> GetAggregateProjectTypeGuids()
+        {
+            return this.aggregateProjectTypeGuids.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries)
+                                                 .Select(Guid.Parse);
+        }
+
+        public void SetTestProject()
+        {
+            this.SetAggregateProjectTypeGuids(ProjectSystemHelper.TestProjectKindGuid);
+        }
+
+        public void ClearProjectKind()
+        {
+            this.aggregateProjectTypeGuids = string.Empty;
+        }
+    }
+}

--- a/src/TestInfrastructure/VsObjectModelMocks/ProjectMock.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/ProjectMock.cs
@@ -24,16 +24,14 @@ using System.IO;
 using System.Linq;
 using EnvDTE;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
-    public class ProjectMock : VsUIHierarchyMock, IVsProject, Project, IVsBuildPropertyStorage, IVsAggregatableProjectCorrected
+    public class ProjectMock : VsUIHierarchyMock, IVsProject, Project, IVsBuildPropertyStorage
     {
         private readonly Dictionary<string, uint> files = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
         private readonly IDictionary<string, string> buildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        private string aggregateProjectTypeGuids = string.Empty;
 
         public DTE DTE { get; set; }
 
@@ -356,37 +354,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #endregion IVsBuildPropertyStorage
 
-        #region IVsAggregatableProjectCorrected
-
-        int IVsAggregatableProjectCorrected.SetInnerProject(IntPtr punkInnerIUnknown)
-        {
-            throw new NotImplementedException();
-        }
-
-        int IVsAggregatableProjectCorrected.InitializeForOuter(string pszFilename, string pszLocation, string pszName, uint grfCreateFlags, ref Guid iidProject, out IntPtr ppvProject, out int pfCanceled)
-        {
-            throw new NotImplementedException();
-        }
-
-        int IVsAggregatableProjectCorrected.OnAggregationComplete()
-        {
-            throw new NotImplementedException();
-        }
-
-        int IVsAggregatableProjectCorrected.GetAggregateProjectTypeGuids(out string pbstrProjTypeGuids)
-        {
-            pbstrProjTypeGuids = this.aggregateProjectTypeGuids;
-            return VSConstants.S_OK;
-        }
-
-        int IVsAggregatableProjectCorrected.SetAggregateProjectTypeGuids(string lpstrProjTypeGuids)
-        {
-            this.aggregateProjectTypeGuids = lpstrProjTypeGuids;
-            return VSConstants.S_OK;
-        }
-
-        #endregion IVsAggregatableProjectCorrected
-
         public uint AddOrGetFile(string filePath)
         {
             uint fileId;
@@ -433,32 +400,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ClearBuildProperty(string propertyName, string configuration = "")
         {
             ((IVsBuildPropertyStorage)this).RemoveProperty(propertyName, configuration, (uint)_PersistStorageType.PST_PROJECT_FILE);
-        }
-
-        public void SetAggregateProjectTypeString(string str)
-        {
-            this.aggregateProjectTypeGuids = str;
-        }
-
-        public void SetAggregateProjectTypeGuids(params Guid[] guids)
-        {
-            this.aggregateProjectTypeGuids = string.Join(";", guids.Select(x => x.ToString("N"))) ?? string.Empty;
-        }
-
-        public IEnumerable<Guid> GetAggregateProjectTypeGuids()
-        {
-            return this.aggregateProjectTypeGuids.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries)
-                                                 .Select(Guid.Parse);
-        }
-
-        public void SetTestProject()
-        {
-            this.SetAggregateProjectTypeGuids(ProjectSystemHelper.TestProjectKindGuid);
-        }
-
-        public void ClearProjectKind()
-        {
-            this.aggregateProjectTypeGuids = string.Empty;
         }
     }
 }

--- a/src/TestInfrastructure/VsObjectModelMocks/SolutionMock.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/SolutionMock.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -515,12 +515,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             }
         }
 
-        public ProjectMock AddOrGetProject(string projectFile, bool isLoaded = true)
+        public ProjectMock AddOrGetProject(string projectFile, bool isLoaded = true, bool isLegacy = true)
         {
             ProjectMock prj;
             if (!this.projects.TryGetValue(projectFile, out prj))
             {
-                projects[projectFile] = prj = new ProjectMock(projectFile);
+                projects[projectFile] = prj = 
+                    (isLegacy) ?
+                    new LegacyProjectMock(projectFile) :
+                    new ProjectMock(projectFile);
                 prj.DTE = this.dte;
                 this.SimulateProjectOpen(prj);
 


### PR DESCRIPTION
Fix #881