### PR TITLE
Modify build to include version in VSIX name

### DIFF
--- a/build/ChangeVersion.proj
+++ b/build/ChangeVersion.proj
@@ -4,6 +4,18 @@
   <Import Project="$(MSBuildProjectDirectory)\RegexTransform.tasks" />
   <PropertyGroup>
     <SolutionRoot>$(MSBuildProjectDirectory)\..</SolutionRoot>
+	
+	<!-- Properties set by the CI build pipeline -->
+    <BuildNumber>0</BuildNumber>
+    <Sha1>not-set</Sha1>
+    <BranchName>not-set</BranchName>
+    <BuildConfiguration>not-set</BuildConfiguration>
+    <!-- Calculated properties -->
+    <FullVersion>$(MainVersion).$(BuildNumber)</FullVersion>
+    <AssemblyVersion>$(MainVersion)</AssemblyVersion>
+    <AssemblyFileVersion>$(FullVersion)</AssemblyFileVersion>
+    <AssemblyInformationalVersion>Version:$(FullVersion) Branch:$(BranchName) Sha1:$(Sha1) Configuration:$(BuildConfiguration)</AssemblyInformationalVersion>
+    <VsixVersion>$(FullVersion)</VsixVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/ChangeVersion.proj
+++ b/build/ChangeVersion.proj
@@ -5,33 +5,26 @@
   <PropertyGroup>
     <SolutionRoot>$(MSBuildProjectDirectory)\..</SolutionRoot>
 	
-	<!-- Properties set by the CI build pipeline -->
-    <BuildNumber>0</BuildNumber>
-    <Sha1>not-set</Sha1>
-    <BranchName>not-set</BranchName>
-    <BuildConfiguration>not-set</BuildConfiguration>
-    <!-- Calculated properties -->
-    <FullVersion>$(MainVersion).$(BuildNumber)</FullVersion>
-    <AssemblyVersion>$(MainVersion)</AssemblyVersion>
-    <AssemblyFileVersion>$(FullVersion)</AssemblyFileVersion>
-    <AssemblyInformationalVersion>Version:$(FullVersion) Branch:$(BranchName) Sha1:$(Sha1) Configuration:$(BuildConfiguration)</AssemblyInformationalVersion>
-    <VsixVersion>$(FullVersion)</VsixVersion>
+    <!-- Other calculated properties used only in RegEx transforms -->
+    <RegExAssemblyVersion>$(MainVersion)</RegExAssemblyVersion>
+    <RegExAssemblyFileVersion>$(FullVersion)</RegExAssemblyFileVersion>
+    <RegExAssemblyInformationalVersion>Version:$(FullVersion) Branch:$(BranchName) Sha1:$(Sha1) Configuration:$(BuildConfiguration)</RegExAssemblyInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <AssemblyVersion Include="$(SolutionRoot)\src\AssemblyInfo.Shared.cs">
       <Find>(?&lt;=\[assembly\: AssemblyVersion\(")([^"]*)</Find>
-      <ReplaceWith>$(AssemblyVersion)</ReplaceWith>
+      <ReplaceWith>$(RegExAssemblyVersion)</ReplaceWith>
       <ExpectedMatchCount>1</ExpectedMatchCount>
     </AssemblyVersion>
     <AssemblyFileVersion Include="$(SolutionRoot)\src\AssemblyInfo.Shared.cs">
       <Find>(?&lt;=\[assembly\: AssemblyFileVersion\(")([^"]*)</Find>
-      <ReplaceWith>$(AssemblyFileVersion)</ReplaceWith>
+      <ReplaceWith>$(RegExAssemblyFileVersion)</ReplaceWith>
       <ExpectedMatchCount>1</ExpectedMatchCount>
     </AssemblyFileVersion>
     <AssemblyInformationalVersion Include="$(SolutionRoot)\src\AssemblyInfo.Shared.cs">
       <Find>(?&lt;=\[assembly\: AssemblyInformationalVersion\(")([^"]*)</Find>
-      <ReplaceWith>$(AssemblyInformationalVersion)</ReplaceWith>
+      <ReplaceWith>$(RegExAssemblyInformationalVersion)</ReplaceWith>
       <ExpectedMatchCount>1</ExpectedMatchCount>
     </AssemblyInformationalVersion>
 
@@ -43,7 +36,7 @@
 
     <VsPackageVersion Include="$(SolutionRoot)\src\Integration.Vsix\SonarLintIntegrationPackage.cs">
       <Find>(?&lt;=\[InstalledProductRegistration\("#110", "#112", ")([^"]*)</Find>
-      <ReplaceWith>$(AssemblyFileVersion)</ReplaceWith>
+      <ReplaceWith>$(RegExAssemblyFileVersion)</ReplaceWith>
       <ExpectedMatchCount>1</ExpectedMatchCount>
     </VsPackageVersion>
   </ItemGroup>

--- a/build/Version.props
+++ b/build/Version.props
@@ -5,5 +5,14 @@
          it builds ChangeVersion.proj. -->
     <MainVersion>4.14.0</MainVersion>
   
+  	<!-- Properties set by the CI build pipeline -->
+    <BuildNumber>0</BuildNumber>
+    <Sha1>not-set</Sha1>
+    <BranchName>not-set</BranchName>
+    <BuildConfiguration>not-set</BuildConfiguration>
+
+    <!-- Calculated properties -->
+    <FullVersion>$(MainVersion).$(BuildNumber)</FullVersion>
+    <VsixVersion>$(FullVersion)</VsixVersion>  
   </PropertyGroup>
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,20 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Manually set the three-part main version and check in the changed file.
-         The other build properties (e.g. Sha1) will be set by the CI build when
+         The other required build properties (e.g. Sha1) will be set by the CI build when
          it builds ChangeVersion.proj. -->
     <MainVersion>4.14.0</MainVersion>
-
-    <!-- Properties set by the CI build pipeline -->
-    <BuildNumber>0</BuildNumber>
-    <Sha1>not-set</Sha1>
-    <BranchName>not-set</BranchName>
-    <BuildConfiguration>not-set</BuildConfiguration>
-    <!-- Calculated properties -->
-    <FullVersion>$(MainVersion).$(BuildNumber)</FullVersion>
-    <AssemblyVersion>$(MainVersion)</AssemblyVersion>
-    <AssemblyFileVersion>$(FullVersion)</AssemblyFileVersion>
-    <AssemblyInformationalVersion>Version:$(FullVersion) Branch:$(BranchName) Sha1:$(Sha1) Configuration:$(BuildConfiguration)</AssemblyInformationalVersion>
-    <VsixVersion>$(FullVersion)</VsixVersion>
+  
   </PropertyGroup>
 </Project>

--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -3,7 +3,7 @@
   <!-- The VSSDK targets need to be imported after the Net.Sdk targets which means we  have to import the
        .NET.Sdk targets using Import rather than specifying it as the Sdk in the Project element. -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  
+
   <!-- Executive summary:
        * to build the VS2017 vsix, build from inside VS2017.
        * to build the VS2019 vsix, build from inside VS2019.
@@ -36,6 +36,8 @@
          To achieve this, this project conditionally imports different VSIX manifests based on the version of VS being
          used to build the project/solution.
   -->
+
+  <Import Project="..\..\build\version.props" />
   
   <PropertyGroup>
     <!-- Hack to prevent VS2017 from automatically attempting to upgrade the project -->
@@ -57,7 +59,8 @@
     <ProjectGuid>{FF2AD819-28F4-493A-8E9B-1D3F16BD4689}</ProjectGuid>
     <RootNamespace>SonarLint.VisualStudio.Integration.Vsix</RootNamespace>
     <AssemblyName>SonarLint.$(VersionSpecificSuffix)</AssemblyName>
- 
+    <TargetVsixContainerName>SonarLint.VSIX-$(VsixVersion)-$(VersionSpecificSuffix).vsix</TargetVsixContainerName>
+    
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
@@ -298,12 +301,12 @@
     <BinariesFolder>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\binaries\))</BinariesFolder>
   </PropertyGroup>
   <ItemGroup>
-    <VSIXesToSign Include="$(BinariesFolder)$(AssemblyName).vsix" />
+    <VSIXesToSign Include="$(BinariesFolder)$(TargetVsixContainerName)" />
   </ItemGroup>
   
-  <Target Name="CopyVsixToBinariesAndSign" AfterTargets="Build" Inputs="$(TargetDir)$(AssemblyName).vsix" Outputs="$(BinariesFolder)$(AssemblyName).vsix">
-    <Message Importance="high" Text="Copying vsix from $(TargetDir)$(AssemblyName).vsix to $(BinariesFolder)$(AssemblyName).vsix" />
-    <Copy OverwriteReadOnlyFiles="true" SourceFiles="$(TargetDir)$(AssemblyName).vsix" DestinationFiles="$(BinariesFolder)$(AssemblyName).vsix" />
+  <Target Name="CopyVsixToBinariesAndSign" AfterTargets="Build" Inputs="$(TargetDir)$(TargetVsixContainerName)" Outputs="$(BinariesFolder)$(TargetVsixContainerName)">
+    <Message Importance="high" Text="Copying vsix from $(TargetDir)$(TargetVsixContainerName) to $(BinariesFolder)$(TargetVsixContainerName)" />
+    <Copy OverwriteReadOnlyFiles="true" SourceFiles="$(TargetDir)$(TargetVsixContainerName)" DestinationFiles="$(BinariesFolder)$(TargetVsixContainerName)" />
 
     <CallTarget Targets="SignVsixesIfPfxSupplied" />
   </Target>


### PR DESCRIPTION
Previously this was done separately in PowerShell in the build pipline.
However, the version properties are available during the build so we can create a VSIX with the expected name here - no need to rename later.