### PR TITLE
Introduced IAnalyzerController to break direct dependency on ISonarLintDaemon

### DIFF
--- a/src/Integration.Vsix/InternalsVisibleTo.cs
+++ b/src/Integration.Vsix/InternalsVisibleTo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarLint for Visual Studio
  * Copyright (C) 2016-2018 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -23,7 +23,14 @@ using System.Runtime.CompilerServices;
 #if SignAssembly
 [assembly: InternalsVisibleTo("SonarLint.VisualStudio.Integration.Vsix.UnitTests,PublicKey=002400000480000094000000060200000024000052534131000400000100010081b4345a022cc0f4b42bdc795a5a7a1623c1e58dc2246645d751ad41ba98f2749dc5c4e0da3a9e09febcb2cd5b088a0f041f8ac24b20e736d8ae523061733782f9c4cd75b44f17a63714aced0b29a59cd1ce58d8e10ccdb6012c7098c39871043b7241ac4ab9f6b34f183db716082cd57c1ff648135bece256357ba735e67dc6")]
 [assembly: InternalsVisibleTo("SonarLint.VisualStudio.Integration.TestInfrastructure,PublicKey=002400000480000094000000060200000024000052534131000400000100010081b4345a022cc0f4b42bdc795a5a7a1623c1e58dc2246645d751ad41ba98f2749dc5c4e0da3a9e09febcb2cd5b088a0f041f8ac24b20e736d8ae523061733782f9c4cd75b44f17a63714aced0b29a59cd1ce58d8e10ccdb6012c7098c39871043b7241ac4ab9f6b34f183db716082cd57c1ff648135bece256357ba735e67dc6")]
+
+// Moq -- see https://github.com/Moq/moq4/wiki/Quickstart
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+
 #else
 [assembly: InternalsVisibleTo("SonarLint.VisualStudio.Integration.Vsix.UnitTests")]
 [assembly: InternalsVisibleTo("SonarLint.VisualStudio.Integration.TestInfrastructure")]
+
+// Moq
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 #endif

--- a/src/Integration.Vsix/SonarLintDaemon/IAnalyzerController.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/IAnalyzerController.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using EnvDTE;
+using SonarLint.VisualStudio.Integration.Vsix.CFamily;
+
+namespace SonarLint.VisualStudio.Integration.Vsix
+{
+    internal interface IAnalyzerController
+    {
+        bool IsAnalysisSupported(IEnumerable<SonarLanguage> languages);
+
+        void RequestAnalysis(string path, string charset, IEnumerable<SonarLanguage> detectedLanguages, IIssueConsumer consumer, ProjectItem projectItem);
+    }
+
+    [Export(typeof(IAnalyzerController))]
+    internal class AnalyzerController : IAnalyzerController
+    {
+        private readonly ISonarLintSettings settings;
+        private readonly ISonarLintDaemon daemon;
+        private readonly ILogger logger;
+
+        [ImportingConstructor]
+        public AnalyzerController(
+            ISonarLintSettings settings,
+            ISonarLintDaemon daemon,
+            ILogger logger
+            )
+        {
+            this.settings = settings;
+            this.daemon = daemon;
+            this.logger = logger;
+        }
+
+        public bool IsAnalysisSupported(IEnumerable<SonarLanguage> languages)
+        {
+            if (languages.Contains(SonarLanguage.CFamily))
+            {
+                return true;
+            }
+            
+            // TODO: this method is called when deciding whether to create a tagger.
+            // If support for additional languages is not active when the user opens a document
+            // then we won't create a tagger. If the user then activates support for additional
+            // languages and saves the file, we won't display any issues because there isn't a
+            // tagger. The user will have to close and re-open the file to see issues.
+            // Is this the behaviour we want, or should we return true here if the language
+            // is supported, and then check whether to analyze when RequestAnalysis is called?
+            bool isSupported = (languages.Contains(SonarLanguage.Javascript) &&
+                settings.IsActivateMoreEnabled);
+            return isSupported;
+        }
+
+        public void RequestAnalysis(string path, string charset, IEnumerable<SonarLanguage> detectedLanguages, IIssueConsumer consumer, ProjectItem projectItem)
+        {
+            bool handled = false;
+            foreach (var language in detectedLanguages)
+            {
+                switch (language)
+                {
+                    case SonarLanguage.Javascript:
+                        handled = true;
+                        if (settings.IsActivateMoreEnabled)
+                        {
+                            // User might have disable additional languages in the meantime
+                            break;
+                        }
+
+                        if (!daemon.IsRunning) // daemon might not have finished starting / might have shutdown
+                        {
+                            logger.WriteLine("Daemon has not started yet. Analysis will not be performed");
+                            break;
+                        }
+
+                        daemon.RequestAnalysis(path, charset, "js", consumer);
+                        break;
+
+                    case SonarLanguage.CFamily:
+                        handled = true;
+                        CFamilyHelper.ProcessFile(new ProcessRunner(logger), consumer, logger, projectItem, path, charset);
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            if (!handled)
+            {
+                logger.WriteLine($"Unsupported content type for {path}");
+            }
+        }
+
+    }
+
+}

--- a/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
@@ -31,7 +31,6 @@ using System.Text.RegularExpressions;
 using Grpc.Core;
 using Microsoft.VisualStudio;
 using Sonarlint;
-using SonarLint.VisualStudio.Integration.Vsix.CFamily;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
 
 namespace SonarLint.VisualStudio.Integration.Vsix


### PR DESCRIPTION
Fixed up existing unit tests

Note: C++ analysis no longer requires additional language support to be enabled

I'm trying to break the refactorings into small pieces so they can still be reviewed. I'm not worrying at the moment about the code coverage; there's no point in additional unit tests to cover code that is still changing.