### PR TITLE
Cleaned up IsSonarQubePluginSupported code and tests

### DIFF
--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -646,15 +646,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Arrange
             VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
             var sonarqubePlugin = new SonarQubePlugin("csharp", "7.0");
 
+            var logger = new TestLogger();
+
             // Act
-            var result = testSubject.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp, logger);
 
             // Assert
             result.Should().BeFalse();
-            this.outputWindowPane.AssertOutputStrings("   Discovered an unsupported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
+            logger.AssertOutputStrings("   Discovered an unsupported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
         }
 
         [TestMethod]
@@ -662,15 +663,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Arrange
             VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
             var sonarqubePlugin = new SonarQubePlugin("csharp", "6.0");
 
+            var logger = new TestLogger();
+
             // Act
-            var result = testSubject.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp, logger);
 
             // Assert
             result.Should().BeTrue();
-            this.outputWindowPane.AssertOutputStrings("   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
+            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
         }
 
         [TestMethod]
@@ -678,15 +680,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Arrange
             VisualStudioHelpers.VisualStudioVersion = "14.0.25420.00";
-            var testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
             var sonarqubePlugin = new SonarQubePlugin("csharp", "7.0");
 
+            var logger = new TestLogger();
+
             // Act
-            var result = testSubject.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp, logger);
 
             // Assert
             result.Should().BeTrue();
-            this.outputWindowPane.AssertOutputStrings("   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0'");
+            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0'");
         }
 
         [TestMethod]
@@ -694,15 +697,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Arrange
             VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
             var sonarqubePlugin = new SonarQubePlugin("vbnet", "5.0");
 
+            var logger = new TestLogger();
+
             // Act
-            var result = testSubject.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet, logger);
 
             // Assert
             result.Should().BeFalse();
-            this.outputWindowPane.AssertOutputStrings("   Discovered an unsupported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
+            logger.AssertOutputStrings("   Discovered an unsupported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
         }
 
         [TestMethod]
@@ -710,15 +714,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Arrange
             VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
             var sonarqubePlugin = new SonarQubePlugin("vbnet", "4.0");
 
+            var logger = new TestLogger();
+
             // Act
-            var result = testSubject.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet, logger);
 
             // Assert
             result.Should().BeTrue();
-            this.outputWindowPane.AssertOutputStrings("   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
+            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
         }
 
         [TestMethod]
@@ -726,15 +731,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Arrange
             VisualStudioHelpers.VisualStudioVersion = "14.0.25420.00";
-            var testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
             var sonarqubePlugin = new SonarQubePlugin("vbnet", "5.0");
 
+            var logger = new TestLogger();
+
             // Act
-            var result = testSubject.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet, logger);
 
             // Assert
             result.Should().BeTrue();
-            this.outputWindowPane.AssertOutputStrings("   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0'");
+            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0'");
         }
 
         #endregion Tests

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -644,103 +644,83 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         [TestMethod]
         public void IsSonarQubePluginSupported_WhenUnsupportedVersionOfVSAndCSharpPluginEquals70_ReturnsFalseAndWriteExpectedText()
         {
-            // Arrange
-            VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var sonarqubePlugin = new SonarQubePlugin("csharp", "7.0");
-
-            var logger = new TestLogger();
-
-            // Act
-            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp, logger);
-
-            // Assert
-            result.Should().BeFalse();
-            logger.AssertOutputStrings("   Discovered an unsupported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
+            TestPluginSupport(
+                expectedResult: false,
+                vsVersion: "14.0",
+                installedPlugin: new SonarQubePlugin("csharp", "7.0"),
+                minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.CSharp,
+                expectedMessage: "   Discovered an unsupported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
         }
 
         [TestMethod]
         public void IsSonarQubePluginSupported_WhenUnsupportedVersionOfVSAndCSharpPluginEquals60_ReturnsTrue()
         {
-            // Arrange
-            VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var sonarqubePlugin = new SonarQubePlugin("csharp", "6.0");
-
-            var logger = new TestLogger();
-
-            // Act
-            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp, logger);
-
-            // Assert
-            result.Should().BeTrue();
-            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
+            TestPluginSupport(
+                expectedResult: true,
+                vsVersion: "14.0",
+                installedPlugin: new SonarQubePlugin("csharp", "6.0"),
+                minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.CSharp,
+                expectedMessage: "   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
         }
 
         [TestMethod]
         public void IsSonarQubePluginSupported_WhenSupportedVersionOfVSAndCSharpPluginEquals70_ReturnsTrueAndWriteExpectedText()
         {
-            // Arrange
-            VisualStudioHelpers.VisualStudioVersion = "14.0.25420.00";
-            var sonarqubePlugin = new SonarQubePlugin("csharp", "7.0");
-
-            var logger = new TestLogger();
-
-            // Act
-            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.CSharp, logger);
-
-            // Assert
-            result.Should().BeTrue();
-            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0'");
+            TestPluginSupport(
+                expectedResult: true,
+                vsVersion: "14.0.25420.00",
+                installedPlugin: new SonarQubePlugin("csharp", "7.0"),
+                minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.CSharp,
+                expectedMessage: "   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0'");
         }
 
         [TestMethod]
         public void IsSonarQubePluginSupported_WhenUnsupportedVersionOfVSAndVBNetPluginEquals50_ReturnsFalseAndWriteExpectedText()
         {
-            // Arrange
-            VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var sonarqubePlugin = new SonarQubePlugin("vbnet", "5.0");
-
-            var logger = new TestLogger();
-
-            // Act
-            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet, logger);
-
-            // Assert
-            result.Should().BeFalse();
-            logger.AssertOutputStrings("   Discovered an unsupported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
+            TestPluginSupport(
+                expectedResult: false,
+                vsVersion: "14.0",
+                installedPlugin: new SonarQubePlugin("vbnet", "5.0"),
+                minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.VbNet,
+                expectedMessage: "   Discovered an unsupported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
         }
 
         [TestMethod]
         public void IsSonarQubePluginSupported_WhenUnsupportedVersionOfVSAndVBNetPluginEquals40_ReturnsTrue()
         {
-            // Arrange
-            VisualStudioHelpers.VisualStudioVersion = "14.0";
-            var sonarqubePlugin = new SonarQubePlugin("vbnet", "4.0");
-
-            var logger = new TestLogger();
-
-            // Act
-            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet, logger);
-
-            // Assert
-            result.Should().BeTrue();
-            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
+            TestPluginSupport(
+                expectedResult: true,
+                vsVersion: "14.0",
+                installedPlugin: new SonarQubePlugin("vbnet", "4.0"),
+                minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.VbNet,
+                expectedMessage: "   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
         }
 
         [TestMethod]
         public void IsSonarQubePluginSupported_WhenSupportedVersionOfVSAndVBNetPluginEquals50_ReturnsTrueAndWriteExpectedText()
         {
-            // Arrange
-            VisualStudioHelpers.VisualStudioVersion = "14.0.25420.00";
-            var sonarqubePlugin = new SonarQubePlugin("vbnet", "5.0");
+            TestPluginSupport(
+                expectedResult: true,
+                vsVersion: "14.0.25420.00",
+                installedPlugin: new SonarQubePlugin("vbnet", "5.0"),
+                minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.VbNet,
+                expectedMessage: "   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0'");
+        }
 
+        private static void TestPluginSupport(bool expectedResult, string vsVersion, SonarQubePlugin installedPlugin,
+            MinimumSupportedSonarQubePlugin minimumSupportedPlugin, 
+            string expectedMessage)
+        {
+            // Arrange
+            VisualStudioHelpers.VisualStudioVersion = vsVersion;
             var logger = new TestLogger();
 
             // Act
-            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { sonarqubePlugin }, MinimumSupportedSonarQubePlugin.VbNet, logger);
+            var result = ConnectionWorkflow.IsSonarQubePluginSupported(new[] { installedPlugin }, minimumSupportedPlugin, logger);
 
             // Assert
-            result.Should().BeTrue();
-            logger.AssertOutputStrings("   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0'");
+            result.Should().Be(expectedResult);
+            logger.AssertOutputStrings(expectedMessage);
         }
 
         #endregion Tests

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -649,7 +649,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 vsVersion: "14.0",
                 installedPlugin: new SonarQubePlugin("csharp", "7.0"),
                 minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.CSharp,
-                expectedMessage: "   Discovered an unsupported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
+                expectedMessage: "   Discovered an unsupported plugin: Language: 'C#', Installed version: '7.0', Minimum version: '5.0', Maximum version: '7.0'");
         }
 
         [TestMethod]
@@ -660,7 +660,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 vsVersion: "14.0",
                 installedPlugin: new SonarQubePlugin("csharp", "6.0"),
                 minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.CSharp,
-                expectedMessage: "   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0', Maximum version: '7.0'");
+                expectedMessage: "   Discovered a supported plugin: Language: 'C#', Installed version: '6.0', Minimum version: '5.0', Maximum version: '7.0'");
         }
 
         [TestMethod]
@@ -671,7 +671,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 vsVersion: "14.0.25420.00",
                 installedPlugin: new SonarQubePlugin("csharp", "7.0"),
                 minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.CSharp,
-                expectedMessage: "   Discovered a supported plugin: Language: 'C#', Minimum version: '5.0'");
+                expectedMessage: "   Discovered a supported plugin: Language: 'C#', Installed version: '7.0', Minimum version: '5.0'");
         }
 
         [TestMethod]
@@ -682,7 +682,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 vsVersion: "14.0",
                 installedPlugin: new SonarQubePlugin("vbnet", "5.0"),
                 minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.VbNet,
-                expectedMessage: "   Discovered an unsupported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
+                expectedMessage: "   Discovered an unsupported plugin: Language: 'VB.NET', Installed version: '5.0', Minimum version: '3.0', Maximum version: '5.0'");
         }
 
         [TestMethod]
@@ -693,7 +693,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 vsVersion: "14.0",
                 installedPlugin: new SonarQubePlugin("vbnet", "4.0"),
                 minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.VbNet,
-                expectedMessage: "   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0', Maximum version: '5.0'");
+                expectedMessage: "   Discovered a supported plugin: Language: 'VB.NET', Installed version: '4.0', Minimum version: '3.0', Maximum version: '5.0'");
         }
 
         [TestMethod]
@@ -704,7 +704,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 vsVersion: "14.0.25420.00",
                 installedPlugin: new SonarQubePlugin("vbnet", "5.0"),
                 minimumSupportedPlugin: MinimumSupportedSonarQubePlugin.VbNet,
-                expectedMessage: "   Discovered a supported plugin: Language: 'VB.NET', Minimum version: '3.0'");
+                expectedMessage: "   Discovered a supported plugin: Language: 'VB.NET', Installed version: '5.0', Minimum version: '3.0'");
         }
 
         private static void TestPluginSupport(bool expectedResult, string vsVersion, SonarQubePlugin installedPlugin,

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -308,7 +308,7 @@ namespace SonarLint.VisualStudio.Integration.Connection
 
             var csharpOrVbNetProjects = new HashSet<EnvDTE.Project>(this.projectSystem.GetSolutionProjects());
             var supportedSonarQubePlugins = MinimumSupportedSonarQubePlugin.All
-                .Where(lang => IsSonarQubePluginSupported(plugins, lang))
+                .Where(lang => IsSonarQubePluginSupported(plugins, lang, host.Logger))
                 .Select(lang => lang.Language);
             this.host.SupportedPluginLanguages.UnionWith(new HashSet<Language>(supportedSonarQubePlugins));
 
@@ -344,8 +344,8 @@ namespace SonarLint.VisualStudio.Integration.Connection
             return string.Format(Strings.OnlySupportedPluginsHaveNoProjectInSolution, supportedPluginsNames);
         }
 
-        internal /*for testing purposes*/ bool IsSonarQubePluginSupported(IEnumerable<SonarQubePlugin> plugins,
-            MinimumSupportedSonarQubePlugin minimumSupportedPlugin)
+        internal static /*for testing purposes*/ bool IsSonarQubePluginSupported(IEnumerable<SonarQubePlugin> plugins,
+            MinimumSupportedSonarQubePlugin minimumSupportedPlugin, ILogger logger)
         {
             var plugin = plugins.FirstOrDefault(x => StringComparer.Ordinal.Equals(x.Key, minimumSupportedPlugin.Key));
 
@@ -353,7 +353,6 @@ namespace SonarLint.VisualStudio.Integration.Connection
             {
                 return false;
             }
-
 
             var pluginInfoMessage = string.Format(CultureInfo.CurrentCulture, Strings.MinimumSupportedSonarQubePlugin,
                 minimumSupportedPlugin.Language.Name, minimumSupportedPlugin.MinimumVersion);
@@ -384,7 +383,7 @@ namespace SonarLint.VisualStudio.Integration.Connection
                 isPluginSupported
                     ? Strings.SupportedPluginFoundMessage
                     : Strings.UnsupportedPluginFoundMessage);
-            this.host.Logger.WriteLine(pluginSupportMessageFormat, pluginInfoMessage);
+            logger.WriteLine(pluginSupportMessageFormat, pluginInfoMessage);
 
             return isPluginSupported;
         }

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -340,7 +340,8 @@ namespace SonarLint.VisualStudio.Integration.Connection
                 return Strings.SolutionContainsNoSupportedProject;
             }
 
-            return string.Format(Strings.OnlySupportedPluginHasNoProjectInSolution, this.host.SupportedPluginLanguages.First().Name);
+            var supportedPluginsNames = string.Join(", ", this.host.SupportedPluginLanguages.Select(p => p.Name));
+            return string.Format(Strings.OnlySupportedPluginsHaveNoProjectInSolution, supportedPluginsNames);
         }
 
         internal /*for testing purposes*/ bool IsSonarQubePluginSupported(IEnumerable<SonarQubePlugin> plugins,

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -838,11 +838,11 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This SonarQube server only supported plugin language ({0}) does not match any of this solution projects&apos; languages..
+        ///   Looks up a localized string similar to The plugins supported by this SonarQube server ({0}) do not match any of the solution projects&apos; languages..
         /// </summary>
-        public static string OnlySupportedPluginHasNoProjectInSolution {
+        public static string OnlySupportedPluginsHaveNoProjectInSolution {
             get {
-                return ResourceManager.GetString("OnlySupportedPluginHasNoProjectInSolution", resourceCulture);
+                return ResourceManager.GetString("OnlySupportedPluginsHaveNoProjectInSolution", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -720,6 +720,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Language: &apos;{0}&apos;, Installed version: &apos;{1}&apos;, Minimum version: &apos;{2}&apos;.
+        /// </summary>
+        public static string InstalledAndMinimumSonarQubePlugin {
+            get {
+                return ResourceManager.GetString("InstalledAndMinimumSonarQubePlugin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Colon (&quot;:&quot;) is not a permitted character..
         /// </summary>
         public static string InvalidCharacterColon {
@@ -743,15 +752,6 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string InvalidTestProjectRegexPattern {
             get {
                 return ResourceManager.GetString("InvalidTestProjectRegexPattern", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Language: &apos;{0}&apos;, Minimum version: &apos;{1}&apos;.
-        /// </summary>
-        public static string MinimumSupportedSonarQubePlugin {
-            get {
-                return ResourceManager.GetString("MinimumSupportedSonarQubePlugin", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -622,9 +622,9 @@ This is the general format to use when writing errors to output window or when t
     <value>   {0}</value>
     <comment>Output window message format. Used whenever the message should be displayed as a sub-message from a step message so the user can clearly identify the grouping. {0} the actual message to display.</comment>
   </data>
-  <data name="MinimumSupportedSonarQubePlugin" xml:space="preserve">
-    <value>Language: '{0}', Minimum version: '{1}'</value>
-    <comment>Error message displayed for every supported plugin when none of them match the minimum required version. {0} the plugin language name, {1} the plugin minimum version.</comment>
+  <data name="InstalledAndMinimumSonarQubePlugin" xml:space="preserve">
+    <value>Language: '{0}', Installed version: '{1}', Minimum version: '{2}'</value>
+    <comment>Error message displayed for every supported plugin when none of them match the minimum required version. {0} the plugin language name, {1} the installed plugin version, {2} the minimum plugin version.</comment>
   </data>
   <data name="DetectingSonarQubePlugins" xml:space="preserve">
     <value>Detecting server plugins</value>

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -707,8 +707,8 @@ This is the general format to use when writing errors to output window or when t
     <value>Notifications are not supported on this version of SonarQube</value>
     <comment>Output window message</comment>
   </data>
-  <data name="OnlySupportedPluginHasNoProjectInSolution" xml:space="preserve">
-    <value>This SonarQube server only supported plugin language ({0}) does not match any of this solution projects' languages.</value>
+  <data name="OnlySupportedPluginsHaveNoProjectInSolution" xml:space="preserve">
+    <value>The plugins supported by this SonarQube server ({0}) do not match any of the solution projects' languages.</value>
     <comment>Output window message printed when the only supported plugin has no matching project types in the current solution. {0} the name of the language.</comment>
   </data>
   <data name="Telemetry_ERROR_Recording" xml:space="preserve">


### PR DESCRIPTION
Minor improvement to plugin detection output message - now includes the installed version number as well as the minimum required version.