### PR TITLE
Move some interfaces to Core

### DIFF
--- a/src/Core/IIssuesFilter.cs
+++ b/src/Core/IIssuesFilter.cs
@@ -18,29 +18,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using Sonarlint;
-using SonarLint.VisualStudio.Integration.Suppression;
 
-namespace SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger
+namespace SonarLint.VisualStudio.Core
 {
-    [Export(typeof(IIssuesFilter))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
-    public class IssuesFilter : IIssuesFilter
+    /// <summary>
+    /// Describes a single issue with the properties required for
+    /// it to be compared against server-side issues by the issues filter
+    /// </summary>
+    public interface IFilterableIssue
     {
-        private readonly ISonarQubeIssuesProvider sonarQubeIssuesProvider;
+        string RuleId { get; }
+        string FilePath { get; }
+        string LineHash { get; }
+        string ProjectGuid { get; }
+        int? StartLine { get; }
+        string WholeLineText { get; }
+    }
 
-        [ImportingConstructor]
-        public IssuesFilter(ISonarQubeIssuesProvider sonarQubeIssuesProvider)
-        {
-            this.sonarQubeIssuesProvider = sonarQubeIssuesProvider ?? throw new ArgumentNullException(nameof(sonarQubeIssuesProvider));
-        }
-
-        public IEnumerable<Issue> Filter(string path, IEnumerable<Issue> issues)
-        {
-            return issues;
-        }
+    public interface IIssuesFilter
+    {
+        IEnumerable<IFilterableIssue> Filter(string path, IEnumerable<IFilterableIssue> issues);
     }
 }

--- a/src/Core/ISonarQubeIssuesProvider.cs
+++ b/src/Core/ISonarQubeIssuesProvider.cs
@@ -22,12 +22,12 @@ using System;
 using System.Collections.Generic;
 using SonarQube.Client.Models;
 
-namespace SonarLint.VisualStudio.Integration.Suppression
+namespace SonarLint.VisualStudio.Core
 {
     public interface ISonarQubeIssuesProvider : IDisposable
     {
         /// <summary>
-        ///     Returns SonarQube suppressed issues for the specified project and file
+        /// Returns SonarQube suppressed issues for the specified project and file
         /// </summary>
         IEnumerable<SonarQubeIssue> GetSuppressedIssues(string projectGuid, string filePath);
     }

--- a/src/Integration.UnitTests/Suppression/IssuesFilterTests.cs
+++ b/src/Integration.UnitTests/Suppression/IssuesFilterTests.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -41,11 +42,28 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
         }
 
         [TestMethod]
-        public void Ctor_NullSonarQubeIssuesProvider_ArgumentNullException()
+        public void Ctor_NullSonarQubeIssuesProvider_ThrowsArgumentNullException()
         {
             Action act = () => new IssuesFilter(null);
 
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("sonarQubeIssuesProvider");
+        }
+
+        [TestMethod]
+        public void Filter_NullIssues_ThrowsArgumentNullException()
+        {
+
+            Action act = () => testSubject.Filter("c:\\path\\file1.txt", null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("issues");
+        }
+
+        [TestMethod]
+        public void Filter_NullFile_DoesNotThrow()
+        {
+            var inputIssues = new List<IFilterableIssue>();
+
+            var result = testSubject.Filter(null, inputIssues);
+            result.Should().NotBeNull();
         }
     }
 }

--- a/src/Integration.UnitTests/Suppression/IssuesFilterTests.cs
+++ b/src/Integration.UnitTests/Suppression/IssuesFilterTests.cs
@@ -22,10 +22,10 @@ using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Suppression;
-using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
-namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
+namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
 {
     [TestClass]
     public class IssuesFilterTests

--- a/src/Integration.UnitTests/Suppression/SuppressedIssuesProviderTests.cs
+++ b/src/Integration.UnitTests/Suppression/SuppressedIssuesProviderTests.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Suppression;

--- a/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerManagerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerManagerTests.cs
@@ -27,9 +27,9 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarAnalyzer.Helpers;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
-using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -34,7 +34,6 @@ using Moq;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
-using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -29,11 +29,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
-using Sonarlint;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
-using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
@@ -62,9 +60,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             mockedJavascriptDocumentFooJs = CreateDocumentMock("foo.js");
             javascriptLanguage = new[] { AnalysisLanguage.Javascript };
 
-            var originalIssues = new List<Issue>();
-            issuesFilter.Setup(x => x.Filter(It.IsAny<string>(), It.IsAny<IEnumerable<Issue>>()))
-                .Callback((string path, IEnumerable<Issue> issues) => originalIssues.AddRange(issues))
+            var originalIssues = new List<IFilterableIssue>();
+            issuesFilter.Setup(x => x.Filter(It.IsAny<string>(), It.IsAny<IEnumerable<IFilterableIssue>>()))
+                .Callback((string path, IEnumerable<IFilterableIssue> issues) => originalIssues.AddRange(issues))
                 .Returns(originalIssues);
 
             testSubject = new TextBufferIssueTracker(taggerProvider.dte, taggerProvider,

--- a/src/Integration.Vsix.UnitTests/Suppression/RoslynSuppressionHandlerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Suppression/RoslynSuppressionHandlerTests.cs
@@ -26,6 +26,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Suppression;
 using SonarQube.Client.Models;

--- a/src/Integration.Vsix/Delegates/SonarAnalyzerManager.cs
+++ b/src/Integration.Vsix/Delegates/SonarAnalyzerManager.cs
@@ -24,8 +24,8 @@ using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarAnalyzer.Helpers;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
-using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix

--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -28,7 +28,6 @@ using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarLint.VisualStudio.Integration.InfoBar;
-using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
@@ -88,7 +87,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 IServiceProvider serviceProvider = this;
 
                 var activeSolutionBoundTracker = await this.GetMefServiceAsync<IActiveSolutionBoundTracker>();
-                var sonarQubeIssuesProvider = await this.GetMefServiceAsync<ISonarQubeIssuesProvider>();
+                var sonarQubeIssuesProvider = await this.GetMefServiceAsync<Core.ISonarQubeIssuesProvider>();
                 var workspace = await this.GetMefServiceAsync<VisualStudioWorkspace>();
 
                 var vsSolution = serviceProvider.GetService<SVsSolution, IVsSolution>();

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -34,7 +34,6 @@ using Microsoft.VisualStudio.Utilities;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
-using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -28,7 +28,6 @@ using Microsoft.VisualStudio.Text;
 using Sonarlint;
 using SonarLint.VisualStudio.Integration.Vsix.Helpers;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
-using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {
@@ -57,7 +56,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private readonly IIssueConverter issueConverter;
         private readonly string charset;
         private readonly ILogger logger;
-        private readonly IIssuesFilter issuesFilter;
+        private readonly Core.IIssuesFilter issuesFilter;
 
         public string FilePath { get; private set; }
         public SnapshotFactory Factory { get; }
@@ -67,13 +66,13 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private readonly ISet<IssueTagger> activeTaggers = new HashSet<IssueTagger>();
         
         public TextBufferIssueTracker(DTE dte, TaggerProvider provider, ITextDocument document,
-            IEnumerable<AnalysisLanguage> detectedLanguages, ILogger logger, IIssuesFilter issuesFilter)
+            IEnumerable<AnalysisLanguage> detectedLanguages, ILogger logger, Core.IIssuesFilter issuesFilter)
             : this(dte, provider, document, detectedLanguages, new IssueConverter(), logger, issuesFilter)
         {
         }
 
         internal TextBufferIssueTracker(DTE dte, TaggerProvider provider, ITextDocument document,
-            IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConverter issueConverter, ILogger logger, IIssuesFilter issuesFilter)
+            IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConverter issueConverter, ILogger logger, Core.IIssuesFilter issuesFilter)
         {
             this.dte = dte;
 
@@ -275,7 +274,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 return;
             }
 
-            issues = issuesFilter.Filter(path, issues);
+            // TODO: collect the additional information required to compare be able to filter
+            // the issues (i.e. the text of the line and the line hash)
+            // issues = issuesFilter.Filter(path, issues);
 
             var newMarkers = issues.Where(IsValidIssueTextRange).Select(CreateIssueMarker);
             UpdateIssues(newMarkers);

--- a/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
+++ b/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
@@ -21,7 +21,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using SonarLint.VisualStudio.Integration.Suppression;
+using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {

--- a/src/Integration/Suppression/IssuesFilter.cs
+++ b/src/Integration/Suppression/IssuesFilter.cs
@@ -18,13 +18,28 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
-using Sonarlint;
+using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.Core;
 
-namespace SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger
+namespace SonarLint.VisualStudio.Integration.Suppression
 {
-    public interface IIssuesFilter
+    [Export(typeof(IIssuesFilter))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class IssuesFilter : IIssuesFilter
     {
-        IEnumerable<Issue> Filter(string path, IEnumerable<Issue> issues);
+        private readonly ISonarQubeIssuesProvider sonarQubeIssuesProvider;
+
+        [ImportingConstructor]
+        public IssuesFilter(ISonarQubeIssuesProvider sonarQubeIssuesProvider)
+        {
+            this.sonarQubeIssuesProvider = sonarQubeIssuesProvider ?? throw new ArgumentNullException(nameof(sonarQubeIssuesProvider));
+        }
+
+        public IEnumerable<IFilterableIssue> Filter(string path, IEnumerable<IFilterableIssue> issues)
+        {
+            return issues;
+        }
     }
 }

--- a/src/Integration/Suppression/IssuesFilter.cs
+++ b/src/Integration/Suppression/IssuesFilter.cs
@@ -39,6 +39,12 @@ namespace SonarLint.VisualStudio.Integration.Suppression
 
         public IEnumerable<IFilterableIssue> Filter(string path, IEnumerable<IFilterableIssue> issues)
         {
+            if (issues == null)
+            {
+                throw new ArgumentNullException(nameof(issues));
+            }
+
+            // TODO: add filtering
             return issues;
         }
     }

--- a/src/Integration/Suppression/SonarQubeIssuesProvider.cs
+++ b/src/Integration/Suppression/SonarQubeIssuesProvider.cs
@@ -25,9 +25,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SonarQube.Client.Models;
-using SonarQube.Client;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
+using SonarQube.Client;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.Suppression
 {

--- a/src/Integration/Suppression/SuppressedIssuesProvider.cs
+++ b/src/Integration/Suppression/SuppressedIssuesProvider.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarQube.Client;


### PR DESCRIPTION
This PR contains almost no actual code changes. Instead, I've moved some of the files to other folders/projects:

* `IIssuesFilter` and `ISonarQubeIssuesProvider` don't depend on VS so I've moved them to the `Core` project. I haven't moved the implementation classes.

* Moved the `IssuesFilter` class to the `Suppressions` folder since that seems a better location than under the tagger folder. I moved the corresponding test classes.

* added the `IFilterableIssue` interface. There are currently multiple data classes that describe issues: the Protobuf one used by the daemon; the Protobuf one use to talk to the CFamily process; and the `LiveIssue` used when suppressing Roslyn issues. I'm not trying to standardise these at the moment.
