### PR TITLE
Apply CPP-2305 to SonarLint: Properly predefine language version macros

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTest.cs
@@ -294,6 +294,20 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
         }
 
         [TestMethod]
+        public void LanguageStandard()
+        {
+            CFamilyHelper.FileConfig.ConvertLanguageStandard("").Should().Be("");
+            CFamilyHelper.FileConfig.ConvertLanguageStandard("Default").Should().Be("");
+            CFamilyHelper.FileConfig.ConvertLanguageStandard(null).Should().Be("");
+            CFamilyHelper.FileConfig.ConvertLanguageStandard("stdcpplatest").Should().Be("/std:c++latest");
+            CFamilyHelper.FileConfig.ConvertLanguageStandard("stdcpp17").Should().Be("/std:c++17");
+            CFamilyHelper.FileConfig.ConvertLanguageStandard("stdcpp14").Should().Be("/std:c++14");
+
+            Action action = () => CFamilyHelper.FileConfig.ConvertLanguageStandard("foo");
+            action.Should().ThrowExactly<ArgumentException>().And.Message.Should().StartWith("Unsupported LanguageStandard: foo");
+        }
+
+        [TestMethod]
         public void CreateRequest_HeaderFile_IsNotProcessed()
         {
             // Arrange

--- a/src/Integration.Vsix.UnitTests/CFamily/MsvcDriverTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/MsvcDriverTest.cs
@@ -449,6 +449,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
                     Env = new List<string>(),
                     Cmd = new List<string>() {
                       "cl.exe",
+                      "/std:c++14",
                       "/J"
                     },
                 }
@@ -503,12 +504,33 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
                     Cmd = new List<string>() {
                       "cl.exe",
                       "/Za",
+                      "/std:c++17",
                       "c:\\file.cpp"
                     },
                 }
             });
-            req.Flags.Should().Be(Request.CPlusPlus | Request.CPlusPlus11 | Request.CPlusPlus14 | Request.OperatorNames);
+            req.Flags.Should().Be(Request.CPlusPlus | Request.CPlusPlus11 | Request.CPlusPlus14 | Request.CPlusPlus17 | Request.OperatorNames);
             req.File.Should().Be("c:\\file.cpp");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.InvalidOperationException), "'/std:latest' is not supported. This test should throw an exception.")]
+        public void unsupported_std_version()
+        {
+             MsvcDriver.ToRequest(new CFamilyHelper.Capture[] {
+                compiler,
+                new CFamilyHelper.Capture()
+                {
+                    Executable = "",
+                    Cwd = "",
+                    Env = new List<string>(),
+                    Cmd = new List<string>() {
+                    "cl.exe",
+                    "/std:latest",
+                    "/J"
+                    },
+                }
+            });
         }
 
         [TestMethod]

--- a/src/Integration.Vsix/CFamily/FileConfig.cs
+++ b/src/Integration.Vsix/CFamily/FileConfig.cs
@@ -77,6 +77,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
                     OmitDefaultLibName = GetEvaluatedPropertyValue(fileTool, "OmitDefaultLibName"),
                     RuntimeTypeInfo = GetEvaluatedPropertyValue(fileTool, "RuntimeTypeInfo"),
                     BasicRuntimeChecks = GetEvaluatedPropertyValue(fileTool, "BasicRuntimeChecks"),
+                    LanguageStandard = GetEvaluatedPropertyValue(fileTool, "LanguageStandard"),
 
                     AdditionalOptions = GetEvaluatedPropertyValue(fileTool, "AdditionalOptions"),
                 };
@@ -155,6 +156,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
 
             public string AdditionalOptions { get; set; }
 
+            public string LanguageStandard { get; set; }
+            
             #endregion
 
             public Capture[] ToCaptures(string path, out string cfamilyLanguage)
@@ -199,6 +202,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
                 Add(c.Cmd, "true".Equals(OmitDefaultLibName) ? "/Zl" : ""); // defines macro "_VC_NODEFAULTLIB"
                 Add(c.Cmd, "false".Equals(RuntimeTypeInfo) ? "/GR-" : ""); // undefines macro "_CPPRTTI"
                 Add(c.Cmd, ConvertBasicRuntimeChecks(BasicRuntimeChecks));
+                Add(c.Cmd, ConvertLanguageStandard(LanguageStandard));
 
                 // TODO Q: what if it contains space in double quotes?
                 AddRange(c.Cmd, AdditionalOptions.Split(' '));
@@ -401,6 +405,25 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
                         return "/Yc" + header;
                     case "Use":
                         return "/Yu" + header;
+                }
+            }
+
+            internal /* for testing */ static string ConvertLanguageStandard(string value)
+            {
+                switch (value)
+                {
+                    default:
+                        throw new ArgumentException($"Unsupported LanguageStandard: {value}", nameof(value));
+                    case null:
+                    case "":
+                    case "Default":
+                        return "";
+                    case "stdcpplatest":
+                        return "/std:c++latest";
+                    case "stdcpp17":
+                        return "/std:c++17";
+                    case "stdcpp14":
+                        return "/std:c++14";
                 }
             }
         }


### PR DESCRIPTION
Fixes #1106 