### PR TITLE
Moved CFamily classes out of Integration.csproj to Core where possible

### DIFF
--- a/src/Core.UnitTests/CFamily/DynamicCFamilyRulesConfigTests.cs
+++ b/src/Core.UnitTests/CFamily/DynamicCFamilyRulesConfigTests.cs
@@ -23,11 +23,10 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.CFamily;
-using SonarLint.VisualStudio.Integration.CFamily;
+using SonarLint.VisualStudio.Integration.UnitTests.CFamily;
 
-namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
+namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
 {
     [TestClass]
     public class DynamicCFamilyRulesConfigTests

--- a/src/Core/CFamily/CFamilyShared.cs
+++ b/src/Core/CFamily/CFamilyShared.cs
@@ -21,7 +21,7 @@
 using System;
 using System.IO;
 
-namespace SonarLint.VisualStudio.Integration.CFamily
+namespace SonarLint.VisualStudio.Core.CFamily
 {
     public static class CFamilyShared
     {

--- a/src/Core/CFamily/DynamicCFamilyRulesConfig.cs
+++ b/src/Core/CFamily/DynamicCFamilyRulesConfig.cs
@@ -22,13 +22,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Core.CFamily;
 
-namespace SonarLint.VisualStudio.Integration.CFamily
+namespace SonarLint.VisualStudio.Core.CFamily
 {
     // Wrapper that handles applying user-level settings on top of the default config
-    internal sealed class DynamicCFamilyRulesConfig : ICFamilyRulesConfig
+    public sealed class DynamicCFamilyRulesConfig : ICFamilyRulesConfig
     {
         private readonly ICFamilyRulesConfig defaultRulesConfig;
 

--- a/src/Integration.Vsix/SonarLintDaemon/DisableRuleCommand.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/DisableRuleCommand.cs
@@ -27,7 +27,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Integration.CFamily;
+using SonarLint.VisualStudio.Core.CFamily;
 using Task = System.Threading.Tasks.Task;
 
 namespace SonarLint.VisualStudio.Integration.Vsix

--- a/src/Integration/CFamily/CFamilyRulesConfigProvider.cs
+++ b/src/Integration/CFamily/CFamilyRulesConfigProvider.cs
@@ -25,6 +25,9 @@ using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 
+// Note: currently this class needs to be in the the Integration assembly because it
+//   references IHost and other internal interfaces.
+
 namespace SonarLint.VisualStudio.Integration.CFamily
 {
     [Export(typeof(ICFamilyRulesConfigProvider))]

--- a/src/TestInfrastructure/CFamily/DummyCFamilyRulesConfig.cs
+++ b/src/TestInfrastructure/CFamily/DummyCFamilyRulesConfig.cs
@@ -24,7 +24,7 @@ using SonarLint.VisualStudio.Core.CFamily;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
 {
-    internal class DummyCFamilyRulesConfig : ICFamilyRulesConfig
+    public class DummyCFamilyRulesConfig : ICFamilyRulesConfig
     {
         public static ICFamilyRulesConfig CreateValidRulesConfig(string languageKey) =>
             new DummyCFamilyRulesConfig


### PR DESCRIPTION
* moved all of the CFamily-related classes that can be moved without additional refactoring out of Integration.csproj and into Core
* moved related tests
* the only remaining class CFamilyRulesConfigProvider still references internal interfaces and so would require more work to move