### PR TITLE
Removed redundant Language.ForProject method

### DIFF
--- a/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
+++ b/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
@@ -310,7 +310,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             {
                 string solutionRuleSet = rsInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     this.configProvider.ProjectToReturn.ProjectKey,
-                    Language.ForProject(project),
+                    ProjectToLanguageMapper.GetLanguageForProject(project),
                     SonarLintMode.LegacyConnected);
                 this.fileSystem.RegisterFile(solutionRuleSet);
             }

--- a/src/Integration.Vsix/Commands/ProjectExcludePropertyToggleCommand.cs
+++ b/src/Integration.Vsix/Commands/ProjectExcludePropertyToggleCommand.cs
@@ -56,7 +56,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                                           .ToList();
 
             Debug.Assert(projects.Any(), "No projects selected");
-            Debug.Assert(projects.All(x => Language.ForProject(x).IsSupported), "Unsupported projects");
+            Debug.Assert(projects.All(x => ProjectToLanguageMapper.GetLanguageForProject(x).IsSupported), "Unsupported projects");
 
             if (projects.Count == 1 ||
                 projects.Select(x => this.propertyManager.GetBooleanProperty(x, PropertyName)).AllEqual())
@@ -104,7 +104,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                                           .GetSelectedProjects()
                                           .ToList();
 
-            if (projects.Any() && projects.All(x => Language.ForProject(x).IsSupported))
+            if (projects.Any() && projects.All(x => ProjectToLanguageMapper.GetLanguageForProject(x).IsSupported))
             {
                 IList<bool> properties = projects.Select(x =>
                     this.propertyManager.GetBooleanProperty(x, PropertyName) ?? false).ToList();

--- a/src/Integration.Vsix/Commands/ProjectSonarLintMenuCommand.cs
+++ b/src/Integration.Vsix/Commands/ProjectSonarLintMenuCommand.cs
@@ -60,7 +60,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                                           .GetSelectedProjects()
                                           .ToList();
 
-            if (projects.Any() && projects.All(x => Language.ForProject(x).IsSupported))
+            if (projects.Any() && projects.All(x => ProjectToLanguageMapper.GetLanguageForProject(x).IsSupported))
             {
                 command.Enabled = true;
                 command.Visible = true;

--- a/src/Integration.Vsix/Commands/ProjectTestPropertySetCommand.cs
+++ b/src/Integration.Vsix/Commands/ProjectTestPropertySetCommand.cs
@@ -64,7 +64,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                                           .ToList();
 
             Debug.Assert(projects.Any(), "No projects selected");
-            Debug.Assert(projects.All(x => Language.ForProject(x).IsSupported), "Unsupported projects");
+            Debug.Assert(projects.All(x => ProjectToLanguageMapper.GetLanguageForProject(x).IsSupported), "Unsupported projects");
 
             foreach (Project project in projects)
             {
@@ -85,7 +85,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                                           .GetSelectedProjects()
                                           .ToList();
 
-            if (projects.Any() && projects.All(x => Language.ForProject(x).IsSupported))
+            if (projects.Any() && projects.All(x => ProjectToLanguageMapper.GetLanguageForProject(x).IsSupported))
             {
                 IList<bool?> properties = projects.Select(x =>
                     this.propertyManager.GetBooleanProperty(x, PropertyName)).ToList();

--- a/src/Integration/Binding/BindingProcessImpl.cs
+++ b/src/Integration/Binding/BindingProcessImpl.cs
@@ -109,7 +109,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
             var patternFilteredProjects = this.projectSystem.GetFilteredSolutionProjects();
             var pluginAndPatternFilteredProjects =
-                patternFilteredProjects.Where(p => this.host.SupportedPluginLanguages.Contains(Language.ForProject(p)));
+                patternFilteredProjects.Where(p => this.host.SupportedPluginLanguages.Contains(ProjectToLanguageMapper.GetLanguageForProject(p)));
 
             this.InternalState.BindingProjects.UnionWith(pluginAndPatternFilteredProjects);
             this.InformAboutFilteredOutProjects();
@@ -292,7 +292,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         internal /* for testing */ IEnumerable<Language> GetBindingLanguages()
         {
-            return this.InternalState.BindingProjects.Select(Language.ForProject)
+            return this.InternalState.BindingProjects.Select(ProjectToLanguageMapper.GetLanguageForProject)
                                        .Distinct()
                                        .Where(this.host.SupportedPluginLanguages.Contains)
                                        .ToArray();

--- a/src/Integration/Binding/NuGetBindingOperation.cs
+++ b/src/Integration/Binding/NuGetBindingOperation.cs
@@ -87,7 +87,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             var projectNugets = projectsToBind
                 .SelectMany(bindingProject =>
                 {
-                    var projectLanguage = Language.ForProject(bindingProject);
+                    var projectLanguage = ProjectToLanguageMapper.GetLanguageForProject(bindingProject);
 
                     List<NuGetPackageInfoResponse> nugetPackages;
                     if (!this.NuGetPackages.TryGetValue(projectLanguage, out nugetPackages))

--- a/src/Integration/Binding/ProjectBindingOperation.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.cs
@@ -136,7 +136,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         private void CaptureProject()
         {
-            this.ProjectLanguage = Language.ForProject(this.initializedProject);
+            this.ProjectLanguage = ProjectToLanguageMapper.GetLanguageForProject(this.initializedProject);
             this.ProjectFullPath = this.initializedProject.FullName;
         }
 

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -312,7 +312,7 @@ namespace SonarLint.VisualStudio.Integration.Connection
             this.host.SupportedPluginLanguages.UnionWith(new HashSet<Language>(supportedSonarQubePlugins));
 
             // If any of the project can be bound then return success
-            if (csharpOrVbNetProjects.Select(Language.ForProject)
+            if (csharpOrVbNetProjects.Select(ProjectToLanguageMapper.GetLanguageForProject)
                                      .Any(this.host.SupportedPluginLanguages.Contains))
             {
                 return true;

--- a/src/Integration/Language.cs
+++ b/src/Integration/Language.cs
@@ -108,17 +108,6 @@ namespace SonarLint.VisualStudio.Integration
             this.Name = name;
         }
 
-        public static Language ForProject(EnvDTE.Project dteProject)
-        {
-            if (dteProject == null)
-            {
-                throw new ArgumentNullException(nameof(dteProject));
-            }
-
-            // TODO: remove this method - change the callers to call the following method directly
-            return ProjectToLanguageMapper.GetLanguageForProject(dteProject);
-        }
-
         #region IEquatable<Language> and Equals
 
         public bool Equals(Language other)

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -608,7 +608,7 @@ namespace SonarLint.VisualStudio.Integration
                 projectSystem.AssertLocalServiceIsNotNull();
 
                 IEnumerable<Language> languages = projectSystem.GetFilteredSolutionProjects()
-                    .Select(Language.ForProject)
+                    .Select(ProjectToLanguageMapper.GetLanguageForProject)
                     .Distinct();
 
                 if (!languages.Any())

--- a/src/Integration/LocalServices/ProjectSystemFilter.cs
+++ b/src/Integration/LocalServices/ProjectSystemFilter.cs
@@ -130,7 +130,7 @@ namespace SonarLint.VisualStudio.Integration
 
         private static bool IsNotSupportedProject(DteProject project)
         {
-            var language = Language.ForProject(project);
+            var language = ProjectToLanguageMapper.GetLanguageForProject(project);
             return (language == null || !language.IsSupported);
         }
 

--- a/src/Integration/LocalServices/ProjectSystemHelper.cs
+++ b/src/Integration/LocalServices/ProjectSystemHelper.cs
@@ -72,7 +72,7 @@ namespace SonarLint.VisualStudio.Integration
             foreach (var hierarchy in EnumerateProjects(solution))
             {
                 Project Project = GetProject(hierarchy);
-                if (Project != null && !Language.ForProject(Project).Equals(Language.Unknown))
+                if (Project != null && !ProjectToLanguageMapper.GetLanguageForProject(Project).Equals(Language.Unknown))
                 {
                     yield return Project;
                 }

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -119,7 +119,7 @@ namespace SonarLint.VisualStudio.Integration
         {
             string expectedSolutionRuleSet = ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                          binding.Project.ProjectKey,
-                         Language.ForProject(project),
+                         ProjectToLanguageMapper.GetLanguageForProject(project),
                          binding.Mode);
 
             return ruleSetSerializer.LoadRuleSet(expectedSolutionRuleSet);

--- a/src/Integration/ProfileConflicts/ConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/ConflictsManager.cs
@@ -139,7 +139,7 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
             {
                 string baselineRuleSet = ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     bindingInfo.ProjectKey,
-                    Language.ForProject(project),
+                    ProjectToLanguageMapper.GetLanguageForProject(project),
                     SonarLintMode.LegacyConnected);
 
                 if (!fileSystem.FileExist(baselineRuleSet))

--- a/src/Integration/Service/DataModel/MinimumSupportedServerPlugin.cs
+++ b/src/Integration/Service/DataModel/MinimumSupportedServerPlugin.cs
@@ -41,7 +41,7 @@ namespace SonarLint.VisualStudio.Integration.Service.DataModel
 
         public bool ISupported(EnvDTE.Project project)
         {
-            return Language.ForProject(project).Equals(Language);
+            return ProjectToLanguageMapper.GetLanguageForProject(project).Equals(Language);
         }
     }
 }


### PR DESCRIPTION
* removes the dependency on EnvDTE.Project so Language can be moved to the Core assembly