### PR TITLE
Implement protocol to talk to the CFamily analyzer (#928)

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTest.cs
@@ -29,7 +29,7 @@ using SonarLint.VisualStudio.Integration.Vsix.CFamily;
 namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
 {
     [TestClass]
-    public class CFamilyTest
+    public class CFamilyHelperTest
     {
         private const string FileName = @"C:\absolute\path\to\file.cpp";
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/CFamily/ProtocolTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/ProtocolTest.cs
@@ -1,0 +1,347 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using EnvDTE;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Integration.Vsix;
+using SonarLint.VisualStudio.Integration.Vsix.CFamily;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
+{
+    [TestClass]
+    public class ProtocolTest
+    {
+        [TestMethod]
+        public void Write_Empty_Request()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.Write(writer, new Request());
+
+                byte[] result = stream.ToArray();
+                result.Length.Should().Be(75);
+            }
+        }
+
+        [TestMethod]
+        public void Write_Request_With_One_Empty_Option()
+        {
+            Request request = new Request();
+            request.Options = new string[] { "" };
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.Write(writer, request);
+
+                byte[] result = stream.ToArray();
+                result.Length.Should().Be(77);
+            }
+        }
+
+        [TestMethod]
+        public void Read_Empty_Response()
+        {
+            using (MemoryStream stream = new MemoryStream(MockEmptyResponse()))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+                Response response = Protocol.Read(reader);
+
+                response.Messages.Length.Should().Be(0);
+            }
+        }
+
+        [TestMethod]
+        public void Read_Response()
+        {
+            using (MemoryStream stream = new MemoryStream(MockResponse()))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+                Response response = Protocol.Read(reader);
+
+                response.Messages.Length.Should().Be(1);
+                response.Messages[0].RuleKey.Should().Be("ruleKey");
+                response.Messages[0].Line.Should().Be(10);
+                response.Messages[0].Column.Should().Be(11);
+                response.Messages[0].EndLine.Should().Be(12);
+                response.Messages[0].EndColumn.Should().Be(13);
+                response.Messages[0].Text.Should().Be("Issue message");
+                response.Messages[0].PartsMakeFlow.Should().Be(true);
+                response.Messages[0].Parts.Length.Should().Be(1);
+            }
+        }
+
+        [TestMethod]
+        public void Read_Bad_Response_Throw()
+        {
+            using (MemoryStream stream = new MemoryStream(MockBadStartResponse()))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+
+                Action act = () => Protocol.Read(reader);
+                act.Should().ThrowExactly<InvalidDataException>();
+            }
+
+            using (MemoryStream stream = new MemoryStream(MockBadEndResponse()))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+
+                Action act = () => Protocol.Read(reader);
+                act.Should().ThrowExactly<InvalidDataException>();
+            }
+
+        }
+
+        [TestMethod]
+        public void Write_UTF8()
+        {
+            WriteUtf("").Should().BeEquivalentTo(new byte[] { 0, 0 });
+            WriteUtf("a").Should().BeEquivalentTo(new byte[] { 0, 1, 97 });
+            WriteUtf("A").Should().BeEquivalentTo(new byte[] { 0, 1, 65 });
+            WriteUtf("0").Should().BeEquivalentTo(new byte[] { 0, 1, 48 });
+            WriteUtf("\n").Should().BeEquivalentTo(new byte[] { 0, 1, 10 });
+            // 3 bytes
+            WriteUtf("\u0800").Should().BeEquivalentTo(new byte[] { 0, 3, 224, 160, 128 });
+            // Special case of NUL
+            Action actNul = () => WriteUtf("\u0000");
+            actNul.Should().ThrowExactly<InvalidOperationException>();
+            // Supplementary characters as surrogate pair  (see CESU-8) are not supported for now
+            Action actSupp = () => WriteUtf("\U00010400");
+            actSupp.Should().ThrowExactly<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void Read_UTF8()
+        {
+            ReadUtf(WriteUtf("")).Should().Be("");
+            ReadUtf(WriteUtf("a")).Should().Be("a");
+            ReadUtf(WriteUtf("A")).Should().Be("A");
+            ReadUtf(WriteUtf("0")).Should().Be("0");
+            ReadUtf(WriteUtf("\n")).Should().Be("\n");
+            // 3 bytes
+            ReadUtf(WriteUtf("\u0800")).Should().Be("\u0800");
+        }
+
+        [TestMethod]
+        public void Write_Short()
+        {
+            WriteShort(0).Should().BeEquivalentTo(new byte[] { 0, 0 });
+            WriteShort(1).Should().BeEquivalentTo(new byte[] { 0, 1 });
+        }
+
+        [TestMethod]
+        public void Write_Int()
+        {
+            WriteInt(0).Should().BeEquivalentTo(new byte[] { 0, 0, 0, 0 });
+            WriteInt(1).Should().BeEquivalentTo(new byte[] { 0, 0, 0, 1 });
+            WriteInt(int.MaxValue).Should().BeEquivalentTo(new byte[] { 0x7F, 0xFF, 0xFF, 0xFF });
+            WriteInt(int.MinValue).Should().BeEquivalentTo(new byte[] { 0x80, 0x00, 0x00, 0x00 });
+        }
+
+        [TestMethod]
+        public void Write_Long()
+        {
+            WriteLong(0).Should().BeEquivalentTo(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 });
+            WriteLong(long.MaxValue).Should().BeEquivalentTo(new byte[] { 127, 255, 255, 255, 255, 255, 255, 255 });
+        }
+
+        [TestMethod]
+        public void Read_Int()
+        {
+            ReadInt(WriteInt(0)).Should().Be(0);
+            ReadInt(WriteInt(int.MaxValue)).Should().Be(int.MaxValue);
+            ReadInt(WriteInt(int.MinValue)).Should().Be(int.MinValue);
+        }
+
+        private byte[] WriteUtf(string s)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteUTF(writer, s);
+
+                return stream.ToArray();
+            }
+        }
+
+        private string ReadUtf(byte[] bytes)
+        {
+            using (MemoryStream stream = new MemoryStream(bytes))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+                return Protocol.ReadUTF(reader);
+            }
+        }
+
+        private byte[] WriteShort(ushort s)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteUShort(writer, s);
+
+                return stream.ToArray();
+            }
+        }
+
+        private byte[] WriteInt(int i)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteInt(writer, i);
+
+                return stream.ToArray();
+            }
+        }
+
+        private int ReadInt(byte[] bytes)
+        {
+            using (MemoryStream stream = new MemoryStream(bytes))
+            {
+                BinaryReader reader = new BinaryReader(stream);
+                return Protocol.ReadInt(reader);
+            }
+        }
+
+        private byte[] WriteLong(long l)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteLong(writer, l);
+
+                return stream.ToArray();
+            }
+        }
+
+        private byte[] MockEmptyResponse()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteUTF(writer, "OUT");
+
+                // 0 issues
+                Protocol.WriteInt(writer, 0);
+
+                // 0 measures
+                Protocol.WriteInt(writer, 0);
+
+                // 0 symbols
+                Protocol.WriteInt(writer, 0);
+
+                Protocol.WriteUTF(writer, "END");
+                return stream.ToArray();
+            }
+        }
+
+        private byte[] MockBadStartResponse()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteUTF(writer, "FOO");
+                return stream.ToArray();
+            }
+        }
+
+        private byte[] MockBadEndResponse()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteUTF(writer, "OUT");
+
+                // 0 issues
+                Protocol.WriteInt(writer, 0);
+
+                // 0 measures
+                Protocol.WriteInt(writer, 0);
+
+                // 0 symbols
+                Protocol.WriteInt(writer, 0);
+
+                Protocol.WriteUTF(writer, "FOO");
+                return stream.ToArray();
+            }
+        }
+
+        private byte[] MockResponse()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                Protocol.WriteUTF(writer, "OUT");
+
+                // 1 issue
+                Protocol.WriteInt(writer, 1);
+
+                Protocol.WriteUTF(writer, "ruleKey");
+                Protocol.WriteUTF(writer, "file.cpp");
+                Protocol.WriteInt(writer, 10);
+                Protocol.WriteInt(writer, 11);
+                Protocol.WriteInt(writer, 12);
+                Protocol.WriteInt(writer, 13);
+                Protocol.WriteInt(writer, 100);
+                Protocol.WriteUTF(writer, "Issue message");
+                writer.Write(true);
+
+                // 1 flow
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteUTF(writer, "another.cpp");
+                Protocol.WriteInt(writer, 14);
+                Protocol.WriteInt(writer, 15);
+                Protocol.WriteInt(writer, 16);
+                Protocol.WriteInt(writer, 17);
+                Protocol.WriteUTF(writer, "Flow message");
+
+                // 1 measure
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteUTF(writer, "file.cpp");
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+
+                byte[] execLines = new byte[] { 1, 2, 3, 4 };
+                Protocol.WriteInt(writer, execLines.Length);
+                writer.Write(execLines);
+                
+
+                // 1 symbol
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+                Protocol.WriteInt(writer, 1);
+
+                Protocol.WriteUTF(writer, "END");
+                return stream.ToArray();
+            }
+        }
+    }
+}

--- a/src/Integration.Vsix/CFamily/Protocol.cs
+++ b/src/Integration.Vsix/CFamily/Protocol.cs
@@ -1,0 +1,319 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+/**
+ * This is a port of the protocol implemented between Java and C++
+ * https://github.com/SonarSource/sonar-cpp/blob/master/sonar-cfamily-plugin/src/main/java/com/sonar/cpp/analyzer/Protocol.java
+ */
+namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
+{
+
+    internal class Request
+    {
+        public const int Verify = 1;
+        public const int C99 = 1 << 1;
+        public const int C11 = 1 << 2;
+        public const int CPlusPlus = 1 << 3;
+        public const int CPlusPlus11 = 1 << 4;
+        public const int CPlusPlus14 = 1 << 5;
+        public const int CPlusPlus17 = 1 << 6;
+        public const int ObjC = 1 << 7;
+        public const int MS = 1 << 8;
+        public const int GNU = 1 << 9;
+        public const int OperatorNames = 1 << 10;
+        public const int CharIsUnsigned = 1 << 11;
+        public const int CreateReproducer = 1 << 14;
+        public const int AutoRefCount = 1 << 15;
+        public const int Weak = 1 << 16;
+        public const int C17 = 1 << 17;
+
+        public string[] Options { get; set; } = Array.Empty<string>();
+        public long Flags { get; set; }
+        public long MsVersion { get; set; }
+        public string[] IncludeDirs { get; set; } = Array.Empty<string>();
+        public string[] FrameworkDirs { get; set; } = Array.Empty<string>();
+        public string[] VfsOverlayFiles { get; set; } = Array.Empty<string>();
+        public string ModuleName { get; set; } = "";
+        public string Predefines { get; set; } = "";
+        public string[] Macros { get; set; } = Array.Empty<string>();
+        public string TargetTriple { get; set; } = "x86_64-unknown-unknown";
+        public string File { get; set; } = "";
+    }
+
+    internal class Response
+    {
+        public Message[] Messages { get; }
+
+        public Response(Message[] messages)
+        {
+            Messages = messages;
+        }
+    }
+
+    internal class MessagePart
+    {
+        public string Filename;
+        public int Line { get; }
+        public int Column { get; }
+        public int EndLine { get; }
+        public int EndColumn { get; }
+        public string Text { get; }
+
+        public MessagePart(string filename, int line, int column, int endLine, int endColumn, string text)
+        {
+            Filename = filename;
+            Line = line;
+            Column = column;
+            EndLine = endLine;
+            EndColumn = endColumn;
+            Text = text;
+        }
+    }
+
+    internal class Message : MessagePart
+    {
+
+        public string RuleKey { get; }
+        public bool PartsMakeFlow { get; }
+        public MessagePart[] Parts { get; }
+
+        public Message(string ruleKey, string filename, int line, int column, int endLine, int endColumn, string message, bool partsMakeFlow, MessagePart[] parts)
+            : base(filename, line, column, endLine, endColumn, message)
+        {
+            RuleKey = ruleKey;
+            PartsMakeFlow = partsMakeFlow;
+            Parts = parts;
+        }
+
+    }
+
+    internal static class Protocol
+    {
+        /**
+          * This method does not close the provided stream.
+          */
+        public static void Write(BinaryWriter writer, Request request)
+        {
+            WriteUTF(writer, "IN");
+            Write(writer, request.Options);
+            WriteLong(writer, request.Flags);
+            WriteLong(writer, request.MsVersion);
+            Write(writer, request.IncludeDirs);
+            Write(writer, request.FrameworkDirs);
+            Write(writer, request.VfsOverlayFiles);
+            WriteUTF(writer, request.ModuleName);
+            WriteUTF(writer, request.Predefines);
+            Write(writer, request.Macros);
+            WriteUTF(writer, request.TargetTriple);
+            WriteUTF(writer, request.File);
+            WriteUTF(writer, "END");
+        }
+
+        internal /* for testing */ static void WriteLong(BinaryWriter writer, long l)
+        {
+            // Big endian conversion
+            byte[] temp = BitConverter.GetBytes(l);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(temp);
+            }
+            writer.Write(temp);
+        }
+
+        internal /* for testing */ static void WriteInt(BinaryWriter writer, int i)
+        {
+            // Big endian conversion
+            byte[] temp = BitConverter.GetBytes(i);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(temp);
+            }
+            writer.Write(temp);
+        }
+
+        internal /* for testing */ static void WriteUShort(BinaryWriter writer, ushort s)
+        {
+            // Big endian conversion
+            byte[] temp = BitConverter.GetBytes(s);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(temp);
+            }
+            writer.Write(temp);
+        }
+
+        private static void Write(BinaryWriter writer, string[] strings)
+        {
+            WriteInt(writer, strings.Length);
+            foreach (string value in strings)
+            {
+                WriteUTF(writer, value);
+            }
+        }
+
+        internal /* for testing */ static void WriteUTF(BinaryWriter writer, string str)
+        {
+            foreach (char c in str)
+            {
+                if (Char.IsSurrogate(c))
+                {
+                    throw new InvalidOperationException("Surrogate characters are not supported");
+                }
+                if (c == '\0')
+                {
+                    throw new InvalidOperationException("NUL character is not supported");
+                }
+            }
+            byte[] bytes = Encoding.UTF8.GetBytes(str);
+            if (bytes.Length > ushort.MaxValue)
+            {
+                throw new InvalidOperationException($"String size is too big to be serialized: {bytes.Length}");
+            }
+            WriteUShort(writer, (ushort)bytes.Length);
+            writer.Write(bytes);
+        }
+        internal /* for testing */ static string ReadUTF(BinaryReader reader)
+        {
+            ushort size = ReadUShort(reader);
+            return Encoding.UTF8.GetString(reader.ReadBytes(size));
+        }
+
+        internal /* for testing */ static int ReadInt(BinaryReader reader)
+        {
+            // Big endian conversion
+            byte[] temp = reader.ReadBytes(4);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(temp);
+            }
+            return BitConverter.ToInt32(temp, 0);
+        }
+
+        internal /* for testing */ static ushort ReadUShort(BinaryReader reader)
+        {
+            // Big endian conversion
+            byte[] temp = reader.ReadBytes(2);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(temp);
+            }
+            return BitConverter.ToUInt16(temp, 0);
+        }
+
+        /**
+           * This method does not close the provided stream.
+           */
+        public static Response Read(BinaryReader reader)
+        {
+
+            if ("OUT" != ReadUTF(reader))
+            {
+                throw new InvalidDataException("Communication issue with the C/C++ analyzer: OUT expected");
+            }
+
+            Message[] messages = new Message[ReadInt(reader)];
+            for (int i = 0; i < messages.Length; i++)
+            {
+                string ruleKey = ReadUTF(reader);
+                string filename = ReadUTF(reader);
+                int line = ReadInt(reader);
+                int column = ReadInt(reader);
+                int endLine = ReadInt(reader);
+                int endColumn = ReadInt(reader);
+                // Skip remediation cost
+                ReadInt(reader);
+                string text = ReadUTF(reader);
+                bool partsMakeFlow = reader.ReadBoolean();
+                MessagePart[] parts = ReadMessageParts(reader);
+                messages[i] = new Message(ruleKey, filename, line, column, endLine, endColumn, text, partsMakeFlow, parts);
+            }
+            // Skip measures
+            int nbMeasures = ReadInt(reader);
+            for (int i = 0; i < nbMeasures; i++)
+            {
+                /* filename */
+                ReadUTF(reader);
+                /* classes */
+                ReadInt(reader);
+                /* functions */
+                ReadInt(reader);
+                /* statements */
+                ReadInt(reader);
+                /* complexity */
+                ReadInt(reader);
+                /* cognitiveComplexity */
+                ReadInt(reader);
+                /* exec lines */
+                reader.ReadBytes(ReadInt(reader));
+            }
+
+            // Skip symbols
+            int nbSymbols = ReadInt(reader);
+            for (int i = 0; i < nbSymbols; i++)
+            {
+                int nbSymbolRefs = ReadInt(reader);
+                for (int j = 0; j < nbSymbolRefs; j++)
+                {
+                    /* line */
+                    ReadInt(reader);
+                    /* column */
+                    ReadInt(reader);
+                    /* endLine */
+                    ReadInt(reader);
+                    /* endColumn */
+                    ReadInt(reader);
+                }
+            }
+
+            if ("END" != ReadUTF(reader))
+            {
+                throw new InvalidDataException("Communication issue with the C/C++ analyzer: END expected");
+            }
+
+            return new Response(messages);
+        }
+
+        private static MessagePart[] ReadMessageParts(BinaryReader reader)
+        {
+            int partsCount = ReadInt(reader);
+            if (partsCount == 0)
+            {
+                return Array.Empty<MessagePart>();
+            }
+            MessagePart[] parts = new MessagePart[partsCount];
+            for (int j = 0; j < parts.Length; j++)
+            {
+                parts[j] = new MessagePart(
+                  /* filename= */ ReadUTF(reader),
+                  /* line= */ ReadInt(reader),
+                  /* column= */ ReadInt(reader),
+                  /* endLine= */ ReadInt(reader),
+                  /* endColumn= */ ReadInt(reader),
+                  /* text= */ ReadUTF(reader));
+            }
+            return parts;
+        }
+    }
+}


### PR DESCRIPTION
New PR limited to the protocol. This time I have implemented the (hopefully) correct encoding for numbers, and a good enough implementation for strings (we could fix NUL and supplementary characters if needed, assuming it is properly handled on C++ side).