### PR TITLE
Fix generation of /Yc /Yu compiler arguments

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/CFamilyTest.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/CFamilyTest.cs
@@ -44,6 +44,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 PreprocessorDefinitions = "D1;D2;",
                 UndefinePreprocessorDefinitions = "U1;U2;",
                 ForcedIncludeFiles = "h1;h2;",
+                PrecompiledHeader = "",
                 CompileAs = "Default",
                 CompileAsManaged = "",
                 RuntimeLibrary = "MultiThreaded",
@@ -91,6 +92,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 PreprocessorDefinitions = "",
                 UndefinePreprocessorDefinitions = "",
                 ForcedIncludeFiles = "",
+                PrecompiledHeader = "Use",
                 PrecompiledHeaderFile = "stdafx.h",
                 UndefineAllPreprocessorDefinitions = "true",
                 IgnoreStandardIncludePath = "true",
@@ -117,7 +119,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             c.Cmd.Should().Equal(new [] {
                 "cl.exe",
                 "/X",
-                "/Yu", "stdafx.h",
+                "/Yustdafx.h",
                 "/u",
                 "/TP",
                 "/clr",
@@ -273,6 +275,20 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             Action action = () => CFamily.FileConfig.ConvertBasicRuntimeChecks("foo");
             action.Should().ThrowExactly<ArgumentException>().And.Message.Should().StartWith("Unsupported BasicRuntimeChecks: foo");
+        }
+
+        [TestMethod]
+        public void PrecompiledHeader()
+        {
+            // https://github.com/SonarSource/sonarlint-visualstudio/issues/738
+            CFamily.FileConfig.ConvertPrecompiledHeader("", "stdafx.h").Should().Be("");
+            CFamily.FileConfig.ConvertPrecompiledHeader("Use", "stdafx.h").Should().Be("/Yustdafx.h");
+            CFamily.FileConfig.ConvertPrecompiledHeader("Create", "stdafx.h").Should().Be("/Ycstdafx.h");
+            CFamily.FileConfig.ConvertPrecompiledHeader("Use", "").Should().Be("/Yu");
+            CFamily.FileConfig.ConvertPrecompiledHeader("Create", "").Should().Be("/Yc");
+
+            Action action = () => CFamily.FileConfig.ConvertPrecompiledHeader("foo", "");
+            action.Should().ThrowExactly<ArgumentException>().And.Message.Should().StartWith("Unsupported PrecompiledHeader: foo");
         }
 
         [TestMethod]

--- a/src/Integration.Vsix/SonarLintDaemon/CFamily.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/CFamily.cs
@@ -105,7 +105,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                     // the next line will throw if the file is not part of a solution
                     projectItem.ConfigurationManager.ActiveConfiguration != null;
             }
-            catch(Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+            catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
                 // Suppress non-critical exceptions
             }
@@ -143,6 +143,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                     UndefinePreprocessorDefinitions = GetEvaluatedPropertyValue(fileTool, "UndefinePreprocessorDefinitions"),
 
                     ForcedIncludeFiles = GetEvaluatedPropertyValue(fileTool, "ForcedIncludeFiles"),
+                    PrecompiledHeader = GetEvaluatedPropertyValue(fileTool, "PrecompiledHeader"),
                     PrecompiledHeaderFile = GetEvaluatedPropertyValue(fileTool, "PrecompiledHeaderFile"),
 
                     CompileAs = GetEvaluatedPropertyValue(fileTool, "CompileAs"),
@@ -205,6 +206,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
             public string ForcedIncludeFiles { get; set; }
 
+            public string PrecompiledHeader { get; set; }
+
             public string PrecompiledHeaderFile { get; set; }
 
             public string CompileAs { get; set; }
@@ -259,7 +262,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 Add(c.Cmd, "true".Equals(IgnoreStandardIncludePath) ? "/X" : "");
                 AddRange(c.Cmd, "/I", AdditionalIncludeDirectories.Split(';'));
                 AddRange(c.Cmd, "/FI", ForcedIncludeFiles.Split(';'));
-                Add(c.Cmd, "/Yu", PrecompiledHeaderFile);
+                Add(c.Cmd, ConvertPrecompiledHeader(PrecompiledHeader, PrecompiledHeaderFile));
 
                 Add(c.Cmd, "true".Equals(UndefineAllPreprocessorDefinitions) ? "/u" : "");
                 AddRange(c.Cmd, "/D", PreprocessorDefinitions.Split(';'));
@@ -465,6 +468,21 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                         return "/RTCu";
                     case "EnableFastChecks":
                         return "/RTC1";
+                }
+            }
+
+            internal static string ConvertPrecompiledHeader(string value, string header)
+            {
+                switch (value)
+                {
+                    default:
+                        throw new ArgumentException($"Unsupported PrecompiledHeader: {value}", nameof(value));
+                    case "": // https://github.com/SonarSource/sonarlint-visualstudio/issues/738
+                        return "";
+                    case "Create":
+                        return "/Yc" + header;
+                    case "Use":
+                        return "/Yu" + header;
                 }
             }
         }


### PR DESCRIPTION
The previous implementation was always adding `/Yu` or `/Yu <name of header.h>` while in fact there is another property to check. Also there should be no space between the argument and the file name (checked in VS UI, and also this is what is expected by the [MsvcDriver](https://github.com/SonarSource/sonar-cpp/blob/f2f07b7c78f9b766942427117550f7a4cbb9c9c0/sonar-cfamily-plugin/src/main/java/com/sonar/cpp/analyzer/MsvcDriver.java#L171)).