### PR TITLE
Added ref to Microsoft.VSSDK.BuildTools NuGet package

### DIFF
--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -32,7 +32,7 @@
          To achieve this, this project conditionally imports different VSIX manifests based on the version of VS being
          used to build the project/solution.
   -->
-
+  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <!-- Hack to prevent VS2017 from automatically attempting to upgrade the project -->
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
@@ -652,6 +652,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Grpc.Core.1.4.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Grpc.Core.1.4.1\build\net45\Grpc.Core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
   <Target Name="IncludeDllsVsix" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -669,4 +671,5 @@
     <Message Importance="high" Text="Generating protobuf classes..." />
     <Exec WorkingDirectory="$(ProjectDir)Protobuf" Command="build.bat" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.16.2.3073\build\Microsoft.VSSDK.BuildTools.targets')" />
 </Project>

--- a/src/Integration.Vsix/packages.config
+++ b/src/Integration.Vsix/packages.config
@@ -42,6 +42,7 @@
   <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net46" />
+  <package id="Microsoft.VSSDK.BuildTools" version="16.2.3073" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VSSDK.Vsixsigntool" version="15.0.26201" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net46" />
   <package id="SonarAnalyzer.CSharp" version="6.7.1.4347" targetFramework="net46" developmentDependency="true" />


### PR DESCRIPTION
* build tested in VS2017, VS2019 and VS2019 Prview (v16.3.0 Preview 1).

The build had started failing in v16.3.0 Preview 1 and adding this ref fixed it (although I'm not sure how it was working before in other vrsions of VS without this reference...)