### PR TITLE
Added Core project and unit test project

### DIFF
--- a/SonarLint.VisualStudio.Integration.sln
+++ b/SonarLint.VisualStudio.Integration.sln
@@ -43,6 +43,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonarQube.Client", "sonarqu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonarQube.Client.Tests", "sonarqube-webclient\SonarQube.Client.Tests\SonarQube.Client.Tests.csproj", "{2D75E7DA-4DD0-4422-BCAF-D0E5093C74DC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "src\Core\Core.csproj", "{4F379759-6798-4C98-9CDD-31853F8E46DF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.UnitTests", "src\Core.UnitTests\Core.UnitTests.csproj", "{11960170-E82F-4241-B1AA-552F168D11AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +105,14 @@ Global
 		{2D75E7DA-4DD0-4422-BCAF-D0E5093C74DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D75E7DA-4DD0-4422-BCAF-D0E5093C74DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D75E7DA-4DD0-4422-BCAF-D0E5093C74DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F379759-6798-4C98-9CDD-31853F8E46DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F379759-6798-4C98-9CDD-31853F8E46DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F379759-6798-4C98-9CDD-31853F8E46DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F379759-6798-4C98-9CDD-31853F8E46DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11960170-E82F-4241-B1AA-552F168D11AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11960170-E82F-4241-B1AA-552F168D11AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11960170-E82F-4241-B1AA-552F168D11AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11960170-E82F-4241-B1AA-552F168D11AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +125,7 @@ Global
 		{33315FCB-3D07-4177-944E-AA45CC3C5539} = {9CF012C2-0303-4643-A5E2-0A45AFE4DBD5}
 		{115CC746-5181-485C-8707-346E8D55B1E5} = {9CF012C2-0303-4643-A5E2-0A45AFE4DBD5}
 		{2D75E7DA-4DD0-4422-BCAF-D0E5093C74DC} = {9CF012C2-0303-4643-A5E2-0A45AFE4DBD5}
+		{11960170-E82F-4241-B1AA-552F168D11AD} = {9CF012C2-0303-4643-A5E2-0A45AFE4DBD5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DABC27C8-E761-4826-AD2D-056F677EF3C0}

--- a/src/Core.UnitTests/Core.UnitTests.csproj
+++ b/src/Core.UnitTests/Core.UnitTests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+
+    <ProjectGuid>{11960170-E82F-4241-B1AA-552F168D11AD}</ProjectGuid>
+    <RootNamespace>SonarLint.VisualStudio.Core.UnitTests</RootNamespace>
+    <AssemblyName>SonarLint.VisualStudio.Core.UnitTests</AssemblyName>
+
+  </PropertyGroup>
+
+  <ItemGroup Label="Framework references">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  
+  <ItemGroup Label="Test framework">
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- NOTE: this assembly should NOT have any dependencies on Visual Studio assemblies -->
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <ProjectGuid>{4F379759-6798-4C98-9CDD-31853F8E46DF}</ProjectGuid>
+    <RootNamespace>SonarLint.VisualStudio.Core</RootNamespace>
+    <AssemblyName>SonarLint.VisualStudio.Core</AssemblyName>
+        
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sonarqube-webclient\SonarQube.Client\SonarQube.Client.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/src/Core/SonarLanguageKeys.cs
+++ b/src/Core/SonarLanguageKeys.cs
@@ -18,13 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SonarLint.VisualStudio.Integration
+namespace SonarLint.VisualStudio.Core
 {
     /// <summary>
     /// Language keys for languages supported by SonarQube/Cloud plugins

--- a/src/Integration.UnitTests/Telemetry/TelemetryManagerTests.cs
+++ b/src/Integration.UnitTests/Telemetry/TelemetryManagerTests.cs
@@ -24,6 +24,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 
 namespace SonarLint.VisualStudio.Integration.Tests

--- a/src/Integration.Vsix/CFamily/RulesMetadataCache.cs
+++ b/src/Integration.Vsix/CFamily/RulesMetadataCache.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SonarLint.VisualStudio.Core;
 using static SonarLint.VisualStudio.Integration.Vsix.CFamily.RulesLoader;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.CFamily

--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -121,6 +121,7 @@
       <Project>{BA771DF7-9F99-4DE3-B85B-3E5DB742A55C}</Project>
       <Name>SonarQube.Client.2015</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\Integration.TeamExplorer\Integration.TeamExplorer.csproj">
       <Project>{9FCAEACD-EDEA-42D3-A8E4-16E42D1CF8F4}</Project>
       <Name>Integration.TeamExplorer</Name>

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -63,6 +63,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\sonarqube-webclient\SonarQube.Client\SonarQube.Client.csproj" />
+    <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\Progress\Progress.csproj" />
     <ProjectReference Include="..\ProgressVS\ProgressVS.csproj" />
   </ItemGroup>

--- a/src/Integration/Telemetry/TelemetryManager.cs
+++ b/src/Integration/Telemetry/TelemetryManager.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Core;
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;


### PR DESCRIPTION
* moved SonarLanguageKeys constants class to the new assembly
* manually verified that the VSIX contains the new assembly
* manually verified that the new assembly has the expected assembly properties

First steps to separate out the code that depends on VS from the code that doesn't.
Created a new assembly to hold the non-VS code. The intention is to gradually move the non-VS code out of `SonarLint.VisualStudio.Integration.dll` and `SonarLint.VisualStudio.Integration.Vsixdll` as a step towards cleaning up and simplifying the architecture.