### PR TITLE
Set connected mode rule settings Parameters to null if no params

### DIFF
--- a/src/Core.UnitTests/CFamily/CFamilyBindingConfigProviderTests.cs
+++ b/src/Core.UnitTests/CFamily/CFamilyBindingConfigProviderTests.cs
@@ -82,8 +82,8 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             settings.Rules["repo1:key3"].Severity.Should().BeNull();
 
 
-            settings.Rules["repo1:key1"].Parameters.Should().BeEmpty();
-            settings.Rules["repo1:key2"].Parameters.Should().BeEmpty();
+            settings.Rules["repo1:key1"].Parameters.Should().BeNull();
+            settings.Rules["repo1:key2"].Parameters.Should().BeNull();
     
             var rule3Params = settings.Rules["repo1:key3"].Parameters;
             rule3Params.Should().NotBeNull();
@@ -135,7 +135,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             slvsRules["repo1:key1"].Severity.Should().Be(IssueSeverity.Major);
             slvsRules["repo2:key2"].Severity.Should().Be(IssueSeverity.Info);
 
-            slvsRules["repo1:key1"].Parameters.Should().BeEmpty();
+            slvsRules["repo1:key1"].Parameters.Should().BeNull();
 
             var rule2Params = slvsRules["repo2:key2"].Parameters;
             rule2Params.Should().NotBeNull();

--- a/src/Core/CFamily/CFamilyBindingConfigProvider.cs
+++ b/src/Core/CFamily/CFamilyBindingConfigProvider.cs
@@ -89,10 +89,18 @@ namespace SonarLint.VisualStudio.Core.CFamily
 
         private static RuleConfig ToRuleConfig(SonarQubeRule sonarQubeRule)
         {
+            // Most rules don't have parameters, so to avoid creating objects unnecessarily
+            // we'll leave the parameters as null unless there really are values.
+            Dictionary<string, string> parameters = null;
+            if ((sonarQubeRule?.Parameters.Count ?? 0) != 0)
+            {
+                parameters = sonarQubeRule?.Parameters.ToDictionary(p => p.Key, p => p.Value);
+            }
+
             var config = new RuleConfig()
             {
                 Level = sonarQubeRule.IsActive ? RuleLevel.On : RuleLevel.Off,
-                Parameters = sonarQubeRule?.Parameters.ToDictionary(p => p.Key, p => p.Value),
+                Parameters = parameters,
                 Severity = Convert(sonarQubeRule.Severity)
             };
 

--- a/src/Core/CFamily/CFamilyBindingConfigProvider.cs
+++ b/src/Core/CFamily/CFamilyBindingConfigProvider.cs
@@ -92,9 +92,9 @@ namespace SonarLint.VisualStudio.Core.CFamily
             // Most rules don't have parameters, so to avoid creating objects unnecessarily
             // we'll leave the parameters as null unless there really are values.
             Dictionary<string, string> parameters = null;
-            if ((sonarQubeRule?.Parameters.Count ?? 0) != 0)
+            if ((sonarQubeRule.Parameters?.Count ?? 0) != 0)
             {
-                parameters = sonarQubeRule?.Parameters.ToDictionary(p => p.Key, p => p.Value);
+                parameters = sonarQubeRule.Parameters.ToDictionary(p => p.Key, p => p.Value);
             }
 
             var config = new RuleConfig()

--- a/src/Core/UserSettings.cs
+++ b/src/Core/UserSettings.cs
@@ -71,7 +71,8 @@ namespace SonarLint.VisualStudio.Core
         // Note: property will be null if "parameters" is missing from the file.
         // This is what we want: most rules won't have parameters and we want to avoid
         // creating hundreds of unnecessary empty dictionaries.
-        // The only downside is that the dictionary that is created won't 
+        // The only downside is that the dictionary that is created will use the default
+        // comparer, which is case-sensitive.
         [JsonProperty("parameters", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, string> Parameters { get; set; }
 


### PR DESCRIPTION
* optimisation to avoid creating hundreds of empty dictionaries.

Note:
* there are already unit tests to check that serialization/deserialization handles null correctly.
* the sonarqube client library GetRulesAsync request is still creating hundreds of empty dictionaries