### PR TITLE
Set default issue severity and type

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/RulesMetadataCacheTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/RulesMetadataCacheTest.cs
@@ -59,8 +59,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
             RulesMetadataCache.Instance.RulesMetadata.TryGetValue("ClassComplexity", out metadata);
             using (new AssertionScope())
             {
-                metadata.Type.Should().Be(RuleType.CodeSmell);
-                metadata.DefaultSeverity.Should().Be(RuleSeverity.Critical);
+                metadata.Type.Should().Be(Sonarlint.Issue.Types.Type.CodeSmell);
+                metadata.DefaultSeverity.Should().Be(Sonarlint.Issue.Types.Severity.Critical);
             }
         }
     }

--- a/src/Integration.Vsix.UnitTests/Integration.Vsix.UnitTests.csproj
+++ b/src/Integration.Vsix.UnitTests/Integration.Vsix.UnitTests.csproj
@@ -186,6 +186,10 @@
     <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="SonarAnalyzer">

--- a/src/Integration.Vsix.UnitTests/packages.config
+++ b/src/Integration.Vsix.UnitTests/packages.config
@@ -37,6 +37,7 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net46" />
   <package id="Moq" version="4.10.1" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net46" />
   <package id="stdole" version="7.0.3300" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
... rather than using hard-coded values.
Fixes #969

Two commits: the first removes duplicate severity/type enums (one from the proto buf, the other defined in the SLVS).