### PR TITLE
Added pause to CancellableJobRunner test to reduce flakiness

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/CancellableJobRunnerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/CancellableJobRunnerTests.cs
@@ -141,6 +141,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
 
 
             WaitForRunnerToFinish(testSubject, testLogger);
+            // Pause for any final progress steps to be reported before checking the progressRecorder below
+            Thread.Sleep(200);
 
             // Other checks
             testSubject.State.Should().Be(CancellableJobRunner.RunnerState.Cancelled);

--- a/src/Integration.Vsix/SonarLintTagger/CancellableJobRunner.cs
+++ b/src/Integration.Vsix/SonarLintTagger/CancellableJobRunner.cs
@@ -81,7 +81,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         {
             var runner = new CancellableJobRunner(jobDescription, operations, progress, logger);
 
-            runner.Execute()
+            runner.ExecuteAsync()
                 .Forget(); // kick off the re-analysis process and return
 
             return runner;
@@ -101,7 +101,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             cancellationSource = new CancellationTokenSource();
         }
 
-        private async System.Threading.Tasks.Task Execute()
+        private async System.Threading.Tasks.Task ExecuteAsync()
         {
             State = RunnerState.Running;
 


### PR DESCRIPTION
The CancelAfterFirstOperation test fails intermittently because of timing issue.
It's not a product issues and it isn't worth the cost of refactoring the product code to make the test 100% reliable, so I've added a 200ms pause to see if that improves reliability sufficiently.

Relates to #1238