### PR TITLE
Changed "RuleSet" in name where no longer appropriate

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingProcessImplTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingProcessImplTests.cs
@@ -146,9 +146,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Assert
             result.Should().BeTrue();
-            testSubject.InternalState.Rulesets.Should().ContainKey(language);
-            testSubject.InternalState.Rulesets[language].Should().Be(configFile);
-            testSubject.InternalState.Rulesets.Count().Should().Be(1);
+            testSubject.InternalState.BindingConfigFiles.Should().ContainKey(language);
+            testSubject.InternalState.BindingConfigFiles[language].Should().Be(configFile);
+            testSubject.InternalState.BindingConfigFiles.Count().Should().Be(1);
 
             testSubject.InternalState.QualityProfiles[language].Should().Be(profile);
 
@@ -178,8 +178,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Assert
             result.Should().BeFalse();
-            testSubject.InternalState.Rulesets.Should().NotContainKey(Language.VBNET, "Not expecting any rules for this language");
-            testSubject.InternalState.Rulesets.Should().NotContainKey(language, "Not expecting any rules");
+            testSubject.InternalState.BindingConfigFiles.Should().NotContainKey(Language.VBNET, "Not expecting any rules for this language");
+            testSubject.InternalState.BindingConfigFiles.Should().NotContainKey(language, "Not expecting any rules");
 
             notifications.AssertProgressMessages(Strings.DownloadingQualityProfileProgressMessage);
 

--- a/src/Integration.UnitTests/Binding/ProjectBindingOperation.WriterTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectBindingOperation.WriterTests.cs
@@ -192,7 +192,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             );
             var dotNetConfig = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetConfig) { NewRuleSetFilePath = newSolutionRuleSetPath };
+            var ruleSetInfo = new ConfigFileInformation(dotNetConfig) { NewFilePath = newSolutionRuleSetPath };
 
             // Act
             string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetName, ruleSetInfo, existingProjectRuleSetPath);
@@ -233,7 +233,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             );
             var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = newSolutionRuleSetPath };
+            var ruleSetInfo = new ConfigFileInformation(dotNetRuleSet) { NewFilePath = newSolutionRuleSetPath };
 
             // Act
             string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetName, ruleSetInfo, PathHelper.CalculateRelativePath(projectFullPath, existingProjectRuleSetPath));
@@ -269,7 +269,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             );
             var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = solutionRuleSetPath };
+            var ruleSetInfo = new ConfigFileInformation(dotNetRuleSet) { NewFilePath = solutionRuleSetPath };
 
             // Act
             string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetName, ruleSetInfo, existingProjectRuleSetPath);
@@ -313,7 +313,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             );
             var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = solutionRuleSetPath };
+            var ruleSetInfo = new ConfigFileInformation(dotNetRuleSet) { NewFilePath = solutionRuleSetPath };
 
             // Act
             string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetName, ruleSetInfo, relativePathToExistingProjectRuleSet);
@@ -353,7 +353,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             );
             var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = newSolutionRuleSetPath };
+            var ruleSetInfo = new ConfigFileInformation(dotNetRuleSet) { NewFilePath = newSolutionRuleSetPath };
 
             // Act
             string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetFileName, ruleSetInfo, currentNonExistingRuleSet);
@@ -387,7 +387,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             );
             var dotNetRuleSet = new DotNetBindingConfigFile(expectedRuleSet);
 
-            var ruleSetInfo = new RuleSetInformation(Language.CSharp, dotNetRuleSet) { NewRuleSetFilePath = solutionRuleSetPath };
+            var ruleSetInfo = new ConfigFileInformation(dotNetRuleSet) { NewFilePath = solutionRuleSetPath };
 
             List<string> filesPending = new List<string>();
             foreach (var currentRuleSet in new[] { null, string.Empty, ProjectBindingOperation.DefaultProjectRuleSet })

--- a/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
@@ -180,7 +180,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_VariousRuleSetsInProjects()
         {
             // Arrange
-            this.ruleStore.RegisterRuleSetPath(Language.VBNET, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterConfigFilePath(Language.VBNET, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
             PropertyMock customRuleSetProperty1 = CreateProperty(this.projectMock, "config1", "Custom.ruleset");
@@ -219,7 +219,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_SameNonDefaultRuleSetsInProject()
         {
             // Arrange
-            this.ruleStore.RegisterRuleSetPath(Language.VBNET, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterConfigFilePath(Language.VBNET, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
             PropertyMock customRuleSetProperty1 = CreateProperty(this.projectMock, "config1", "Custom.ruleset");
@@ -246,7 +246,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_SameDefaultRuleSetsInProject()
         {
             // Arrange
-            this.ruleStore.RegisterRuleSetPath(Language.VBNET, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterConfigFilePath(Language.VBNET, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
             PropertyMock defaultRuleSetProperty1 = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
@@ -273,7 +273,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_Cancellation()
         {
             // Arrange
-            this.ruleStore.RegisterRuleSetPath(Language.CSharp, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterConfigFilePath(Language.CSharp, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
             PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
@@ -300,7 +300,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            this.ruleStore.RegisterRuleSetPath(Language.CSharp, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterConfigFilePath(Language.CSharp, @"c:\Solution\sln.ruleset");
             PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);
@@ -325,7 +325,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            this.ruleStore.RegisterRuleSetPath(Language.CSharp, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterConfigFilePath(Language.CSharp, @"c:\Solution\sln.ruleset");
             PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);

--- a/src/Integration/Binding/BindingProcessImpl.cs
+++ b/src/Integration/Binding/BindingProcessImpl.cs
@@ -132,7 +132,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     return false;
                 }
 
-                this.InternalState.Rulesets[language] = bindingConfig;
+                this.InternalState.BindingConfigFiles[language] = bindingConfig;
 
                 currentLanguage++;
                 progress?.Report(new FixedStepsProgress(string.Empty, currentLanguage, languageCount));
@@ -156,7 +156,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         public void InitializeSolutionBindingOnUIThread()
         {
-            this.solutionBindingOperation.RegisterKnownRuleSets(this.InternalState.Rulesets);
+            this.solutionBindingOperation.RegisterKnownConfigFiles(this.InternalState.BindingConfigFiles);
 
             var projectsToUpdate = GetProjectsForRulesetBinding(this.InternalState.IsFirstBinding, this.InternalState.BindingProjects.ToArray(),
                 this.unboundProjectFinder, this.host.Logger);
@@ -289,7 +289,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 get;
             } = new HashSet<Project>();
 
-            public Dictionary<Language, IBindingConfigFile> Rulesets
+            public Dictionary<Language, IBindingConfigFile> BindingConfigFiles
             {
                 get;
             } = new Dictionary<Language, IBindingConfigFile>();

--- a/src/Integration/Binding/ConfigFileInformation.cs
+++ b/src/Integration/Binding/ConfigFileInformation.cs
@@ -20,7 +20,6 @@
 
 using System;
 using SonarLint.VisualStudio.Core.Binding;
-using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
@@ -28,15 +27,15 @@ namespace SonarLint.VisualStudio.Integration.Binding
     /// Data class that exposes simple data that can be accessed from any thread.
     /// The class itself is not thread safe and assumes only one thread accessing it at any given time.
     /// </summary>
-    public class RuleSetInformation
+    public class ConfigFileInformation
     {
-        public RuleSetInformation(Language language, IBindingConfigFile bindingConfigFile)
+        public ConfigFileInformation(IBindingConfigFile bindingConfigFile)
         {
             BindingConfigFile = bindingConfigFile ?? throw new ArgumentNullException(nameof(bindingConfigFile));
         }
 
         public IBindingConfigFile BindingConfigFile { get; }
 
-        public string NewRuleSetFilePath { get; set; }
+        public string NewFilePath { get; set; }
     }
 }

--- a/src/Integration/Binding/ISolutionBindingConfigFileStore.cs
+++ b/src/Integration/Binding/ISolutionBindingConfigFileStore.cs
@@ -25,19 +25,19 @@ using Language = SonarLint.VisualStudio.Core.Language;
 namespace SonarLint.VisualStudio.Integration.Binding
 {
     /// <summary>
-    /// Provides access to solution level rules
+    /// Provides access to solution-level binding configuration files
     /// </summary>
-    public interface ISolutionRuleStore
+    public interface ISolutionBindingConfigFileStore
     {
         /// <summary>
         /// Registers a mapping of <see cref="Language"/> to <see cref="IBindingConfigFile"/>/>.
         /// </summary>
-        /// <param name="ruleSets">Required</param>
-        void RegisterKnownRuleSets(IDictionary<Language, IBindingConfigFile> ruleSets);
+        /// <param name="languageToFileMap">Required</param>
+        void RegisterKnownConfigFiles(IDictionary<Language, IBindingConfigFile> languageToFileMap);
 
         /// <summary>
-        /// Retrieves the solution-level rules configuration mapped to the <see cref="Language"/>.
+        /// Retrieves the solution-level configuration mapped to the <see cref="Language"/>.
         /// </summary>
-        RuleSetInformation GetRuleSetInformation(Language language);
+        ConfigFileInformation GetConfigFileInformation(Language language);
     }
 }

--- a/src/Integration/Binding/ISolutionBindingOperation.cs
+++ b/src/Integration/Binding/ISolutionBindingOperation.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
     /// * co-ordinates writing project-level changes (delegating to to <see cref="ProjectBindingOperation"/>)
     /// For legacy connected mode, the solution-level items are added to the solution file
     /// </remarks>
-    public interface ISolutionBindingOperation : ISolutionRuleStore
+    public interface ISolutionBindingOperation : ISolutionBindingConfigFileStore
     {
         void Initialize(IEnumerable<Project> projects, IDictionary<Language, SonarQubeQualityProfile> profilesMap);
 

--- a/src/Integration/Binding/ProjectBindingOperation.Writer.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.Writer.cs
@@ -44,7 +44,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <param name="ruleSetFileName">The rule set file name</param>
         /// <param name="solutionRuleSet\">Full path of the parent solution-level SonarQube rule set</param>
         /// <returns>Full file path of the file that we expect to write to</returns>
-        internal /*for testing purposes*/ string QueueWriteProjectLevelRuleSet(string projectFullPath, string ruleSetFileName, RuleSetInformation solutionRuleSet, string currentRuleSetPath)
+        internal /*for testing purposes*/ string QueueWriteProjectLevelRuleSet(string projectFullPath, string ruleSetFileName, ConfigFileInformation solutionRuleSet, string currentRuleSetPath)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(projectFullPath));
             Debug.Assert(!string.IsNullOrWhiteSpace(ruleSetFileName));
@@ -59,7 +59,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             string existingRuleSetPath;
             RuleSet existingRuleSet;
-            if (this.TryUpdateExistingProjectRuleSet(solutionRuleSet.NewRuleSetFilePath, ruleSetRoot, currentRuleSetPath, out existingRuleSetPath, out existingRuleSet))
+            if (this.TryUpdateExistingProjectRuleSet(solutionRuleSet.NewFilePath, ruleSetRoot, currentRuleSetPath, out existingRuleSetPath, out existingRuleSet))
             {
                 Debug.Assert(existingRuleSetPath != null);
                 Debug.Assert(existingRuleSet != null);
@@ -75,7 +75,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
 
             // Create a new project level rule set
-            string solutionIncludePath = PathHelper.CalculateRelativePath(ruleSetRoot, solutionRuleSet.NewRuleSetFilePath);
+            string solutionIncludePath = PathHelper.CalculateRelativePath(ruleSetRoot, solutionRuleSet.NewFilePath);
             
             RuleSet newRuleSet = GenerateNewProjectRuleSet(solutionIncludePath, currentRuleSetPath, dotNetRuleSet.DisplayName);
             string newRuleSetPath = this.GenerateNewProjectRuleSetPath(ruleSetRoot, ruleSetFileName);

--- a/src/Integration/Binding/ProjectBindingOperation.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.cs
@@ -37,17 +37,17 @@ namespace SonarLint.VisualStudio.Integration.Binding
     {
         private readonly IServiceProvider serviceProvider;
         private readonly ISourceControlledFileSystem sourceControlledFileSystem;
-        private readonly ISolutionRuleStore ruleStore;
+        private readonly ISolutionBindingConfigFileStore configFileStore;
 
         private readonly Dictionary<Property, PropertyInformation> propertyInformationMap = new Dictionary<Property, PropertyInformation>();
         private readonly Project initializedProject;
         private readonly ILogger logger;
 
-        public ProjectBindingOperation(IServiceProvider serviceProvider, Project project, ISolutionRuleStore ruleStore, ILogger logger)
+        public ProjectBindingOperation(IServiceProvider serviceProvider, Project project, ISolutionBindingConfigFileStore configFileStore, ILogger logger)
         {
             this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             this.initializedProject = project ?? throw new ArgumentNullException(nameof(project));
-            this.ruleStore = ruleStore ?? throw new ArgumentNullException(nameof(ruleStore));
+            this.configFileStore = configFileStore ?? throw new ArgumentNullException(nameof(configFileStore));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             this.sourceControlledFileSystem = this.serviceProvider.GetService<ISourceControlledFileSystem>();
@@ -77,7 +77,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         public void Prepare(CancellationToken token)
         {
-            var solutionRuleSet = this.ruleStore.GetRuleSetInformation(this.ProjectLanguage);
+            var solutionRuleSet = this.configFileStore.GetConfigFileInformation(this.ProjectLanguage);
 
             // We want to limit the number of rulesets so for this we use the previously calculated TargetRuleSetFileName
             // and group by it. This handles the special case of all the properties having the same ruleset and also the case

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionRuleStore.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionRuleStore.cs
@@ -27,27 +27,27 @@ using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
-    internal class ConfigurableSolutionRuleStore : ISolutionRuleStore
+    internal class ConfigurableSolutionRuleStore : ISolutionBindingConfigFileStore
     {
-        private readonly Dictionary<Language, RuleSetInformation> availableRuleSets = new Dictionary<Language, RuleSetInformation>();
+        private readonly Dictionary<Language, ConfigFileInformation> availableFiles = new Dictionary<Language, ConfigFileInformation>();
 
         #region ISolutionRuleStore
 
-        RuleSetInformation ISolutionRuleStore.GetRuleSetInformation(Language language)
+        ConfigFileInformation ISolutionBindingConfigFileStore.GetConfigFileInformation(Language language)
         {
-            RuleSetInformation ruleSet;
-            this.availableRuleSets.TryGetValue(language, out ruleSet);
+            ConfigFileInformation ruleSet;
+            this.availableFiles.TryGetValue(language, out ruleSet);
 
             return ruleSet;
         }
 
-        void ISolutionRuleStore.RegisterKnownRuleSets(IDictionary<Language, IBindingConfigFile> ruleSets)
+        void ISolutionBindingConfigFileStore.RegisterKnownConfigFiles(IDictionary<Language, IBindingConfigFile> languageToFileMap)
         {
-            ruleSets.Should().NotBeNull("Not expecting nulls");
+            languageToFileMap.Should().NotBeNull("Not expecting nulls");
 
-            foreach (var rule in ruleSets)
+            foreach (var rule in languageToFileMap)
             {
-                availableRuleSets.Add(rule.Key, new RuleSetInformation(rule.Key, rule.Value));
+                availableFiles.Add(rule.Key, new ConfigFileInformation(rule.Value));
             }
         }
 
@@ -55,15 +55,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Test helpers
 
-        public void RegisterRuleSetPath(Language language, string path, IBindingConfigFile bindingConfig = null)
+        public void RegisterConfigFilePath(Language language, string path, IBindingConfigFile bindingConfig = null)
         {
-            if (!this.availableRuleSets.ContainsKey(language))
+            if (!this.availableFiles.ContainsKey(language))
             {
                 bindingConfig = bindingConfig ?? new DotNetBindingConfigFile(new RuleSet("SonarQube"));
-                this.availableRuleSets[language] = new RuleSetInformation(language, bindingConfig);
+                this.availableFiles[language] = new ConfigFileInformation(bindingConfig);
             }
 
-            this.availableRuleSets[language].NewRuleSetFilePath = path;
+            this.availableFiles[language].NewFilePath = path;
         }
 
         #endregion Test helpers


### PR DESCRIPTION
* no product changes - renaming only.
* not all project types are configured using RuleSets to so the use of "RuleSet" in some method names is no longer appropriate. Changed to be more general e.g. "ConfigFile"