### PR TITLE
Renamed Roslyn-specific classes

### DIFF
--- a/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerConnectedWorkflowTests.cs
+++ b/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerConnectedWorkflowTests.cs
@@ -33,12 +33,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     [TestClass]
     public class SonarAnalyzerConnectedWorkflowTests
     {
-        private Mock<ISuppressionHandler> suppressionHandlerMock;
+        private Mock<IRoslynSuppressionHandler> suppressionHandlerMock;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            suppressionHandlerMock = new Mock<ISuppressionHandler>();
+            suppressionHandlerMock = new Mock<IRoslynSuppressionHandler>();
         }
 
         #region Ctor Tests

--- a/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerLegacyConnectedWorkflowTests.cs
+++ b/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerLegacyConnectedWorkflowTests.cs
@@ -38,7 +38,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     {
         private class TestableSonarAnalyzerLegacyConnectedWorkflow : SonarAnalyzerLegacyConnectedWorkflow
         {
-            public TestableSonarAnalyzerLegacyConnectedWorkflow(ISuppressionHandler suppressionHandler, ILogger logger)
+            public TestableSonarAnalyzerLegacyConnectedWorkflow(IRoslynSuppressionHandler suppressionHandler, ILogger logger)
                 : base(new AdhocWorkspace(), suppressionHandler, logger)
             {
             }
@@ -60,13 +60,13 @@ namespace SonarAnalyzer.Helpers
 }";
         private const string SonarAnalyzerAssemblyName = "SonarAnalyzer";
 
-        private Mock<ISuppressionHandler> suppressionHandlerMock;
+        private Mock<IRoslynSuppressionHandler> suppressionHandlerMock;
         private Mock<ILogger> loggerMock;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            suppressionHandlerMock = new Mock<ISuppressionHandler>();
+            suppressionHandlerMock = new Mock<IRoslynSuppressionHandler>();
             loggerMock = new Mock<ILogger>();
         }
 

--- a/src/Integration.Vsix.UnitTests/Suppression/RoslynLiveIssueFactoryTests.cs
+++ b/src/Integration.Vsix.UnitTests/Suppression/RoslynLiveIssueFactoryTests.cs
@@ -34,7 +34,7 @@ using static SonarLint.VisualStudio.Integration.UnitTests.Helpers.MoqExtensions;
 namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
 {
     [TestClass]
-    public class LiveIssueFactoryTests
+    public class RoslynLiveIssueFactoryTests
     {
         // Well-known value for a project that exists in the solution
         private const string ProjectInSolutionFilePath = "C:\\Project1.csproj";
@@ -46,7 +46,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
         public void Ctor_WithNullWorkspace_ThrowsArgumentNullException()
         {
             // Arrange
-            Action action = () => new LiveIssueFactory(null, new Mock<IVsSolution>().Object);
+            Action action = () => new RoslynLiveIssueFactory(null, new Mock<IVsSolution>().Object);
 
             // Assert
             action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("workspace");
@@ -56,7 +56,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
         public void Ctor_WithNullVsSolution_ThrowsArgumentNullException()
         {
             // Arrange
-            Action action = () => new LiveIssueFactory(new AdhocWorkspace(), null);
+            Action action = () => new RoslynLiveIssueFactory(new AdhocWorkspace(), null);
 
             // Assert
             action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("vsSolution");
@@ -72,7 +72,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
                 new KeyValuePair<string, string>("Project2", "22222222-2222-2222-2222-222222222222"));
 
             // Act
-            new LiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
+            new RoslynLiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
 
             // Assert
             vsSolutionMock.Verify(x => x.GetProjectFilesInSolution(0, It.IsAny<uint>(), It.IsAny<string[]>(), out fileCountOut),
@@ -99,7 +99,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
             uint fileCountOut;
 
             // Act
-            IDictionary<string, string> map = LiveIssueFactory.BuildProjectPathToIdMap(vsSolutionMock.Object);
+            IDictionary<string, string> map = RoslynLiveIssueFactory.BuildProjectPathToIdMap(vsSolutionMock.Object);
 
             // Assert
             vsSolutionMock.Verify(x => x.GetProjectFilesInSolution(0, It.IsAny<uint>(), It.IsAny<string[]>(), out fileCountOut),
@@ -131,7 +131,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
                 .Returns(Guid.Empty);
 
             // Act
-            new LiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
+            new RoslynLiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
 
             // Assert
             vsSolutionMock.Verify(x => x.GetProjectFilesInSolution(0, It.IsAny<uint>(), It.IsAny<string[]>(), out fileCount),
@@ -147,13 +147,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
             uint fileCount = 0;
             vsSolutionMock.Setup(x => x.GetProjectFilesInSolution(0, 0, null, out fileCount))
                 .Returns(VSConstants.S_OK);
-            vsSolutionMock.Setup(x => x.GetProjectFilesInSolution(0, 0, new string[0], out fileCount))
+            vsSolutionMock.Setup(x => x.GetProjectFilesInSolution(0, 0, Array.Empty<string>(), out fileCount))
                 .Returns(VSConstants.E_FAIL);
             vsSolutionMock.As<IVsSolution5>().Setup(x => x.GetGuidOfProjectFile(It.IsAny<string>()))
                 .Returns(Guid.Empty);
 
             // Act
-            new LiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
+            new RoslynLiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
 
             // Assert
             vsSolutionMock.Verify(x => x.GetProjectFilesInSolution(0, It.IsAny<uint>(), It.IsAny<string[]>(), out fileCount),
@@ -179,7 +179,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
                 }));
             vsSolutionMock.As<IVsSolution5>().Setup(x => x.GetGuidOfProjectFile(It.IsAny<string>()))
                 .Returns(Guid.Empty);
-            var liveIssueFactory = new LiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
+            var liveIssueFactory = new RoslynLiveIssueFactory(new AdhocWorkspace(), vsSolutionMock.Object);
 
             var diagnostic = CreateDiagnostic(Location.None);
 
@@ -315,7 +315,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
 }"), VersionStamp.Default))));
             workspace.TryApplyChanges(solution);
 
-            var liveIssueFactory = new LiveIssueFactory(workspace, vsSolutionMock.Object);
+            var liveIssueFactory = new RoslynLiveIssueFactory(workspace, vsSolutionMock.Object);
 
             var syntaxTree = workspace.CurrentSolution.Projects.First().GetCompilationAsync().Result.SyntaxTrees.First();
 
@@ -358,6 +358,5 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
 
             return vsSolutionMock;
         }
-
     }
 }

--- a/src/Integration.Vsix.UnitTests/Suppression/RoslynLiveIssueFactoryTests.cs
+++ b/src/Integration.Vsix.UnitTests/Suppression/RoslynLiveIssueFactoryTests.cs
@@ -216,12 +216,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
         public void Create_WhenIssueIsModuleLevel_ReturnsExpectedIssue()
         {
             // Arrange & Act
-            var diagnostic = CreateDiagnostic(Location.None);
+            var diagnostic = CreateDiagnostic(Location.None, "cpp:123");
             var result = SetupAndCreate(diagnostic, diagnosticProjectFilePath: ProjectInSolutionFilePath);
 
             // Assert
             result.Should().NotBeNull();
-            result.Diagnostic.Should().Be(diagnostic);
+            result.RuleId.Should().Be("cpp:123");
             result.ProjectGuid.Should().Be("31d0daac-8606-40fe-8df0-01784706ea3e");
             result.FilePath.Should().BeNull();
             result.StartLine.Should().BeNull();
@@ -234,13 +234,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
         {
             // Arrange & Act
             var location = Location.Create("C:\\MySource.cs", AnyTextSpan, new LinePositionSpan());
-            var diagnostic = CreateDiagnostic(location);
+            var diagnostic = CreateDiagnostic(location, "S4567");
 
             var result = SetupAndCreate(diagnostic, diagnosticProjectFilePath: ProjectInSolutionFilePath);
 
             // Assert
             result.Should().NotBeNull();
-            result.Diagnostic.Should().Be(diagnostic);
+            result.RuleId.Should().Be("S4567");
             result.ProjectGuid.Should().Be("31d0daac-8606-40fe-8df0-01784706ea3e");
             result.FilePath.Should().Be("C:\\MySource.cs");
             result.StartLine.Should().BeNull();
@@ -256,13 +256,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
             var location = Location.Create("C:\\MySource.cs",
                     AnyTextSpan,
                     new LinePositionSpan(new LinePosition(inRangeLineNumber, 1), new LinePosition(inRangeLineNumber, 2)));
-            var diagnostic = CreateDiagnostic(location);
+            var diagnostic = CreateDiagnostic(location, "xxx");
 
             var result = SetupAndCreate(diagnostic, diagnosticProjectFilePath: ProjectInSolutionFilePath);
 
             // Assert
             result.Should().NotBeNull();
-            result.Diagnostic.Should().Be(diagnostic);
+            result.RuleId.Should().Be("xxx");
             result.ProjectGuid.Should().Be("31d0daac-8606-40fe-8df0-01784706ea3e");
             result.FilePath.Should().Be("C:\\MySource.cs");
             result.StartLine.Should().Be(2);
@@ -288,9 +288,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
             result.Should().BeNull();
         }
 
-        private Diagnostic CreateDiagnostic(Location location)
+        private Diagnostic CreateDiagnostic(Location location, string ruleId = "anything")
         {
-            var anyDescriptor = new DiagnosticDescriptor("id",
+            var anyDescriptor = new DiagnosticDescriptor(ruleId,
                 "title", "message", "category", DiagnosticSeverity.Hidden, true);
 
             return Diagnostic.Create(anyDescriptor, location);

--- a/src/Integration.Vsix.UnitTests/Suppression/RoslynSuppressionHandlerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Suppression/RoslynSuppressionHandlerTests.cs
@@ -269,7 +269,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
 
         private void SetLiveIssue(Diagnostic diagnostic, int startLine, string wholeLineText)
         {
-            LiveIssue liveIssue = new LiveIssue(diagnostic, Guid.NewGuid().ToString(),
+            LiveIssue liveIssue = new LiveIssue(diagnostic.Id, Guid.NewGuid().ToString(),
                 filePath: "dummy file path",
                 startLine: startLine,
                 wholeLineText: wholeLineText);

--- a/src/Integration.Vsix/Delegates/SonarAnalyzerConnectedWorkflow.cs
+++ b/src/Integration.Vsix/Delegates/SonarAnalyzerConnectedWorkflow.cs
@@ -29,9 +29,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     // This workflow affects only the VSIX Analyzers
     internal class SonarAnalyzerConnectedWorkflow : SonarAnalyzerWorkflowBase
     {
-        private readonly ISuppressionHandler suppressionHandler;
+        private readonly IRoslynSuppressionHandler suppressionHandler;
 
-        public SonarAnalyzerConnectedWorkflow(Workspace workspace, ISuppressionHandler suppressionHandler)
+        public SonarAnalyzerConnectedWorkflow(Workspace workspace, IRoslynSuppressionHandler suppressionHandler)
             : base(workspace)
         {
             if (suppressionHandler == null)

--- a/src/Integration.Vsix/Delegates/SonarAnalyzerLegacyConnectedWorkflow.cs
+++ b/src/Integration.Vsix/Delegates/SonarAnalyzerLegacyConnectedWorkflow.cs
@@ -30,12 +30,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     // This workflow affects both the VSIX Analyzers + the NuGet Analyzers
     internal class SonarAnalyzerLegacyConnectedWorkflow : SonarAnalyzerWorkflowBase
     {
-        private readonly ISuppressionHandler suppressionHandler;
+        private readonly IRoslynSuppressionHandler suppressionHandler;
         private readonly ILogger logger;
 
         private readonly Func<SyntaxTree, Diagnostic, bool> shouldDiagnosticBeReportedFunc;
 
-        public SonarAnalyzerLegacyConnectedWorkflow(Workspace workspace, ISuppressionHandler suppressionHandler, ILogger logger)
+        public SonarAnalyzerLegacyConnectedWorkflow(Workspace workspace, IRoslynSuppressionHandler suppressionHandler, ILogger logger)
             : base(workspace)
         {
             if (suppressionHandler == null)

--- a/src/Integration.Vsix/Delegates/SonarAnalyzerManager.cs
+++ b/src/Integration.Vsix/Delegates/SonarAnalyzerManager.cs
@@ -98,8 +98,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 case SonarLintMode.LegacyConnected:
                 case SonarLintMode.Connected:
                     this.logger.WriteLine(Resources.Strings.AnalyzerManager_InConnectedMode);
-                    var liveIssueFactory = new LiveIssueFactory(workspace, vsSolution);
-                    var suppressionHandler = new SuppressionHandler(liveIssueFactory, sonarQubeIssuesProvider);
+                    var liveIssueFactory = new RoslynLiveIssueFactory(workspace, vsSolution);
+                    var suppressionHandler = new RoslynSuppressionHandler(liveIssueFactory, sonarQubeIssuesProvider);
 
                     if (configuration.Mode == SonarLintMode.Connected)
                     {

--- a/src/Integration.Vsix/Suppression/IRoslynLiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/IRoslynLiveIssueFactory.cs
@@ -22,7 +22,7 @@ using Microsoft.CodeAnalysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {
-    public interface ILiveIssueFactory
+    public interface IRoslynLiveIssueFactory
     {
         LiveIssue Create(SyntaxTree syntaxTree, Diagnostic diagnostic);
     }

--- a/src/Integration.Vsix/Suppression/IRoslynSuppressionHandler.cs
+++ b/src/Integration.Vsix/Suppression/IRoslynSuppressionHandler.cs
@@ -22,7 +22,7 @@ using Microsoft.CodeAnalysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {
-    public interface ISuppressionHandler
+    public interface IRoslynSuppressionHandler
     {
         bool ShouldIssueBeReported(SyntaxTree syntaxTree, Diagnostic diagnostic);
     }

--- a/src/Integration.Vsix/Suppression/LiveIssue.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssue.cs
@@ -19,34 +19,33 @@
  */
 
 using System.IO;
-using Microsoft.CodeAnalysis;
 using SonarLint.VisualStudio.Integration.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {
     /// <summary>
-    /// Information about a single Roslyn issue, decorated with the extra information required to map it to a
+    /// Information about a single issue in the IDE, decorated with the extra information required to map it to a
     /// SonarQube issue.
     /// </summary>
     public class LiveIssue
     {
         // module level issue
-        public LiveIssue(Diagnostic diagnostic, string projectGuid)
-            : this(diagnostic, projectGuid, null)
+        public LiveIssue(string ruleId, string projectGuid)
+            : this(ruleId, projectGuid, null)
         {
         }
 
         // file level issue
-        public LiveIssue(Diagnostic diagnostic, string projectGuid, string filePath)
-            : this(diagnostic, projectGuid, filePath, null, null)
+        public LiveIssue(string ruleId, string projectGuid, string filePath)
+            : this(ruleId, projectGuid, filePath, null, null)
         {
         }
 
         // line(s) level issue
-        public LiveIssue(Diagnostic diagnostic, string projectGuid, string filePath, int? startLine,
+        public LiveIssue(string ruleId, string projectGuid, string filePath, int? startLine,
             string wholeLineText = "")
         {
-            Diagnostic = diagnostic;
+            RuleId = ruleId;
             ProjectGuid = projectGuid;
 
             if (filePath != null)
@@ -57,12 +56,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
             if (startLine != null)
             {
                 StartLine = startLine;
-                WholeLineText = wholeLineText;                
+                WholeLineText = wholeLineText;
                 LineHash = ChecksumCalculator.Calculate(WholeLineText);
-            }            
+            }
         }
 
-        public Diagnostic Diagnostic { get; }
+        public string RuleId { get; }
         public string FilePath { get; }
         public string LineHash { get; }
         public string ProjectGuid { get; }

--- a/src/Integration.Vsix/Suppression/RoslynLiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/RoslynLiveIssueFactory.cs
@@ -42,7 +42,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
     /// Factory for <see cref="LiveIssue"/>s i.e. diagnostics that are decorated with
     /// additional information required to map to issues in the SonarQube server format
     /// </summary>
-    internal sealed class LiveIssueFactory : ILiveIssueFactory
+    internal sealed class RoslynLiveIssueFactory : IRoslynLiveIssueFactory
     {
         private readonly Workspace workspace;
 
@@ -51,7 +51,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
         /// </summary>
         private readonly IDictionary<string, string> projectPathToProjectIdMap;
 
-        public LiveIssueFactory(Workspace workspace, IVsSolution vsSolution)
+        public RoslynLiveIssueFactory(Workspace workspace, IVsSolution vsSolution)
         {
             if (workspace == null)
             {

--- a/src/Integration.Vsix/Suppression/RoslynLiveIssueFactory.cs
+++ b/src/Integration.Vsix/Suppression/RoslynLiveIssueFactory.cs
@@ -93,7 +93,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 
             if (diagnostic.Location == Location.None) // Project-level issue
             {
-                return new LiveIssue(diagnostic, projectGuid);
+                return new LiveIssue(diagnostic.Id, projectGuid);
             }
 
             var lineSpan = diagnostic.Location.GetLineSpan();
@@ -105,14 +105,14 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 
             if (isFileLevelIssue) // File-level issue
             {
-                return new LiveIssue(diagnostic, projectGuid, lineSpan.Path);
+                return new LiveIssue(diagnostic.Id, projectGuid, lineSpan.Path);
             }
 
             try
             {
                 var lineText = syntaxTree.GetText().Lines[lineSpan.EndLinePosition.Line].ToString();
                 var sonarQubeLineNumber = lineSpan.StartLinePosition.Line + 1; // Roslyn lines are 0-based, SonarQube lines are 1-based
-                return new LiveIssue(diagnostic, projectGuid, lineSpan.Path, sonarQubeLineNumber, lineText); // Line-level issue
+                return new LiveIssue(diagnostic.Id, projectGuid, lineSpan.Path, sonarQubeLineNumber, lineText); // Line-level issue
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {

--- a/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
+++ b/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
@@ -69,7 +69,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 
             // Try to find an issue with the same ID and either the same line number or some line hash
             bool matchFound = potentialMatchingIssues
-                .Where(i => StringComparer.OrdinalIgnoreCase.Equals(liveIssue.Diagnostic.Id, i.RuleId))
+                .Where(i => StringComparer.OrdinalIgnoreCase.Equals(liveIssue.RuleId, i.RuleId))
                 .Any(i => liveIssue.StartLine == i.Line || StringComparer.Ordinal.Equals(liveIssue.LineHash, i.Hash));
 
             return !matchFound;

--- a/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
+++ b/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
@@ -25,12 +25,12 @@ using SonarLint.VisualStudio.Integration.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {
-    internal class SuppressionHandler : ISuppressionHandler
+    internal class RoslynSuppressionHandler : IRoslynSuppressionHandler
     {
-        private readonly ILiveIssueFactory liveIssueFactory;
+        private readonly IRoslynLiveIssueFactory liveIssueFactory;
         private readonly ISonarQubeIssuesProvider serverIssuesProvider;
 
-        public SuppressionHandler(ILiveIssueFactory liveIssueFactory, ISonarQubeIssuesProvider serverIssuesProvider)
+        public RoslynSuppressionHandler(IRoslynLiveIssueFactory liveIssueFactory, ISonarQubeIssuesProvider serverIssuesProvider)
         {
             if (liveIssueFactory == null)
             {


### PR DESCRIPTION
There are two commits; I suggest looking at them separately.

* the first just contains file renames (prefixing Roslyn-specific classes with `Roslyn`), and minor test code cleanup. There are no product code changes.
* the second removes the Roslyn-specific `Diagnostic` property from `LiveIssue` as only the rule identifier is required. I'm aiming to reuse the `LiveIssue` class for other languages.