### PR TITLE
Changed solution binding solution-level save to be generic

### DIFF
--- a/src/Core/IRulesConfigurationProvider.cs
+++ b/src/Core/IRulesConfigurationProvider.cs
@@ -36,6 +36,9 @@ namespace SonarLint.VisualStudio.Core.Binding
     /// For C++ it will be in a json file in a Sonar-specific format</remarks>
     public interface IRulesConfigurationFile
     {
-        // WIP - this is currently just a marker interface
+        /// <summary>
+        /// Saves the file, replacing any existing file
+        /// </summary>
+        void Save(string fullFilePath);
     }
 }

--- a/src/Integration.UnitTests/Binding/DotNetRulesConfigurationFileTests.cs
+++ b/src/Integration.UnitTests/Binding/DotNetRulesConfigurationFileTests.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Integration.Binding;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class DotNetRulesConfigurationFileTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void Ctor_InvalidArgs()
+        {
+            Action act = () => new DotNetRulesConfigurationFile(null);
+
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("ruleSet");
+        }
+
+        [TestMethod]
+        public void Save_InvalidArgs()
+        {
+            var testSubject = new DotNetRulesConfigurationFile(new RuleSet("dummy"));
+
+            // 1. Null -> throw
+            Action act = () => testSubject.Save(null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("fullFilePath");
+
+            // 2. Empty -> throw
+            act = () => testSubject.Save("");
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("fullFilePath");
+        }
+
+        [TestMethod]
+        public void Save_ValidFilePath_SaveCalled()
+        {
+            // We can't mock the RuleSet class so we're testing Save by actually
+            // writing to disk.
+            // Arrange
+            var testDir = Path.Combine(TestContext.DeploymentDirectory, TestContext.TestName);
+            Directory.CreateDirectory(testDir);
+            var fullPath = Path.Combine(testDir, "savedRuleSet.txt");
+
+            var testSubject = new DotNetRulesConfigurationFile(new RuleSet("dummy"));
+
+            // Act
+            testSubject.Save(fullPath);
+
+            // Assert
+            File.Exists(fullPath).Should().BeTrue();
+        }
+    }
+}

--- a/src/Integration.UnitTests/Binding/DotNetRulesConfigurationFileTests.cs
+++ b/src/Integration.UnitTests/Binding/DotNetRulesConfigurationFileTests.cs
@@ -23,7 +23,6 @@ using System.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using SonarLint.VisualStudio.Integration.Binding;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests

--- a/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
@@ -28,6 +28,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
@@ -379,9 +380,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var connectionInformation = new ConnectionInformation(new Uri("http://xyz"));
             SolutionBindingOperation testSubject = this.CreateTestSubject("key", connectionInformation, bindingMode);
 
+            var rulesConfigFileMock = new Mock<IRulesConfigurationFileWithRuleset>();
+            rulesConfigFileMock.Setup(x => x.RuleSet).Returns(new RuleSet("cs"));
+            
             var ruleSetMap = new Dictionary<Language, IRulesConfigurationFile>()
             {
-                { Language.CSharp, new DotNetRulesConfigurationFile(new RuleSet("cs")) }
+                { Language.CSharp, rulesConfigFileMock.Object }
             };
             
             testSubject.RegisterKnownRuleSets(ruleSetMap);
@@ -413,6 +417,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             savedProject.Profiles.Should().HaveCount(1);
             savedProject.Profiles[Language.CSharp].ProfileKey.Should().Be("expected profile Key");
             savedProject.Profiles[Language.CSharp].ProfileTimestamp.Should().Be(expectedTimeStamp);
+
+            //rulesConfigFileMock.Verify(x => x.Save(It.IsAny<string>()), Times.Once);
+
         }
 
         [TestMethod]

--- a/src/Integration/Binding/DotNetRuleConfigurationFile.cs
+++ b/src/Integration/Binding/DotNetRuleConfigurationFile.cs
@@ -27,7 +27,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
     {
         public DotNetRulesConfigurationFile(RuleSet ruleSet)
         {
-            this.RuleSet = ruleSet ?? throw new ArgumentOutOfRangeException(nameof(ruleSet));
+            this.RuleSet = ruleSet ?? throw new ArgumentNullException(nameof(ruleSet));
         }
 
         #region IRulesConfigurationFileWithRuleset methods

--- a/src/Integration/Binding/DotNetRuleConfigurationFile.cs
+++ b/src/Integration/Binding/DotNetRuleConfigurationFile.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    internal class DotNetRulesConfigurationFile : IRulesConfigurationFileWithRuleset
+    {
+        public DotNetRulesConfigurationFile(RuleSet ruleSet)
+        {
+            this.RuleSet = ruleSet ?? throw new ArgumentOutOfRangeException(nameof(ruleSet));
+        }
+
+        #region IRulesConfigurationFileWithRuleset methods
+
+        public RuleSet RuleSet { get; }
+
+        public void Save(string fullFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(fullFilePath))
+            {
+                throw new ArgumentNullException(nameof(fullFilePath));
+            }
+
+            this.RuleSet.WriteToFile(fullFilePath);
+        }
+
+        #endregion
+    }
+}

--- a/src/Integration/Binding/DotNetRuleConfigurationProvider.cs
+++ b/src/Integration/Binding/DotNetRuleConfigurationProvider.cs
@@ -48,7 +48,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         public static bool TryGetRuleSet(IRulesConfigurationFile rulesConfigurationFile, out RuleSet ruleSet)
         {
-            ruleSet = (rulesConfigurationFile as DotNetRulesConfigurationFile)?.RuleSet;
+            ruleSet = (rulesConfigurationFile as IRulesConfigurationFileWithRuleset)?.RuleSet;
             return ruleSet != null;
         }
 

--- a/src/Integration/Binding/DotNetRuleConfigurationProvider.cs
+++ b/src/Integration/Binding/DotNetRuleConfigurationProvider.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -34,41 +33,6 @@ using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    interface IRulesConfigurationFileWithRuleset : IRulesConfigurationFile
-    {
-        RuleSet RuleSet { get; }
-    }
-
-    internal class DotNetRulesConfigurationFile : IRulesConfigurationFileWithRuleset
-    {
-        public DotNetRulesConfigurationFile(RuleSet ruleSet)
-        {
-            this.RuleSet = ruleSet;
-        }
-
-        public static bool TryGetRuleSet(IRulesConfigurationFile rulesConfigurationFile, out RuleSet ruleSet)
-        {
-            ruleSet = (rulesConfigurationFile as IRulesConfigurationFileWithRuleset)?.RuleSet;
-            return ruleSet != null;
-        }
-
-        #region IRulesConfigurationFileWithRuleset methods
-
-        public RuleSet RuleSet { get; }
-
-        public void Save(string fullFilePath)
-        {
-            if (string.IsNullOrWhiteSpace(fullFilePath))
-            {
-                throw new ArgumentNullException(nameof(fullFilePath));
-            }
-
-            this.RuleSet.WriteToFile(fullFilePath);
-        }
-
-        #endregion
-    }
-
     internal class DotNetRuleConfigurationProvider : IRulesConfigurationProvider
     {
         private readonly ISonarQubeService sonarQubeService;

--- a/src/Integration/Binding/DotNetRuleConfigurationProvider.cs
+++ b/src/Integration/Binding/DotNetRuleConfigurationProvider.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -33,10 +34,13 @@ using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    internal class DotNetRulesConfigurationFile : IRulesConfigurationFile
+    interface IRulesConfigurationFileWithRuleset : IRulesConfigurationFile
     {
-        public RuleSet RuleSet { get; }
+        RuleSet RuleSet { get; }
+    }
 
+    internal class DotNetRulesConfigurationFile : IRulesConfigurationFileWithRuleset
+    {
         public DotNetRulesConfigurationFile(RuleSet ruleSet)
         {
             this.RuleSet = ruleSet;
@@ -47,6 +51,22 @@ namespace SonarLint.VisualStudio.Integration.Binding
             ruleSet = (rulesConfigurationFile as DotNetRulesConfigurationFile)?.RuleSet;
             return ruleSet != null;
         }
+
+        #region IRulesConfigurationFileWithRuleset methods
+
+        public RuleSet RuleSet { get; }
+
+        public void Save(string fullFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(fullFilePath))
+            {
+                throw new ArgumentNullException(nameof(fullFilePath));
+            }
+
+            this.RuleSet.WriteToFile(fullFilePath);
+        }
+
+        #endregion
     }
 
     internal class DotNetRuleConfigurationProvider : IRulesConfigurationProvider

--- a/src/Integration/Binding/IRuleConfigurationFileWithRuleSet.cs
+++ b/src/Integration/Binding/IRuleConfigurationFileWithRuleSet.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+using SonarLint.VisualStudio.Core.Binding;
+
+// Note: this interface was added as part of the refactoring that was done when
+// the support for configuration of C++ files in Connected Mode was added.
+// It minimised the changes required to the existing binding code that is
+// ruleset-specific, at the cost of downcasts in a couple of places (done by
+// the TryGetRuleSet extension method).
+
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    /// <summary>
+    /// Extends the base rules configuration interface for C#/VB projects where
+    /// the rules config is expected to be in a ruleset
+    /// </summary>
+    public interface IRulesConfigurationFileWithRuleset : IRulesConfigurationFile
+    {
+        RuleSet RuleSet { get; }
+    }
+
+    internal static class RulesConfigurationFileExtensions
+    {
+        public static bool TryGetRuleSet(this IRulesConfigurationFile rulesConfigurationFile, out RuleSet ruleSet)
+        {
+            ruleSet = (rulesConfigurationFile as IRulesConfigurationFileWithRuleset)?.RuleSet;
+            return ruleSet != null;
+        }
+    }
+}

--- a/src/Integration/Binding/ProjectBindingOperation.Writer.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.Writer.cs
@@ -51,7 +51,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             Debug.Assert(solutionRuleSet != null);
 
             // TODO: clean up to remove down-cast to check for RuleSet
-            DotNetRulesConfigurationFile.TryGetRuleSet(solutionRuleSet.RulesConfigurationFile, out var dotNetRuleSet);
+            solutionRuleSet.RulesConfigurationFile.TryGetRuleSet(out var dotNetRuleSet);
             Debug.Assert(dotNetRuleSet != null, "Only expecting this method to be called for projects that have a VS RuleSet");
 
             string projectRoot = Path.GetDirectoryName(projectFullPath);

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -194,7 +194,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 Debug.Assert(!string.IsNullOrWhiteSpace(info.NewRuleSetFilePath), "Expected to be set during registration time");
 
                 // duncanp - add support for C++ projects
-                if (!DotNetRulesConfigurationFile.TryGetRuleSet(info.RulesConfigurationFile, out var dotnetRuleset))
+                if (!info.RulesConfigurationFile.TryGetRuleSet(out var dotnetRuleset))
                 {
                     break;
                 }

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -183,9 +183,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
             Debug.Assert(this.SolutionFullPath != null, "Expected to be initialized");
 
-            var ruleSetSerializer = this.serviceProvider.GetService<IRuleSetSerializer>();
-            ruleSetSerializer.AssertLocalServiceIsNotNull();
-
             foreach (var keyValue in this.rulesConfigInformationMap)
             {
                 if (token.IsCancellationRequested)
@@ -209,7 +206,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     this.sourceControlledFileSystem.CreateDirectory(ruleSetDirectoryPath); // will no-op if exists
 
                     // Create or overwrite existing rule set
-                    ruleSetSerializer.WriteRuleSetFile(dotnetRuleset, info.NewRuleSetFilePath);
+                    info.RulesConfigurationFile.Save(info.NewRuleSetFilePath);
 
                     return true;
                 });


### PR DESCRIPTION
No longer uses `IRuleSetSerializer` for solution-level rules config files i.e. no longer dependent on the `RuleSet` class.
Now calls `IRulesConfigurationFileWithRuleset.Save` instead.