### PR TITLE
Re-ordered the Options UI to put static elements first

### DIFF
--- a/src/Integration.Vsix/Settings/GeneralOptionsDialogControl.xaml
+++ b/src/Integration.Vsix/Settings/GeneralOptionsDialogControl.xaml
@@ -23,45 +23,48 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
-        <Button Grid.Column="0" Grid.Row="0" Content="Activate more..." Click="OnActivateMoreClicked"
-                x:Name="ActivateButton"
+        <Button Grid.Column="0" Grid.Row="0" Content="Open user settings"
+                x:Name="OpenSettingsButton"
                 Margin="5" Padding="5,2.5" />
         <TextBlock Grid.Column="1" Grid.Row="0"
+                   Text="Open the per-user settings file."
+                   VerticalAlignment="Center"
+                   Margin="5"
+                   TextWrapping="Wrap" />
+        <TextBlock Grid.Column="1" Grid.Row="1"
+                   VerticalAlignment="Center"
+                   Margin="5,0,0,5" TextWrapping="Wrap" >
+            <Run>The file will be created if it does not exist.</Run>
+            <LineBreak />
+            <Run>Note: currently only the C-Family analysis rules use the per-user settings file.</Run>
+        </TextBlock>
+
+        <Button Grid.Column="0" Grid.Row="2" Content="Activate more..." Click="OnActivateMoreClicked"
+                x:Name="ActivateButton"
+                Margin="5,25,5,5" Padding="5,2.5" />
+        <TextBlock Grid.Column="1" Grid.Row="2"
                    x:Name="ActivateText"
                    Text="Install and activate support for JavaScript."
                    VerticalAlignment="Center"
-                   Margin="5" TextWrapping="Wrap"/>
+                   Margin="5,25,5,5" TextWrapping="Wrap"/>
 
-        <Button Grid.Column="0" Grid.Row="0" Content="Deactivate" Click="OnDeactivateClicked"
+        <Button Grid.Column="0" Grid.Row="2" Content="Deactivate" Click="OnDeactivateClicked"
                 x:Name="DeactivateButton" Visibility="Collapsed"
-                Margin="5" Padding="5,2.5" />
-        <TextBlock Grid.Column="1" Grid.Row="0"
+                Margin="5,25,5,5" Padding="5,2.5" />
+        <TextBlock Grid.Column="1" Grid.Row="2"
                    x:Name="DeactivateText" Visibility="Collapsed"
                    Text="Deactivate JavaScript support."
                    VerticalAlignment="Center"
-                   Margin="5" TextWrapping="Wrap"/>
+                   Margin="5,25,5,5" TextWrapping="Wrap"/>
 
-        <Button Grid.Column="0" Grid.Row="3" Content="Open user settings"
-                x:Name="OpenSettingsButton"
-                Margin="5,25,5,5" Padding="5,2.5" />
-        <TextBlock Grid.Column="1" Grid.Row="3"
-                   Text="Open the per-user settings file."
-                   VerticalAlignment="Center"
-                   Margin="5,25,5,5"
-                   TextWrapping="Wrap" />
         <TextBlock Grid.Column="1" Grid.Row="4"
-                   Text="The file will be created if it does not exist."
-                   VerticalAlignment="Center"
-                   Margin="5,0,0,5" TextWrapping="Wrap" />
-        
-        <TextBlock Grid.Column="1" Grid.Row="1"
                    Text="SonarLint can also analyze JavaScript files. After installing the support for this language, it will be activated for newly opened files. Note that it doesn't benefit from the connected mode for now."
                    Margin="5" TextWrapping="Wrap" />
 
-        <StackPanel x:Name="VerbosityPanel" Grid.Row="5" Grid.ColumnSpan="2">
+        <StackPanel x:Name="VerbosityPanel" Grid.Row="6" Grid.ColumnSpan="2">
 
             <TextBlock Text="SonarLint output verbosity for the analysis of additional languages:"
-                       Margin="5,25,5,5" TextWrapping="Wrap" />
+                       Margin="5" TextWrapping="Wrap" />
 
             <ComboBox x:Name="DaemonVerbosity" SelectedIndex="2" HorizontalContentAlignment="Stretch" Margin="5" Padding="5,2.5"/>
         </StackPanel>


### PR DESCRIPTION
* moved "open settings" to the top - it never changes.
* the "additional languages" elements are shown/hidden and change text. Now all appear last -> less visually jarring when they change.