### PR TITLE
Changed C-family rules config to be language-specific

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTest.cs
@@ -422,7 +422,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
         [TestMethod]
         public void GetKeyValueOptionsList_UsingEmbeddedRulesJson()
         {
-            var options = CFamilyHelper.GetKeyValueOptionsList(RulesMetadataCache.Instance);
+            var options = CFamilyHelper.GetKeyValueOptionsList(RulesMetadataCache.GetSettings("cpp"));
 
             // QP option
             CheckHasOption("internal.qualityProfile=");

--- a/src/Integration.Vsix.UnitTests/CFamily/RulesMetadataCacheTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/RulesMetadataCacheTest.cs
@@ -61,11 +61,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
 
             // We don't currently support ObjC rules in VS
             RulesMetadataCache.GetSettings("objc").Should().BeNull();
-        }
-
-        private static IEnumerable<string> GetRulesByLanguage(IEnumerable<string> ruleKeys, string language) =>
-            ruleKeys.Where(key => key.StartsWith(language.ToLowerInvariant() + ":"));
-        
+        }        
 
         [TestMethod]
         public void Read_Rules_Params()

--- a/src/Integration.Vsix/CFamily/CFamilyHelper.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyHelper.cs
@@ -67,7 +67,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
                 return null;
             }
 
-            request.Options = GetKeyValueOptionsList(RulesMetadataCache.Instance);
+            request.Options = GetKeyValueOptionsList(RulesMetadataCache.GetSettings(request.CFamilyLanguage));
             return request;
         }
 

--- a/src/Integration.Vsix/CFamily/CLangAnalyzer.cs
+++ b/src/Integration.Vsix/CFamily/CLangAnalyzer.cs
@@ -86,8 +86,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
             if (response != null)
             {
                 Debug.Assert(response.Messages.All(m => m.Filename == request.File), "Issue for unexpected file returned");
+                var rulesConfig = RulesMetadataCache.GetSettings(request.CFamilyLanguage);
                 var issues = response.Messages
-                        .Select(m => CFamilyHelper.ToSonarLintIssue(m, request.CFamilyLanguage, RulesMetadataCache.Instance))
+                        .Select(m => CFamilyHelper.ToSonarLintIssue(m, request.CFamilyLanguage, rulesConfig))
                         .ToList();
 
                 telemetryManager.LanguageAnalyzed(request.CFamilyLanguage); // different keys for C and C++

--- a/src/Integration.Vsix/CFamily/RulesLoader.cs
+++ b/src/Integration.Vsix/CFamily/RulesLoader.cs
@@ -121,6 +121,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
             [JsonProperty("defaultSeverity")]
             public Sonarlint.Issue.Types.Severity DefaultSeverity { get; set; }
 
+            [JsonProperty("compatibleLanguages")]
+            public string[] CompatibleLanguages { get; set; }
         }
 
         /// <summary>

--- a/src/Integration.Vsix/CFamily/RulesMetadataCache.cs
+++ b/src/Integration.Vsix/CFamily/RulesMetadataCache.cs
@@ -75,7 +75,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
 
             public SingleLanguageRulesConfiguration(string cFamilyLanguage)
             {
-                var ruleKeysForLanguage = AllLanguagesRulesMetadata.Where(kvp => kvp.Value.CompatibleLanguages.Contains(cFamilyLanguage, RuleKeyComparer))
+                var ruleKeysForLanguage = AllLanguagesRulesMetadata
+                    .Where(kvp => kvp.Value.CompatibleLanguages.Contains(cFamilyLanguage, RuleKeyComparer))
                     .Select(kvp => kvp.Key)
                     .ToArray();
 

--- a/src/Integration.Vsix/CFamily/RulesMetadataCache.cs
+++ b/src/Integration.Vsix/CFamily/RulesMetadataCache.cs
@@ -36,27 +36,68 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
         IDictionary<string, RuleMetadata> RulesMetadata { get; }
     }
 
-    internal sealed class RulesMetadataCache : IRulesConfiguration
+    internal sealed class RulesMetadataCache
     {
-        private static readonly Lazy<RulesMetadataCache> lazy = new Lazy<RulesMetadataCache>(() => new RulesMetadataCache());
+        private static IEnumerable<string> AllLanguagesAllRuleKeys { get; }
+        private static IEnumerable<string> AllLanguagesActiveRuleKeys { get; }
+        private static IDictionary<string, RuleMetadata> AllLanguagesRulesMetadata { get; }
+        private static IDictionary<string, IDictionary<string, string>> AllLanguagesRulesParameters { get; }
 
-        public static IRulesConfiguration Instance { get { return lazy.Value; } }
+        private static IDictionary<string, IRulesConfiguration> RulesByLanguage { get; }
 
-        public IEnumerable<string> AllRuleKeys { get; }
-        public IEnumerable<string> ActiveRuleKeys { get; }
-
-        public IDictionary<string, IDictionary<string, string>> RulesParameters { get; }
-
-        public IDictionary<string, RuleMetadata> RulesMetadata { get; }
-
-        private RulesMetadataCache()
+        public static IRulesConfiguration GetSettings(string cFamilyLanguage)
         {
-            AllRuleKeys = RulesLoader.ReadRulesList();
-            ActiveRuleKeys = RulesLoader.ReadActiveRulesList();
-            RulesParameters = AllRuleKeys
-                .ToDictionary(key => key, key => RulesLoader.ReadRuleParams(key));
-            RulesMetadata = AllRuleKeys
-                .ToDictionary(key => key, key => RulesLoader.ReadRuleMetadata(key));
+            RulesByLanguage.TryGetValue(cFamilyLanguage, out var rulesConfiguration);
+            return rulesConfiguration;
         }
+
+        static RulesMetadataCache()
+        {
+            // Read all rules/metadata, irrespective of language. Stored in
+            // statics so we don't re-read the files for each language
+            AllLanguagesAllRuleKeys = RulesLoader.ReadRulesList();
+            AllLanguagesActiveRuleKeys = RulesLoader.ReadActiveRulesList();
+            AllLanguagesRulesParameters = AllLanguagesAllRuleKeys
+                .ToDictionary(key => key, key => RulesLoader.ReadRuleParams(key));
+            AllLanguagesRulesMetadata = AllLanguagesAllRuleKeys
+                .ToDictionary(key => key, key => RulesLoader.ReadRuleMetadata(key));
+
+            RulesByLanguage = new Dictionary<string, IRulesConfiguration>
+            {
+                { SonarLanguageKeys.CPlusPlus,  new SingleLanguageRulesConfiguration(SonarLanguageKeys.CPlusPlus)},
+                { SonarLanguageKeys.C, new SingleLanguageRulesConfiguration(SonarLanguageKeys.C)}
+            };
+        }
+
+        private class SingleLanguageRulesConfiguration : IRulesConfiguration
+        {
+            private static StringComparer RuleKeyComparer = StringComparer.OrdinalIgnoreCase;
+
+            public SingleLanguageRulesConfiguration(string cFamilyLanguage)
+            {
+                var ruleKeysForLanguage = AllLanguagesRulesMetadata.Where(kvp => kvp.Value.CompatibleLanguages.Contains(cFamilyLanguage, RuleKeyComparer))
+                    .Select(kvp => kvp.Key)
+                    .ToArray();
+
+                AllRuleKeys = ruleKeysForLanguage;
+                ActiveRuleKeys = AllLanguagesActiveRuleKeys
+                    .Intersect(ruleKeysForLanguage, RuleKeyComparer)
+                    .ToArray();
+
+                RulesParameters = ruleKeysForLanguage
+                    .ToDictionary(key => key, key => AllLanguagesRulesParameters[key]);
+                RulesMetadata = ruleKeysForLanguage
+                    .ToDictionary(key => key, key => AllLanguagesRulesMetadata[key]);
+            }
+
+            public IEnumerable<string> AllRuleKeys { get; }
+
+            public IEnumerable<string> ActiveRuleKeys { get; }
+
+            public IDictionary<string, IDictionary<string, string>> RulesParameters { get; }
+
+            public IDictionary<string, RuleMetadata> RulesMetadata { get; }
+        }
+
     }
 }


### PR DESCRIPTION
Not all C-Family rules apply to all C-Family languages (C, C++, ObjC). SLVS detects whether the code being analysed is C or C++, but previously it passed the same rules configuration to `subprocess.exe` regardless.

This change means that the configuration passed to `subprocess.exe` is now language-specific.