### PR TITLE
Modified sln-level rule config naming to be type-specific

### DIFF
--- a/src/Core.UnitTests/CFamily/CFamilyRulesConfigurationProviderTests.cs
+++ b/src/Core.UnitTests/CFamily/CFamilyRulesConfigurationProviderTests.cs
@@ -232,7 +232,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             testSubject.IsLanguageSupported(Language.C).Should().BeTrue();
             testSubject.IsLanguageSupported(Language.Cpp).Should().BeTrue();
 
-            testSubject.IsLanguageSupported(new Language("cpp", "FooXXX"));
+            testSubject.IsLanguageSupported(new Language("cpp", "FooXXX", "foo"));
 
             // 2. Not supported
             testSubject.IsLanguageSupported(Language.CSharp).Should().BeFalse();

--- a/src/Core.UnitTests/Helpers/LanguageHelperTests.cs
+++ b/src/Core.UnitTests/Helpers/LanguageHelperTests.cs
@@ -35,7 +35,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.Helpers
             LanguageHelper.ToServerLanguage(null).Should().BeNull();
 
             // 2. Unknown languages
-            CheckMapping(new Language("foo", "bar"), null);
+            CheckMapping(new Language("foo", "bar", "file_suffix"), null);
         }
 
         [TestMethod]
@@ -46,7 +46,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.Helpers
             CheckMapping(Language.CSharp, SonarQubeLanguage.CSharp);
             CheckMapping(Language.VBNET, SonarQubeLanguage.VbNet);
 
-            CheckMapping(new Language("VB", "Any name at all - isn't used in the mapping"), SonarQubeLanguage.VbNet);
+            CheckMapping(new Language("VB", "Any name at all - isn't used in the mapping", "file_suffix"), SonarQubeLanguage.VbNet);
         }
 
         private static void CheckMapping(Language language, SonarQubeLanguage expectedServerLanguage)

--- a/src/Core.UnitTests/LanguageTests.cs
+++ b/src/Core.UnitTests/LanguageTests.cs
@@ -33,14 +33,18 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             // Arrange
             var key = "k";
             var name = "MyName";
+            var fileSuffix = "suffix";
 
             // Act + Assert
             // Nulls
-            Action act = () => new Language(name, null);
+            Action act = () => new Language(name, null, fileSuffix);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("name");
 
-            act = () => new Language(null, key);
+            act = () => new Language(null, key, fileSuffix);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("id");
+
+            act = () => new Language(name, key, null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("fileSuffix");
         }
 
         [TestMethod]
@@ -63,7 +67,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         [TestMethod]
         public void Language_ISupported_UnsupportedLanguage_IsFalse()
         {
-            var other = new Language("foo", "Foo language");
+            var other = new Language("foo", "Foo language", "file_suffix");
             other.IsSupported.Should().BeFalse();
         }
 
@@ -71,9 +75,9 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         public void Language_Equality()
         {
             // Arrange
-            var lang1a = new Language("Language 1", "lang1");
-            var lang1b = new Language("Language 1", "lang1");
-            var lang2 = new Language("Language 2", "lang2");
+            var lang1a = new Language("Language 1", "lang1", "file_suffix");
+            var lang1b = new Language("Language 1", "lang1", "file_suffix");
+            var lang2 = new Language("Language 2", "lang2", "file_suffix");
 
             // Act + Assert
             lang1b.Should().Be(lang1a, "Languages with the same keys and GUIDs should be equal");

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -42,10 +42,10 @@ namespace SonarLint.VisualStudio.Core
     public sealed class Language : IEquatable<Language>
     {
         public readonly static Language Unknown = new Language();
-        public readonly static Language CSharp = new Language("CSharp", CoreStrings.CSharpLanguageName);
-        public readonly static Language VBNET = new Language("VB", CoreStrings.VBNetLanguageName);
-        public readonly static Language Cpp = new Language("C++", CoreStrings.CppLanguageName);
-        public readonly static Language C = new Language("C", "C");
+        public readonly static Language CSharp = new Language("CSharp", CoreStrings.CSharpLanguageName, "csharp.ruleset");
+        public readonly static Language VBNET = new Language("VB", CoreStrings.VBNetLanguageName, "vb.ruleset");
+        public readonly static Language Cpp = new Language("C++", CoreStrings.CppLanguageName, "cpp.settings");
+        public readonly static Language C = new Language("C", "C", "c.settings");
 
         /// <summary>
         /// A stable identifier for this language.
@@ -56,6 +56,12 @@ namespace SonarLint.VisualStudio.Core
         /// The language display name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Suffix and extension added to the language-specific rules configuration file for the language
+        /// </summary>
+        /// <remarks>e.g. for ruleset-based languages this will be a language identifier + ".ruleset"</remarks>
+        public string FileSuffixAndExtension { get; }
 
         /// <summary>
         /// Returns whether or not this language is a supported project language.
@@ -91,9 +97,10 @@ namespace SonarLint.VisualStudio.Core
         {
             this.Id = string.Empty;
             this.Name = CoreStrings.UnknownLanguageName;
+            this.FileSuffixAndExtension = string.Empty;
         }
 
-        public Language(string id, string name)
+        public Language(string id, string name, string fileSuffix)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -105,8 +112,14 @@ namespace SonarLint.VisualStudio.Core
                 throw new ArgumentNullException(nameof(name));
             }
 
+            if (string.IsNullOrWhiteSpace(fileSuffix))
+            {
+                throw new ArgumentNullException(nameof(fileSuffix));
+            }
+
             this.Id = id;
             this.Name = name;
+            this.FileSuffixAndExtension = fileSuffix;
         }
 
         #region IEquatable<Language> and Equals

--- a/src/Integration.UnitTests/Binding/DotNetRulesConfigurationProviderTests.cs
+++ b/src/Integration.UnitTests/Binding/DotNetRulesConfigurationProviderTests.cs
@@ -237,7 +237,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             testSubject.IsLanguageSupported(Language.CSharp).Should().BeTrue();
             testSubject.IsLanguageSupported(Language.VBNET).Should().BeTrue();
 
-            testSubject.IsLanguageSupported(new Language("CSharp", "FooXXX"));
+            testSubject.IsLanguageSupported(new Language("CSharp", "FooXXX", "file_suffix"));
 
             // 2. Not supported
             testSubject.IsLanguageSupported(Language.C).Should().BeFalse();

--- a/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
@@ -251,10 +251,24 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             include = new RuleSetInclude("..\\xxx\\SUBDIR2\\file.txt", RuleAction.Default);
             include.FilePath.Should().Be("..\\xxx\\subdir2\\file.txt");
 
-            // 2. Check our file name calculation function produces lower case
+            // 2. Check our file name calculation function produces lower-case
             this.projectSystemHelper.CurrentActiveSolution = new SolutionMock(null, @"z:\folder\solution\solutionFile.sln");
+            string ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MYKEY", new Language("l_id", "l_name", "FILESUFFIX.ANDEXT"), SonarLintMode.Connected);
+            ruleSetPath.Should().Be(@"z:\folder\solution\.sonarlint\mykeyfilesuffix.andext"); // should be lower-case
+        }
+
+        [TestMethod]
+        public void CheckSolutionRuleSet_RuleConfigIncludePath_UsesLanguageSpecificSuffixAndExtension()
+        {
+            this.projectSystemHelper.CurrentActiveSolution = new SolutionMock(null, @"z:\folder\solution\solutionFile.sln");
+
+            // 1. VB
             string ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MYKEY", Language.VBNET, SonarLintMode.Connected);
             ruleSetPath.Should().Be(@"z:\folder\solution\.sonarlint\mykeyvb.ruleset"); // should be lower-case
+
+            // 2. Cpp
+            ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MYKEY", Language.Cpp, SonarLintMode.Connected);
+            ruleSetPath.Should().Be(@"z:\folder\solution\.sonarlint\mykeycpp.settings"); // should be lower-case
         }
 
         [TestMethod]

--- a/src/Integration/LocalServices/SolutionRuleSetsInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionRuleSetsInformationProvider.cs
@@ -149,8 +149,7 @@ namespace SonarLint.VisualStudio.Integration
                 throw new InvalidOperationException(Strings.SolutionIsClosed);
             }
 
-            string fileNameSuffix = language.Id;
-            return GenerateSolutionRuleSetPath(ruleSetDirectoryRoot, ProjectKey, fileNameSuffix);
+            return GenerateSolutionRuleSetPath(ruleSetDirectoryRoot, ProjectKey, language.FileSuffixAndExtension);
         }
 
         public bool TryGetProjectRuleSetFilePath(Project project, RuleSetDeclaration declaration, out string fullFilePath)
@@ -181,12 +180,12 @@ namespace SonarLint.VisualStudio.Integration
         /// </summary>
         /// <param name="ruleSetRootPath">Root directory to generate the full file path under</param>
         /// <param name="ProjectKey">SonarQube project key to generate a rule set file name path for</param>
-        /// <param name="fileNameSuffix">Fixed file name suffix</param>
-        private static string GenerateSolutionRuleSetPath(string ruleSetRootPath, string ProjectKey, string fileNameSuffix)
+        /// <param name="fileNameSuffixAndExtension">Fixed file name suffix and extension (language-specific)</param>
+        private static string GenerateSolutionRuleSetPath(string ruleSetRootPath, string ProjectKey, string fileNameSuffixAndExtension)
         {
             // Cannot use Path.ChangeExtension here because if the sonar project name contains
             // a dot (.) then everything after this will be replaced with .ruleset
-            string fileName = $"{PathHelper.EscapeFileName(ProjectKey + fileNameSuffix)}.{Constants.RuleSetFileExtension}"
+            string fileName = PathHelper.EscapeFileName(ProjectKey + fileNameSuffixAndExtension)
                 .ToLowerInvariant(); // Must be lower case - see https://github.com/SonarSource/sonarlint-visualstudio/issues/1068
             return Path.Combine(ruleSetRootPath, fileName);
         }


### PR DESCRIPTION
Previously the extension was always ".ruleset". This is no longer appropriate for all languages (i.e. we don't use rulesets for connected mode C++ configuration).