### PR TITLE
Renamed binding config classes and interfaces

### DIFF
--- a/src/Core.UnitTests/CFamily/CFamilyBindingConfigFileTests.cs
+++ b/src/Core.UnitTests/CFamily/CFamilyBindingConfigFileTests.cs
@@ -29,12 +29,12 @@ using SonarLint.VisualStudio.Core.SystemAbstractions;
 namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
 {
     [TestClass]
-    public class CFamilyRulesConfigurationFileTests
+    public class CFamilyBindingConfigFileTests
     {
         [TestMethod]
         public void Ctor_InvalidArgs()
         {
-            Action act = () => new CFamilyRulesConfigurationFile(null);
+            Action act = () => new CFamilyBindingConfigFile(null);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("userSettings");
         }
 
@@ -42,7 +42,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
         public void Ctor_ValidArgs()
         {
             var userSettings = new UserSettings();
-            var testSubject = new CFamilyRulesConfigurationFile(userSettings);
+            var testSubject = new CFamilyBindingConfigFile(userSettings);
             testSubject.UserSettings.Equals(userSettings);
         }
 
@@ -71,7 +71,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             fileSystemMock.Setup(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()))
                 .Callback<string, string>((p, t) => { actualPath = p; actualText = t; });
 
-            var testSubject = new CFamilyRulesConfigurationFile(settings, fileSystemMock.Object);
+            var testSubject = new CFamilyBindingConfigFile(settings, fileSystemMock.Object);
 
             // Act
             testSubject.Save("c:\\full\\path\\file.txt");

--- a/src/Core.UnitTests/CFamily/CFamilyBindingConfigProviderTests.cs
+++ b/src/Core.UnitTests/CFamily/CFamilyBindingConfigProviderTests.cs
@@ -34,7 +34,7 @@ using SonarQube.Client.Models;
 namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
 {
     [TestClass]
-    public class CFamilyRulesConfigurationProviderTests
+    public class CFamilyBindingConfigProviderTests
     {
         [TestMethod]
         public void ConvertRulesToSettings()
@@ -55,7 +55,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             };
 
             // Act
-            var settings = CFamilyRulesConfigurationProvider.CreateUserSettingsFromQPRules(qpRules);
+            var settings = CFamilyBindingConfigProvider.CreateUserSettingsFromQPRules(qpRules);
 
             // Assert
             settings.Rules.Count.Should().Be(3);
@@ -97,16 +97,16 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             serviceMock.Setup(x => x.GetRulesAsync(true, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => rules);
 
-            var testSubject = new CFamilyRulesConfigurationProvider(serviceMock.Object, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(CreateQp(), null, Language.Cpp, CancellationToken.None);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), null, Language.Cpp, CancellationToken.None);
 
             // Assert
             result.Should().NotBeNull();
-            result.Should().BeOfType<CFamilyRulesConfigurationFile>();
+            result.Should().BeOfType<CFamilyBindingConfigFile>();
 
-            var cfamilyConfigFile = (CFamilyRulesConfigurationFile)result;
+            var cfamilyConfigFile = (CFamilyBindingConfigFile)result;
             cfamilyConfigFile.UserSettings.Should().NotBeNull();
 
             var slvsRules = cfamilyConfigFile.UserSettings.Rules;
@@ -139,16 +139,16 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             serviceMock.Setup(x => x.GetRulesAsync(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new List<SonarQubeRule>());
 
-            var testSubject = new CFamilyRulesConfigurationProvider(serviceMock.Object, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(CreateQp(), null, Language.Cpp, CancellationToken.None);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), null, Language.Cpp, CancellationToken.None);
 
             // Assert
             result.Should().NotBeNull();
-            result.Should().BeOfType<CFamilyRulesConfigurationFile>();
+            result.Should().BeOfType<CFamilyBindingConfigFile>();
 
-            var cfamilyConfigFile = (CFamilyRulesConfigurationFile)result;
+            var cfamilyConfigFile = (CFamilyBindingConfigFile)result;
             cfamilyConfigFile.UserSettings.Should().NotBeNull();
             cfamilyConfigFile.UserSettings.Rules.Should().NotBeNull();
             cfamilyConfigFile.UserSettings.Rules.Count.Should().Be(0);
@@ -166,10 +166,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             serviceMock.Setup(x => x.GetRulesAsync(It.IsAny<bool>(), It.IsAny<string>(), CancellationToken.None))
                 .ThrowsAsync(new InvalidOperationException("invalid op"));
 
-            var testSubject = new CFamilyRulesConfigurationProvider(serviceMock.Object, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(CreateQp(), null, Language.Cpp, CancellationToken.None);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), null, Language.Cpp, CancellationToken.None);
 
             // Assert
             result.Should().BeNull();
@@ -192,10 +192,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
                         return new List<SonarQubeRule>();
                     }) ;
 
-            var testSubject = new CFamilyRulesConfigurationProvider(serviceMock.Object, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(CreateQp(), null, Language.Cpp, cts.Token);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), null, Language.Cpp, cts.Token);
 
             // Assert
             result.Should().BeNull();
@@ -211,10 +211,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             CancellationTokenSource cts = new CancellationTokenSource();
             var serviceMock = new Mock<ISonarQubeService>();
 
-            var testSubject = new CFamilyRulesConfigurationProvider(serviceMock.Object, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            Action act = () => testSubject.GetRulesConfigurationAsync(CreateQp(), null, Language.VBNET, cts.Token).Wait();
+            Action act = () => testSubject.GetConfigurationAsync(CreateQp(), null, Language.VBNET, cts.Token).Wait();
 
             // Assert
             act.Should().ThrowExactly<AggregateException>().And.InnerException.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -226,7 +226,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             // Arrange
             var testLogger = new TestLogger();
             var serviceMock = new Mock<ISonarQubeService>();
-            var testSubject = new CFamilyRulesConfigurationProvider(serviceMock.Object, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // 1. Supported languages
             testSubject.IsLanguageSupported(Language.C).Should().BeTrue();

--- a/src/Core/Binding/CompositeBindingConfigProvider.cs
+++ b/src/Core/Binding/CompositeBindingConfigProvider.cs
@@ -27,11 +27,11 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Core.Binding
 {
-    public class CompositeRulesConfigurationProvider : IRulesConfigurationProvider
+    public class CompositeBindingConfigProvider : IBindingConfigProvider
     {
-        private readonly HashSet<IRulesConfigurationProvider> providers;
+        private readonly HashSet<IBindingConfigProvider> providers;
 
-        public CompositeRulesConfigurationProvider(params IRulesConfigurationProvider[] providers)
+        public CompositeBindingConfigProvider(params IBindingConfigProvider[] providers)
         {
             // params args can't be null - will be an empty array
             if (providers.Length == 0)
@@ -43,14 +43,14 @@ namespace SonarLint.VisualStudio.Core.Binding
                 throw new ArgumentNullException(nameof(providers));
             }
 
-            this.providers = new HashSet<IRulesConfigurationProvider>(providers);
+            this.providers = new HashSet<IBindingConfigProvider>(providers);
         }
 
-        internal /* for testing */ IEnumerable<IRulesConfigurationProvider> Providers { get { return this.providers; } }
+        internal /* for testing */ IEnumerable<IBindingConfigProvider> Providers { get { return this.providers; } }
 
-        #region IRulesConfigurationProvider methods
+        #region IBindingConfigProvider methods
 
-        public async Task<IRulesConfigurationFile> GetRulesConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey, Language language, CancellationToken cancellationToken)
+        public async Task<IBindingConfigFile> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey, Language language, CancellationToken cancellationToken)
         {
             var provider = Providers.FirstOrDefault(p => p.IsLanguageSupported(language));
 
@@ -58,10 +58,10 @@ namespace SonarLint.VisualStudio.Core.Binding
             {
                 throw new ArgumentOutOfRangeException(nameof(language));
             }
-            IRulesConfigurationFile config = null;
+            IBindingConfigFile config = null;
             if (provider != null)
             {
-                config = await provider?.GetRulesConfigurationAsync(qualityProfile, organizationKey, language, cancellationToken);
+                config = await provider?.GetConfigurationAsync(qualityProfile, organizationKey, language, cancellationToken);
             }
 
             return config;
@@ -72,6 +72,6 @@ namespace SonarLint.VisualStudio.Core.Binding
             return Providers.Any(p => p.IsLanguageSupported(language));
         }
 
-        #endregion IRulesConfigurationProvider methods
+        #endregion IBindingConfigProvider methods
     }
 }

--- a/src/Core/Binding/IBindingConfigProvider.cs
+++ b/src/Core/Binding/IBindingConfigProvider.cs
@@ -24,19 +24,25 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Core.Binding
 {
-    public interface IRulesConfigurationProvider
+    /// <summary>
+    /// Contract to provide the binding-related configuration for one or more languages
+    /// </summary>
+    public interface IBindingConfigProvider
     {
         bool IsLanguageSupported(Language language);
 
-        Task<IRulesConfigurationFile> GetRulesConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey, Language language, CancellationToken cancellationToken);
+        /// <summary>
+        /// Returns a configuration file for the specified language
+        /// </summary>
+        Task<IBindingConfigFile> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey, Language language, CancellationToken cancellationToken);
     }
 
     /// <summary>
-    /// Abstraction of the various types of configuration file used to store rule configuration information
+    /// Abstraction of the various types of configuration file used to store binding configuration information
     /// </summary>
-    /// <remarks>e.g. for C# and VB.NET the rules configuration will be in a ruleset file.
+    /// <remarks>e.g. for C# and VB.NET the configuration will be in a ruleset file.
     /// For C++ it will be in a json file in a Sonar-specific format</remarks>
-    public interface IRulesConfigurationFile
+    public interface IBindingConfigFile
     {
         /// <summary>
         /// Saves the file, replacing any existing file

--- a/src/Core/CFamily/CFamilyBindingConfigFile.cs
+++ b/src/Core/CFamily/CFamilyBindingConfigFile.cs
@@ -25,16 +25,16 @@ using SonarLint.VisualStudio.Core.SystemAbstractions;
 
 namespace SonarLint.VisualStudio.Core.CFamily
 {
-    public class CFamilyRulesConfigurationFile : IRulesConfigurationFile
+    public class CFamilyBindingConfigFile : IBindingConfigFile
     {
         private readonly IFile fileWrapper;
 
-        public CFamilyRulesConfigurationFile(UserSettings userSettings)
+        public CFamilyBindingConfigFile(UserSettings userSettings)
             : this (userSettings, new FileWrapper())
         {
         }
 
-        public CFamilyRulesConfigurationFile(UserSettings userSettings, IFile fileWrapper)
+        public CFamilyBindingConfigFile(UserSettings userSettings, IFile fileWrapper)
         {
             this.UserSettings = userSettings ?? throw new ArgumentNullException(nameof(userSettings));
             this.fileWrapper = fileWrapper;
@@ -42,7 +42,7 @@ namespace SonarLint.VisualStudio.Core.CFamily
 
         internal /* for testing */ UserSettings UserSettings { get; }
 
-        #region IRulesConfigurationFile implementation
+        #region IBindingConfigFile implementation
 
         public void Save(string fullFilePath)
         {
@@ -50,6 +50,6 @@ namespace SonarLint.VisualStudio.Core.CFamily
             fileWrapper.WriteAllText(fullFilePath, dataAsText);
         }
 
-        #endregion IRulesConfigurationFile implementation
+        #endregion IBindingConfigFile implementation
     }
 }

--- a/src/Core/CFamily/CFamilyBindingConfigProvider.cs
+++ b/src/Core/CFamily/CFamilyBindingConfigProvider.cs
@@ -30,25 +30,25 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Core.CFamily
 {
-    public class CFamilyRulesConfigurationProvider : IRulesConfigurationProvider
+    public class CFamilyBindingConfigProvider : IBindingConfigProvider
     {
         private readonly ISonarQubeService sonarQubeService;
         private readonly ILogger logger;
 
-        public CFamilyRulesConfigurationProvider(ISonarQubeService sonarQubeService, ILogger logger)
+        public CFamilyBindingConfigProvider(ISonarQubeService sonarQubeService, ILogger logger)
         {
             this.sonarQubeService = sonarQubeService ?? throw new ArgumentNullException(nameof(sonarQubeService));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        #region IRulesConfigurationProvider implementation
+        #region IBindingConfigProvider implementation
 
         public bool IsLanguageSupported(Language language)
         {
             return Language.Cpp.Equals(language) || Language.C.Equals(language);
         }
 
-        public async Task<IRulesConfigurationFile> GetRulesConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey,
+        public async Task<IBindingConfigFile> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey,
             Language language, CancellationToken cancellationToken)
         {
             if (!IsLanguageSupported(language))
@@ -67,12 +67,12 @@ namespace SonarLint.VisualStudio.Core.CFamily
             cancellationToken.ThrowIfCancellationRequested();
 
             var config = CreateUserSettingsFromQPRules(result);
-            var configFile = new CFamilyRulesConfigurationFile(config);
+            var configFile = new CFamilyBindingConfigFile(config);
 
             return configFile;
         }
 
-        #endregion implementation
+        #endregion IBindingConfigProvider implementation
 
         internal /* for testing */ static UserSettings CreateUserSettingsFromQPRules(IList<SonarQubeRule> rules)
         {

--- a/src/Integration.UnitTests/Binding/DotNetBindingConfigFileTests.cs
+++ b/src/Integration.UnitTests/Binding/DotNetBindingConfigFileTests.cs
@@ -28,14 +28,14 @@ using SonarLint.VisualStudio.Integration.Binding;
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     [TestClass]
-    public class DotNetRulesConfigurationFileTests
+    public class DotNetBindingConfigFileTests
     {
         public TestContext TestContext { get; set; }
 
         [TestMethod]
         public void Ctor_InvalidArgs()
         {
-            Action act = () => new DotNetRulesConfigurationFile(null);
+            Action act = () => new DotNetBindingConfigFile(null);
 
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("ruleSet");
         }
@@ -43,7 +43,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         [TestMethod]
         public void Save_InvalidArgs()
         {
-            var testSubject = new DotNetRulesConfigurationFile(new RuleSet("dummy"));
+            var testSubject = new DotNetBindingConfigFile(new RuleSet("dummy"));
 
             // 1. Null -> throw
             Action act = () => testSubject.Save(null);
@@ -64,7 +64,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             Directory.CreateDirectory(testDir);
             var fullPath = Path.Combine(testDir, "savedRuleSet.txt");
 
-            var testSubject = new DotNetRulesConfigurationFile(new RuleSet("dummy"));
+            var testSubject = new DotNetBindingConfigFile(new RuleSet("dummy"));
 
             // Act
             testSubject.Save(fullPath);

--- a/src/Integration.UnitTests/Binding/DotNetBindingConfigProviderTests.cs
+++ b/src/Integration.UnitTests/Binding/DotNetBindingConfigProviderTests.cs
@@ -40,7 +40,7 @@ using Language = SonarLint.VisualStudio.Core.Language;
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     [TestClass]
-    public class DotNetRulesConfigurationProviderTests
+    public class DotNetBindingConfigProviderTests
     {
         private Mock<ISonarQubeService> sonarQubeServiceMock;
         private TestLogger logger;
@@ -53,7 +53,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public async Task GetRulesConfig_Success()
+        public async Task GetConfig_Success()
         {
             // Arrange
             const string QualityProfileName = "SQQualityProfileName";
@@ -82,12 +82,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             SonarQubeQualityProfile profile = this.ConfigureProfileExport(export, language, QualityProfileName);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(profile, "TODO", language, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(profile, "TODO", language, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
             result.Should().NotBeNull();
-            var dotNetResult = result as DotNetRulesConfigurationFile;
+            var dotNetResult = result as DotNetBindingConfigFile;
             dotNetResult.Should().NotBeNull();
 
             RuleSetAssert.AreEqual(expectedRuleSet, dotNetResult.RuleSet, "Unexpected rule set");
@@ -97,7 +97,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public async Task GetRulesConfig_WhenProfileExportIsNotAvailable_Fails()
+        public async Task GetConfig_WhenProfileExportIsNotAvailable_Fails()
         {
             // Arrange
             var testSubject = this.CreateTestSubject();
@@ -106,7 +106,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var profile = this.ConfigureProfileExport(null, language, "");
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(profile, null, language, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(profile, null, language, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
@@ -119,7 +119,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public async Task GetRulesConfig_WithNoRules_Fails()
+        public async Task GetConfig_WithNoRules_Fails()
         {
             // Arrange
             const string QualityProfileName = "SQQualityProfileName";
@@ -135,7 +135,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var profile = this.ConfigureProfileExport(export, language, QualityProfileName);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(profile, null, language, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(profile, null, language, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
@@ -148,7 +148,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public async Task GetRulesConfig_WithNoActiveRules_Fails()
+        public async Task GetConfig_WithNoActiveRules_Fails()
         {
             // Arrange
             const string QualityProfileName = "SQQualityProfileName";
@@ -168,7 +168,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var profile = this.ConfigureProfileExport(export, language, QualityProfileName);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(profile, null, language, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(profile, null, language, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
@@ -181,7 +181,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public async Task GetRulesConfig_LegacyMode_WithNoNugetPackage_Fails()
+        public async Task GetConfig_LegacyMode_WithNoNugetPackage_Fails()
         {
             // Arrange
             const string QualityProfileName = "SQQualityProfileName";
@@ -197,7 +197,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var profile = this.ConfigureProfileExport(export, language, QualityProfileName);
 
             // Act
-            var result = await testSubject.GetRulesConfigurationAsync(profile, null, language, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(profile, null, language, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
@@ -220,7 +220,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = this.CreateTestSubject("key", "anyProject", nuGetOpMock.Object);
 
             // Act
-            Action act = () => testSubject.GetRulesConfigurationAsync(qualityProfile, null, Language.Cpp, cts.Token).Wait();
+            Action act = () => testSubject.GetConfigurationAsync(qualityProfile, null, Language.Cpp, cts.Token).Wait();
 
             // Assert
             act.Should().ThrowExactly<AggregateException>().And.InnerException.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -246,12 +246,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Helpers
 
-        private DotNetRuleConfigurationProvider CreateTestSubject(string projectName = "anyProjectName", string serverUrl = "http://localhost",
+        private DotNetBindingConfigProvider CreateTestSubject(string projectName = "anyProjectName", string serverUrl = "http://localhost",
             INuGetBindingOperation nuGetBindingOperation = null)
         {
             nuGetBindingOperation = nuGetBindingOperation ?? new NoOpNuGetBindingOperation(this.logger);
 
-            return new DotNetRuleConfigurationProvider(this.sonarQubeServiceMock.Object, nuGetBindingOperation, serverUrl, projectName, this.logger);
+            return new DotNetBindingConfigProvider(this.sonarQubeServiceMock.Object, nuGetBindingOperation, serverUrl, projectName, this.logger);
         }
 
         private SonarQubeQualityProfile ConfigureProfileExport(RoslynExportProfileResponse export, Language language, string profileName)

--- a/src/Integration.UnitTests/Binding/ProjectBindingOperation.WriterTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectBindingOperation.WriterTests.cs
@@ -190,9 +190,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 numRules: 0,
                 includes: new[] { newSolutionRuleSetInclude }
             );
-            var dotNetRulesConfig = new DotNetRulesConfigurationFile(expectedRuleSet);
+            var dotNetConfig = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRulesConfig) { NewRuleSetFilePath = newSolutionRuleSetPath };
+            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetConfig) { NewRuleSetFilePath = newSolutionRuleSetPath };
 
             // Act
             string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetName, ruleSetInfo, existingProjectRuleSetPath);
@@ -231,7 +231,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 numRules: 0,
                 includes: new[] { newSolutionRuleSetInclude }
             );
-            var dotNetRuleSet = new DotNetRulesConfigurationFile(expectedRuleSet);
+            var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
             var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = newSolutionRuleSetPath };
 
@@ -267,7 +267,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                     PathHelper.CalculateRelativePath(projectFullPath, solutionRuleSetPath)
                 }
             );
-            var dotNetRuleSet = new DotNetRulesConfigurationFile(expectedRuleSet);
+            var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
             var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = solutionRuleSetPath };
 
@@ -311,7 +311,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                     PathHelper.CalculateRelativePath(projectFullPath, solutionRuleSetPath)
                 }
             );
-            var dotNetRuleSet = new DotNetRulesConfigurationFile(expectedRuleSet);
+            var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
             var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = solutionRuleSetPath };
 
@@ -351,7 +351,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 numRules: 0,
                 includes: new[] { currentNonExistingRuleSet, newSolutionRuleSetInclude }
             );
-            var dotNetRuleSet = new DotNetRulesConfigurationFile(expectedRuleSet);
+            var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
             var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = newSolutionRuleSetPath };
 
@@ -385,7 +385,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 numRules: 0,
                 includes: new[] { expectedSolutionRuleSetInclude }
             );
-            var dotNetRuleSet = new DotNetRulesConfigurationFile(expectedRuleSet);
+            var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
             var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = solutionRuleSetPath };
 

--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
@@ -47,7 +47,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private ConfigurableHost host;
         private ConfigurableTeamExplorerController teamExplorerController;
         private ConfigurableInfoBarManager infoBarManager;
-        private ConfigurableSolutionBindingInformationProvider solutionBindingInformationProvider;
+        private ConfigurableUnboundProjectFinder unboundProjectFinder;
         private ConfigurableVsOutputWindowPane outputWindowPane;
         private ConfigurableConfigurationProvider configProvider;
         private ConfigurableStateManager stateManager;
@@ -72,7 +72,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 });
             this.serviceProvider.RegisterService(typeof(SComponentModel), componentModel);
 
-            this.solutionBindingInformationProvider = new ConfigurableSolutionBindingInformationProvider();
+            this.unboundProjectFinder = new ConfigurableUnboundProjectFinder();
 
             var outputWindow = new ConfigurableVsOutputWindow();
             this.outputWindowPane = outputWindow.GetOrCreateSonarLintPane();
@@ -93,7 +93,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ErrorListInfoBarController_Ctor_NullHost_Throws()
         {
             // Arrange
-            Action act = () => new ErrorListInfoBarController(null, this.solutionBindingInformationProvider);
+            Action act = () => new ErrorListInfoBarController(null, this.unboundProjectFinder);
 
             // Act & Assert
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("host");
@@ -106,7 +106,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             Action act = () => new ErrorListInfoBarController(this.host, null);
 
             // Act & Assert
-            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("bindingInformationProvider");
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("unboundProjectFinder");
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution(hasUnboundProject: false);
             // Set project system with no filtered project, to quickly stop SonarQubeQualityProfileBackgroundProcessor
             var projectSystem = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
@@ -135,8 +135,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
             SetSolutionExistsAndFullyLoadedContextState(isActive: true);
-            this.solutionBindingInformationProvider.UnboundProjects = new[] { new ProjectMock("unbound.csproj") };
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            this.unboundProjectFinder.UnboundProjects = new[] { new ProjectMock("unbound.csproj") };
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
 
             // Act
             testSubject.Refresh();
@@ -155,8 +155,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Arrange
             this.SetBindingMode(SonarLintMode.Connected);
             SetSolutionExistsAndFullyLoadedContextState(isActive: true);
-            this.solutionBindingInformationProvider.UnboundProjects = new[] { new ProjectMock("unbound.csproj") };
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            this.unboundProjectFinder.UnboundProjects = new[] { new ProjectMock("unbound.csproj") };
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
 
             // Act
             testSubject.Refresh();
@@ -174,7 +174,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             SetSolutionExistsAndFullyLoadedContextState(isActive: false);
 
@@ -201,7 +201,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.Standalone);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution(hasUnboundProject: true);
 
             // Act
@@ -218,7 +218,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution(hasUnboundProject: false);
 
             // Act
@@ -236,7 +236,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution(hasUnboundProject: false);
             var projectSystem = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), projectSystem);
@@ -273,7 +273,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             testSubject.Refresh();
             RunAsyncAction();
@@ -295,7 +295,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             testSubject.Refresh();
             RunAsyncAction();
@@ -316,7 +316,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             this.host.SetActiveSection(ConfigurableSectionController.CreateDefault());
             testSubject.Refresh();
@@ -338,7 +338,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             this.host.SetActiveSection(ConfigurableSectionController.CreateDefault());
             testSubject.Refresh();
@@ -366,7 +366,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             this.host.SetActiveSection(ConfigurableSectionController.CreateDefault());
             testSubject.Refresh();
@@ -393,7 +393,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ErrorListInfoBarController_InfoBar_ClickButton_HasDisconnectedActiveSection()
         {
             // Arrange
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int bindingCalled = 0;
             ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args =>
@@ -447,7 +447,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int bindingCalled = 0;
             ProjectViewModel project = null;
@@ -486,7 +486,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int bindExecuted = 0;
             bool canExecute = false;
@@ -539,7 +539,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int executed = 0;
             ProjectViewModel project = null;
@@ -577,7 +577,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int executed = 0;
             ProjectViewModel project = null;
@@ -617,7 +617,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int executed = 0;
             ProjectViewModel project = null;
@@ -657,7 +657,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int refreshCalled = 0;
             ConfigurableSectionController section = this.ConfigureActiveSectionWithRefreshCommand(c =>
@@ -714,7 +714,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             int bindCommandExecuted = 0;
             ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args => { bindCommandExecuted++; });
@@ -757,7 +757,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args => { });
             this.ConfigureProjectViewModel(section);
@@ -784,7 +784,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             this.SetBindingMode(SonarLintMode.LegacyConnected);
-            var testSubject = new ErrorListInfoBarController(this.host, this.solutionBindingInformationProvider);
+            var testSubject = new ErrorListInfoBarController(this.host, this.unboundProjectFinder);
             this.ConfigureLoadedSolution();
             ConfigurableSectionController section = this.ConfigureActiveSectionWithBindCommand(args => { });
             this.ConfigureProjectViewModel(section);
@@ -917,7 +917,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             if (hasUnboundProject)
             {
-                this.solutionBindingInformationProvider.UnboundProjects = new[] { new ProjectMock("unbound.csproj") };
+                this.unboundProjectFinder.UnboundProjects = new[] { new ProjectMock("unbound.csproj") };
             }
 
             SetSolutionExistsAndFullyLoadedContextState(isActive: true);

--- a/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests_SolutionConfigLevel.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests_SolutionConfigLevel.cs
@@ -92,7 +92,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         [DataRow(SonarLintMode.LegacyConnected, /* cppConfig =*/ true, /* cConfig */ false)]
         [DataRow(SonarLintMode.LegacyConnected , /* cppConfig =*/ false, /* cConfig */ false)]
         [DataRow(SonarLintMode.LegacyConnected, /* cppConfig =*/ false, /* cConfig */ true)]
-        public void GetUnboundProjects_ValidSolution_CFamily_RequiresBothCppAndCRulesConfig(SonarLintMode mode,
+        public void GetUnboundProjects_ValidSolution_CFamily_RequiresBothCppAndCConfig(SonarLintMode mode,
             bool cppConfigExists, bool cConfigExists)
         {
             // Cpp projects should have both C++ and C solution-level rules config files

--- a/src/Integration.UnitTests/LocalServices/UnboundProjectFinderTests_ProjectLevelConfig.cs
+++ b/src/Integration.UnitTests/LocalServices/UnboundProjectFinderTests_ProjectLevelConfig.cs
@@ -31,14 +31,14 @@ using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using Language = SonarLint.VisualStudio.Core.Language;
 
-// This file contains tests for SolutionBindingInformationProvider that relate to
+// This file contains tests for UnboundProjectFinder that relate to
 // the project-level config files.
 // The solution-level config tests are in another class.
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     [TestClass]
-    public class SolutionBindingInformationProviderTests_ProjectLevelConfig
+    public class UnboundProjectFinderTests_ProjectLevelConfig
     {
         private ConfigurableServiceProvider serviceProvider;
         private ConfigurableConfigurationProvider configProvider;
@@ -73,7 +73,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ArgCheck()
         {
             // Arrange
-            Action action = () => new SolutionBindingInformationProvider(null);
+            Action action = () => new UnboundProjectFinder(null);
 
             // Act & Assert
             action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("serviceProvider");
@@ -223,8 +223,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Helpers
 
-        private SolutionBindingInformationProvider CreateTestSubject() =>
-            new SolutionBindingInformationProvider(this.serviceProvider, this.fileMock.Object);
+        private UnboundProjectFinder CreateTestSubject() =>
+            new UnboundProjectFinder(this.serviceProvider, this.fileMock.Object);
        
         private IEnumerable<Project> SetValidFilteredProjects()
         {

--- a/src/Integration.UnitTests/LocalServices/UnboundProjectFinderTests_SolutionConfigLevel.cs
+++ b/src/Integration.UnitTests/LocalServices/UnboundProjectFinderTests_SolutionConfigLevel.cs
@@ -29,14 +29,14 @@ using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 
-// This file contains tests for SolutionBindingInformationProvider that relate to
+// This file contains tests for UnboundProjectFinder that relate to
 // the solution-level config files.
 // The project-level config tests are in another class.
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
 {
     [TestClass]
-    public class SolutionBindingInformationProviderTests_SolutionConfigLevel
+    public class UnboundProjectFinderTests_SolutionConfigLevel
     {
         [TestMethod]
         [DataRow(SonarLintMode.Connected)]
@@ -58,7 +58,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         [TestMethod]
         [DataRow(SonarLintMode.Connected)]
         [DataRow(SonarLintMode.LegacyConnected)]
-        public void GetUnboundProjects_ValidSolution_SolutionRuleConfigtIsMissing(SonarLintMode mode)
+        public void GetUnboundProjects_ValidSolution_SolutionRuleConfigIsMissing(SonarLintMode mode)
         {
             // If the solution ruleset is missing then all projects will be returned as unbound
             // Arrange - no projects created
@@ -187,7 +187,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
                 return project;
             }
 
-            public SolutionBindingInformationProvider CreateTestSubject()
+            public UnboundProjectFinder CreateTestSubject()
             {
                 var projectSystemHelper = new Mock<IProjectSystemHelper>();
                 projectSystemHelper.Setup(x => x.GetFilteredSolutionProjects()).Returns(projects);
@@ -203,7 +203,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
                 sp.RegisterService(typeof(IConfigurationProvider), configProviderMock.Object);
                 sp.RegisterService(typeof(IRuleSetSerializer), ruleSetSerializerMock.Object);
 
-                var testSubject = new SolutionBindingInformationProvider(sp, fileMock.Object);
+                var testSubject = new UnboundProjectFinder(sp, fileMock.Object);
                 return testSubject;
             }
 

--- a/src/Integration.Vsix.UnitTests/CFamily/DynamicRulesConfigurationTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/DynamicRulesConfigurationTests.cs
@@ -24,7 +24,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.CFamily;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily

--- a/src/Integration/Binding/BindingController.cs
+++ b/src/Integration/Binding/BindingController.cs
@@ -168,12 +168,12 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             var bindingInformationProvider = new SolutionBindingInformationProvider(host);
 
-            var dotNetConfigProvider = new DotNetRuleConfigurationProvider(host.SonarQubeService, nugetBindingOp,
+            var dotNetConfigProvider = new DotNetBindingConfigProvider(host.SonarQubeService, nugetBindingOp,
                 bindingArgs.Connection.ServerUri.ToString(), bindingArgs.ProjectName,
                 host.Logger);
 
-            var cppConfigProvider = new CFamilyRulesConfigurationProvider(host.SonarQubeService, host.Logger);
-            var ruleConfigProvider = new CompositeRulesConfigurationProvider(dotNetConfigProvider, cppConfigProvider);
+            var cppConfigProvider = new CFamilyBindingConfigProvider(host.SonarQubeService, host.Logger);
+            var ruleConfigProvider = new CompositeBindingConfigProvider(dotNetConfigProvider, cppConfigProvider);
 
             var bindingProcess = new BindingProcessImpl(host, bindingArgs, solutionBindingOp, nugetBindingOp, bindingInformationProvider, ruleConfigProvider, isFirstBinding);
 

--- a/src/Integration/Binding/BindingController.cs
+++ b/src/Integration/Binding/BindingController.cs
@@ -166,7 +166,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 modeToBind,
                 host.Logger);
 
-            var bindingInformationProvider = new SolutionBindingInformationProvider(host);
+            var unboundProjectFinder = new UnboundProjectFinder(host);
 
             var dotNetConfigProvider = new DotNetBindingConfigProvider(host.SonarQubeService, nugetBindingOp,
                 bindingArgs.Connection.ServerUri.ToString(), bindingArgs.ProjectName,
@@ -175,7 +175,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             var cppConfigProvider = new CFamilyBindingConfigProvider(host.SonarQubeService, host.Logger);
             var ruleConfigProvider = new CompositeBindingConfigProvider(dotNetConfigProvider, cppConfigProvider);
 
-            var bindingProcess = new BindingProcessImpl(host, bindingArgs, solutionBindingOp, nugetBindingOp, bindingInformationProvider, ruleConfigProvider, isFirstBinding);
+            var bindingProcess = new BindingProcessImpl(host, bindingArgs, solutionBindingOp, nugetBindingOp, unboundProjectFinder, ruleConfigProvider, isFirstBinding);
 
             return bindingProcess;
         }

--- a/src/Integration/Binding/DotNetBindingConfigFile.cs
+++ b/src/Integration/Binding/DotNetBindingConfigFile.cs
@@ -18,32 +18,32 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
-using SonarLint.VisualStudio.Core.Binding;
-
-// Note: this interface was added as part of the refactoring that was done when
-// the support for configuration of C++ files in Connected Mode was added.
-// It minimised the changes required to the existing binding code that is
-// ruleset-specific, at the cost of downcasts in a couple of places (done by
-// the TryGetRuleSet extension method).
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    /// <summary>
-    /// Extends the base rules configuration interface for C#/VB projects where
-    /// the rules config is expected to be in a ruleset
-    /// </summary>
-    public interface IRulesConfigurationFileWithRuleset : IRulesConfigurationFile
+    internal class DotNetBindingConfigFile : IBindingConfigFileWithRuleset
     {
-        RuleSet RuleSet { get; }
-    }
-
-    internal static class RulesConfigurationFileExtensions
-    {
-        public static bool TryGetRuleSet(this IRulesConfigurationFile rulesConfigurationFile, out RuleSet ruleSet)
+        public DotNetBindingConfigFile(RuleSet ruleSet)
         {
-            ruleSet = (rulesConfigurationFile as IRulesConfigurationFileWithRuleset)?.RuleSet;
-            return ruleSet != null;
+            this.RuleSet = ruleSet ?? throw new ArgumentNullException(nameof(ruleSet));
         }
+
+        #region IBindingConfigFileWithRuleset methods
+
+        public RuleSet RuleSet { get; }
+
+        public void Save(string fullFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(fullFilePath))
+            {
+                throw new ArgumentNullException(nameof(fullFilePath));
+            }
+
+            this.RuleSet.WriteToFile(fullFilePath);
+        }
+
+        #endregion
     }
 }

--- a/src/Integration/Binding/DotNetBindingConfigProvider.cs
+++ b/src/Integration/Binding/DotNetBindingConfigProvider.cs
@@ -35,7 +35,7 @@ using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    internal class DotNetRuleConfigurationProvider : IRulesConfigurationProvider
+    internal class DotNetBindingConfigProvider : IBindingConfigProvider
     {
         private readonly ISonarQubeService sonarQubeService;
         private readonly INuGetBindingOperation nuGetBindingOperation;
@@ -44,7 +44,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly string serverUrl;
         private readonly string projectName;
 
-        public DotNetRuleConfigurationProvider(ISonarQubeService sonarQubeService, INuGetBindingOperation nuGetBindingOperation, string serverUrl, string projectName, ILogger logger)
+        public DotNetBindingConfigProvider(ISonarQubeService sonarQubeService, INuGetBindingOperation nuGetBindingOperation, string serverUrl, string projectName, ILogger logger)
         {
             this.sonarQubeService = sonarQubeService;
             this.nuGetBindingOperation = nuGetBindingOperation;
@@ -58,7 +58,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             return Language.CSharp.Equals(language) || Language.VBNET.Equals(language);
         }
 
-        public async Task<IRulesConfigurationFile> GetRulesConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey, Language language, CancellationToken cancellationToken)
+        public async Task<IBindingConfigFile> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, string organizationKey, Language language, CancellationToken cancellationToken)
         {
             if(!IsLanguageSupported(language))
             {
@@ -103,7 +103,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             // Remove/Move/Refactor code when XML ruleset file is no longer downloaded but the proper API is used to retrieve rules
             UpdateDownloadedSonarQubeQualityProfile(ruleSet, qualityProfile, this.projectName, this.serverUrl);
 
-            return new DotNetRulesConfigurationFile(ruleSet);
+            return new DotNetBindingConfigFile(ruleSet);
         }
 
         private void UpdateDownloadedSonarQubeQualityProfile(RuleSet ruleSet, SonarQubeQualityProfile qualityProfile, string projectName, string serverUrl)

--- a/src/Integration/Binding/IBindingConfigFileWithRuleSet.cs
+++ b/src/Integration/Binding/IBindingConfigFileWithRuleSet.cs
@@ -18,32 +18,32 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+using SonarLint.VisualStudio.Core.Binding;
+
+// Note: this interface was added as part of the refactoring that was done when
+// the support for configuration of C++ files in Connected Mode was added.
+// It minimised the changes required to the existing binding code that is
+// ruleset-specific, at the cost of downcasts in a couple of places (done by
+// the TryGetRuleSet extension method).
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    internal class DotNetRulesConfigurationFile : IRulesConfigurationFileWithRuleset
+    /// <summary>
+    /// Extends the base binding configuration interface for C#/VB projects where
+    /// the config is expected to have a ruleset
+    /// </summary>
+    public interface IBindingConfigFileWithRuleset : IBindingConfigFile
     {
-        public DotNetRulesConfigurationFile(RuleSet ruleSet)
+        RuleSet RuleSet { get; }
+    }
+
+    internal static class BindingConfigurFileExtensions
+    {
+        public static bool TryGetRuleSet(this IBindingConfigFile bindingConfigFile, out RuleSet ruleSet)
         {
-            this.RuleSet = ruleSet ?? throw new ArgumentNullException(nameof(ruleSet));
+            ruleSet = (bindingConfigFile as IBindingConfigFileWithRuleset)?.RuleSet;
+            return ruleSet != null;
         }
-
-        #region IRulesConfigurationFileWithRuleset methods
-
-        public RuleSet RuleSet { get; }
-
-        public void Save(string fullFilePath)
-        {
-            if (string.IsNullOrWhiteSpace(fullFilePath))
-            {
-                throw new ArgumentNullException(nameof(fullFilePath));
-            }
-
-            this.RuleSet.WriteToFile(fullFilePath);
-        }
-
-        #endregion
     }
 }

--- a/src/Integration/Binding/ISolutionRuleStore.cs
+++ b/src/Integration/Binding/ISolutionRuleStore.cs
@@ -30,10 +30,10 @@ namespace SonarLint.VisualStudio.Integration.Binding
     public interface ISolutionRuleStore
     {
         /// <summary>
-        /// Registers a mapping of <see cref="Language"/> to <see cref="IRulesConfigurationFile"/>/>.
+        /// Registers a mapping of <see cref="Language"/> to <see cref="IBindingConfigFile"/>/>.
         /// </summary>
         /// <param name="ruleSets">Required</param>
-        void RegisterKnownRuleSets(IDictionary<Language, IRulesConfigurationFile> ruleSets);
+        void RegisterKnownRuleSets(IDictionary<Language, IBindingConfigFile> ruleSets);
 
         /// <summary>
         /// Retrieves the solution-level rules configuration mapped to the <see cref="Language"/>.

--- a/src/Integration/Binding/ProjectBindingOperation.Writer.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.Writer.cs
@@ -51,7 +51,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             Debug.Assert(solutionRuleSet != null);
 
             // TODO: clean up to remove down-cast to check for RuleSet
-            solutionRuleSet.RulesConfigurationFile.TryGetRuleSet(out var dotNetRuleSet);
+            solutionRuleSet.BindingConfigFile.TryGetRuleSet(out var dotNetRuleSet);
             Debug.Assert(dotNetRuleSet != null, "Only expecting this method to be called for projects that have a VS RuleSet");
 
             string projectRoot = Path.GetDirectoryName(projectFullPath);

--- a/src/Integration/Binding/RuleSetInformation.cs
+++ b/src/Integration/Binding/RuleSetInformation.cs
@@ -30,12 +30,12 @@ namespace SonarLint.VisualStudio.Integration.Binding
     /// </summary>
     public class RuleSetInformation
     {
-        public RuleSetInformation(Language language, IRulesConfigurationFile rulesConfigurationFile)
+        public RuleSetInformation(Language language, IBindingConfigFile bindingConfigFile)
         {
-            RulesConfigurationFile = rulesConfigurationFile ?? throw new ArgumentNullException(nameof(rulesConfigurationFile));
+            BindingConfigFile = bindingConfigFile ?? throw new ArgumentNullException(nameof(bindingConfigFile));
         }
 
-        public IRulesConfigurationFile RulesConfigurationFile { get; }
+        public IBindingConfigFile BindingConfigFile { get; }
 
         public string NewRuleSetFilePath { get; set; }
     }

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -46,26 +46,26 @@ namespace SonarLint.VisualStudio.Integration
         internal /*for testing purposes*/ static readonly Guid ErrorListToolWindowGuid = new Guid(ToolWindowGuids80.ErrorList);
 
         private readonly IHost host;
-        private readonly ISolutionBindingInformationProvider bindingInformationProvider;
+        private readonly IUnboundProjectFinder unboundProjectFinder;
         private readonly IConfigurationProvider configProvider;
         private IInfoBar currentErrorWindowInfoBar;
         private bool currentErrorWindowInfoBarHandlingClick;
         private BoundSonarQubeProject infoBarBinding;
         private bool isDisposed;
 
-        public ErrorListInfoBarController(IHost host, ISolutionBindingInformationProvider bindingInformationProvider)
+        public ErrorListInfoBarController(IHost host, IUnboundProjectFinder unboundProjectFinder)
         {
             if (host == null)
             {
                 throw new ArgumentNullException(nameof(host));
             }
-            if (bindingInformationProvider == null)
+            if (unboundProjectFinder == null)
             {
-                throw new ArgumentNullException(nameof(bindingInformationProvider));
+                throw new ArgumentNullException(nameof(unboundProjectFinder));
             }
 
             this.host = host;
-            this.bindingInformationProvider = bindingInformationProvider;
+            this.unboundProjectFinder = unboundProjectFinder;
 
             this.configProvider = host.GetService<IConfigurationProvider>();
             this.configProvider.AssertLocalServiceIsNotNull();
@@ -88,7 +88,7 @@ namespace SonarLint.VisualStudio.Integration
 
             // TODO: part of SVS-72, need to call IProjectSystemFilter.SetTestRegex
             // and specify the regex that you get from IHost.SonarQubeService.GetProperties
-            // before calling to ISolutionBindingInformationProvider which will internally
+            // before calling to IUnboundProjectFinder which will internally
             // use the regex information to determine which projects are filtered and which are not
             // all this needs to be on a background thread!
 
@@ -195,7 +195,7 @@ namespace SonarLint.VisualStudio.Integration
         {
             this.OutputMessage(Strings.SonarLintCheckingForUnboundProjects);
 
-            Project[] unboundProjects = this.bindingInformationProvider.GetUnboundProjects().ToArray();
+            Project[] unboundProjects = this.unboundProjectFinder.GetUnboundProjects().ToArray();
             if (unboundProjects.Length > 0)
             {
                 this.OutputMessage(Strings.SonarLintFoundUnboundProjects, unboundProjects.Length, string.Join(", ", unboundProjects.Select(p => p.UniqueName)));

--- a/src/Integration/LocalServices/IUnboundProjectFinder.cs
+++ b/src/Integration/LocalServices/IUnboundProjectFinder.cs
@@ -23,18 +23,21 @@ using EnvDTE;
 
 namespace SonarLint.VisualStudio.Integration
 {
-    // "GetUnboundProjects"is used by the error list controller in connected mode (legacy & new)
+    // "GetUnboundProjects" is used by the error list controller in connected mode (legacy & new)
     // to find projects that have been added to a bound solution but do not have the ruleset
     // set correctly.
+    // It is also used by the BindingProcessImpl to find projects that required project-level binding.
 
-    // TODO: rename this interface e.g. IUnboundProjectProvider/Finder/Locator
-    internal interface ISolutionBindingInformationProvider
+    internal interface IUnboundProjectFinder
     {
         /// <summary>
-        /// Return all the SonarQube unbound projects in the current solution.
-        /// It's up to the caller to make sure that the solution is fully loaded before calling this method.
+        /// Return all of the projects in the current solution for which the required solution-level or project-level configuration is missing
         /// </summary>
-        /// <remarks>Internally projects are filtered using the <see cref="IProjectSystemFilter"/> service.
+        /// <remarks>
+        /// It's up to the caller to make sure that the solution is fully loaded before calling this method.
+        /// Not all projects required project-level configuration e.g. Cpp projects. However, they still require
+        /// solution-level configuration (e.g. a  file contains the rules configuration).
+        /// Internally projects are filtered using the <see cref="IProjectSystemFilter"/> service.
         /// <seealso cref="IProjectSystemHelper.GetFilteredSolutionProjects"/></remarks>
         /// <returns>Will always return an instance, never a null</returns>
         IEnumerable<Project> GetUnboundProjects();

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -118,8 +118,8 @@ namespace SonarLint.VisualStudio.Integration
             Debug.Assert(project != null);
 
             // If solution is not bound/is missing a rules configuration file, no need to go further
-            var slnLevelRulesConfigFilepath = CalculateSonarQubeSolutionRuleConfigPath(ruleSetInfoProvider, binding, language);
-            if (!fileWrapper.Exists(slnLevelRulesConfigFilepath))
+            var slnLevelBindingConfigFilepath = CalculateSonarQubeSolutionBindingConfigPath(ruleSetInfoProvider, binding, language);
+            if (!fileWrapper.Exists(slnLevelBindingConfigFilepath))
             {
                 return false;
             }
@@ -131,7 +131,7 @@ namespace SonarLint.VisualStudio.Integration
 
             // Projects that required project-level binding should be using RuleSets for configuration,
             // so we assume that the solution-level config file is a ruleset.
-            RuleSet sonarQubeRuleSet = ruleSetSerializer.LoadRuleSet(slnLevelRulesConfigFilepath);
+            RuleSet sonarQubeRuleSet = ruleSetSerializer.LoadRuleSet(slnLevelBindingConfigFilepath);
             if (sonarQubeRuleSet == null)
             {
                 return false;
@@ -148,7 +148,7 @@ namespace SonarLint.VisualStudio.Integration
             return (projectRuleSet != null && RuleSetIncludeChecker.HasInclude(projectRuleSet, sonarQubeRuleSet));
         }
 
-        private static string CalculateSonarQubeSolutionRuleConfigPath(ISolutionRuleSetsInformationProvider ruleSetInfoProvider, BindingConfiguration binding, Core.Language language)
+        private static string CalculateSonarQubeSolutionBindingConfigPath(ISolutionRuleSetsInformationProvider ruleSetInfoProvider, BindingConfiguration binding, Core.Language language)
             => ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     binding.Project.ProjectKey,
                     language,

--- a/src/Integration/LocalServices/UnboundProjectFinder.cs
+++ b/src/Integration/LocalServices/UnboundProjectFinder.cs
@@ -30,18 +30,18 @@ using SonarLint.VisualStudio.Integration.NewConnectedMode;
 
 namespace SonarLint.VisualStudio.Integration
 {
-    internal class SolutionBindingInformationProvider : ISolutionBindingInformationProvider
+    internal class UnboundProjectFinder : IUnboundProjectFinder
     {
         private readonly IServiceProvider serviceProvider;
         private readonly ISolutionRuleSetsInformationProvider ruleSetInfoProvider;
         private readonly IFile fileWrapper;
 
-        public SolutionBindingInformationProvider(IServiceProvider serviceProvider)
+        public UnboundProjectFinder(IServiceProvider serviceProvider)
             : this(serviceProvider, new FileWrapper())
         {
         }
 
-        internal /* for testing */ SolutionBindingInformationProvider(IServiceProvider serviceProvider, IFile fileWrapper)
+        internal /* for testing */ UnboundProjectFinder(IServiceProvider serviceProvider, IFile fileWrapper)
         {
             if (serviceProvider == null)
             {
@@ -56,7 +56,7 @@ namespace SonarLint.VisualStudio.Integration
             this.fileWrapper = fileWrapper;
         }
 
-        #region ISolutionBindingInformationProvider
+        #region IUnboundProjectFinder implementation
 
         public IEnumerable<Project> GetUnboundProjects()
         {
@@ -73,7 +73,7 @@ namespace SonarLint.VisualStudio.Integration
 
             return this.GetUnboundProjects(bindingConfig);
         }
-        #endregion
+        #endregion IUnboundProjectFinder implementation
 
         #region Non-public API
 

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -321,7 +321,7 @@ namespace SonarLint.VisualStudio.Integration
             this.localServices.Add(typeof(IRuleSetInspector), new Lazy<ILocalService>(() => new RuleSetInspector(this, Logger)));
             this.localServices.Add(typeof(IRuleSetConflictsController), new Lazy<ILocalService>(() => new RuleSetConflictsController(this, new ConflictsManager(this, Logger))));
             this.localServices.Add(typeof(IProjectSystemFilter), new Lazy<ILocalService>(() => new ProjectSystemFilter(this)));
-            this.localServices.Add(typeof(IErrorListInfoBarController), new Lazy<ILocalService>(() => new ErrorListInfoBarController(this, new SolutionBindingInformationProvider(this))));
+            this.localServices.Add(typeof(IErrorListInfoBarController), new Lazy<ILocalService>(() => new ErrorListInfoBarController(this, new UnboundProjectFinder(this))));
 
             // Use Lazy<object> to avoid creating instances needlessly, since the interfaces are serviced by the same instance
             var sccFs = new Lazy<ILocalService>(() => new SourceControlledFileSystem(this, Logger));

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -611,11 +611,11 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to create the rules configuration for language {0}.
+        ///   Looks up a localized string similar to Failed to create the configuration for language {0}.
         /// </summary>
-        public static string FailedToCreateRulesConfigForLanguage {
+        public static string FailedToCreateBindingConfigForLanguage {
             get {
-                return ResourceManager.GetString("FailedToCreateRulesConfigForLanguage", resourceCulture);
+                return ResourceManager.GetString("FailedToCreateBindingConfigForLanguage", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -742,9 +742,9 @@ This is the general format to use when writing errors to output window or when t
   <data name="Bind_Ruleset_SomeProjectsDoNotNeedToBeUpdated" xml:space="preserve">
     <value>Ruleset binding: the following projects already reference the generated ruleset:</value>
   </data>
-  <data name="FailedToCreateRulesConfigForLanguage" xml:space="preserve">
-    <value>Failed to create the rules configuration for language {0}</value>
-    <comment>Output window message displayed when the application failed to fetch and create the rules configuration associated with a language. {0} the language name.</comment>
+  <data name="FailedToCreateBindingConfigForLanguage" xml:space="preserve">
+    <value>Failed to create the configuration for language {0}</value>
+    <comment>Output window message displayed when the application failed to fetch and create the binding configuration associated with a language. {0} the language name.</comment>
   </data>
   <data name="Bind_Project_NotRequired" xml:space="preserve">
     <value>Project-level binding is not required for project '{0}'</value>

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionRuleStore.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionRuleStore.cs
@@ -41,7 +41,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return ruleSet;
         }
 
-        void ISolutionRuleStore.RegisterKnownRuleSets(IDictionary<Language, IRulesConfigurationFile> ruleSets)
+        void ISolutionRuleStore.RegisterKnownRuleSets(IDictionary<Language, IBindingConfigFile> ruleSets)
         {
             ruleSets.Should().NotBeNull("Not expecting nulls");
 
@@ -55,12 +55,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Test helpers
 
-        public void RegisterRuleSetPath(Language language, string path, IRulesConfigurationFile rulesConfiguration = null)
+        public void RegisterRuleSetPath(Language language, string path, IBindingConfigFile bindingConfig = null)
         {
             if (!this.availableRuleSets.ContainsKey(language))
             {
-                rulesConfiguration = rulesConfiguration ?? new DotNetRulesConfigurationFile(new RuleSet("SonarQube"));
-                this.availableRuleSets[language] = new RuleSetInformation(language, rulesConfiguration);
+                bindingConfig = bindingConfig ?? new DotNetBindingConfigFile(new RuleSet("SonarQube"));
+                this.availableRuleSets[language] = new RuleSetInformation(language, bindingConfig);
             }
 
             this.availableRuleSets[language].NewRuleSetFilePath = path;

--- a/src/TestInfrastructure/Framework/ConfigurableUnboundProjectFinder.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableUnboundProjectFinder.cs
@@ -24,7 +24,7 @@ using EnvDTE;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
-    internal class ConfigurableSolutionBindingInformationProvider : ISolutionBindingInformationProvider
+    internal class ConfigurableUnboundProjectFinder : IUnboundProjectFinder
     {
         public IEnumerable<Project> UnboundProjects { get; set; } = Enumerable.Empty<Project>();
 


### PR DESCRIPTION
* no code changes - only renames.
* there were too many interfaces/classes with "Rules" in the name. Renamed the binding-related ones to include "Binding" to make it clearer they are binding-specific.
* shortened names.