### PR TITLE
Moved suppression interfaces to Core

### DIFF
--- a/src/Core/Suppressions/IFilterableIssue.cs
+++ b/src/Core/Suppressions/IFilterableIssue.cs
@@ -18,12 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-
-namespace SonarLint.VisualStudio.Integration.Suppression
+namespace SonarLint.VisualStudio.Core.Suppression
 {
-    public interface ISuppressedIssuesMonitor
+    /// <summary>
+    /// Describes a single issue with the properties required for
+    /// it to be compared against server-side issues by the issues filter
+    /// </summary>
+    public interface IFilterableIssue
     {
-        event EventHandler SuppressionsUpdateRequested;
+        string RuleId { get; }
+        string FilePath { get; }
+        string LineHash { get; }
+        string ProjectGuid { get; }
+        int? StartLine { get; }
+        string WholeLineText { get; }
     }
 }

--- a/src/Core/Suppressions/IIssuesFilter.cs
+++ b/src/Core/Suppressions/IIssuesFilter.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+
+namespace SonarLint.VisualStudio.Core.Suppression
+{
+    public interface IIssuesFilter
+    {
+        IEnumerable<IFilterableIssue> Filter(string path, IEnumerable<IFilterableIssue> issues);
+    }
+}

--- a/src/Core/Suppressions/ISonarQubeIssuesProvider.cs
+++ b/src/Core/Suppressions/ISonarQubeIssuesProvider.cs
@@ -18,12 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
+using System;
+using System.Collections.Generic;
+using SonarQube.Client.Models;
 
-namespace SonarLint.VisualStudio.Integration.Suppression
+namespace SonarLint.VisualStudio.Core.Suppression
 {
-    public interface ISuppressedIssueMatcher
+    public interface ISonarQubeIssuesProvider : IDisposable
     {
-        bool SuppressionExists(IFilterableIssue issue);
+        /// <summary>
+        /// Returns SonarQube suppressed issues for the specified project and file
+        /// </summary>
+        IEnumerable<SonarQubeIssue> GetSuppressedIssues(string projectGuid, string filePath);
     }
 }

--- a/src/Core/Suppressions/ISuppressedIssueMatcher.cs
+++ b/src/Core/Suppressions/ISuppressedIssueMatcher.cs
@@ -18,17 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using SonarQube.Client.Models;
-
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Suppression
 {
-    public interface ISonarQubeIssuesProvider : IDisposable
+    public interface ISuppressedIssueMatcher
     {
-        /// <summary>
-        /// Returns SonarQube suppressed issues for the specified project and file
-        /// </summary>
-        IEnumerable<SonarQubeIssue> GetSuppressedIssues(string projectGuid, string filePath);
+        bool SuppressionExists(IFilterableIssue issue);
     }
 }

--- a/src/Core/Suppressions/ISuppressedIssuesMonitor.cs
+++ b/src/Core/Suppressions/ISuppressedIssuesMonitor.cs
@@ -18,26 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
+using System;
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Suppression
 {
-    /// <summary>
-    /// Describes a single issue with the properties required for
-    /// it to be compared against server-side issues by the issues filter
-    /// </summary>
-    public interface IFilterableIssue
+    public interface ISuppressedIssuesMonitor
     {
-        string RuleId { get; }
-        string FilePath { get; }
-        string LineHash { get; }
-        string ProjectGuid { get; }
-        int? StartLine { get; }
-        string WholeLineText { get; }
-    }
-
-    public interface IIssuesFilter
-    {
-        IEnumerable<IFilterableIssue> Filter(string path, IEnumerable<IFilterableIssue> issues);
+        event EventHandler SuppressionsUpdateRequested;
     }
 }

--- a/src/Integration.UnitTests/Suppression/IssuesFilterTests.cs
+++ b/src/Integration.UnitTests/Suppression/IssuesFilterTests.cs
@@ -24,7 +24,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NuGet;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression

--- a/src/Integration.UnitTests/Suppression/SuppressedIssueMatcherTests.cs
+++ b/src/Integration.UnitTests/Suppression/SuppressedIssueMatcherTests.cs
@@ -22,7 +22,7 @@ using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Suppression;
 using SonarQube.Client.Models;
 

--- a/src/Integration.UnitTests/Suppression/SuppressedIssuesProviderTests.cs
+++ b/src/Integration.UnitTests/Suppression/SuppressedIssuesProviderTests.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Suppression;

--- a/src/Integration.Vsix.UnitTests/Analysis/AnalysisConfigMonitorTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/AnalysisConfigMonitorTests.cs
@@ -22,8 +22,8 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
-using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.UnitTests;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests

--- a/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerManagerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Delegates/SonarAnalyzerManagerTests.cs
@@ -27,7 +27,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarAnalyzer.Helpers;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Vsix;

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonIssueAdapterTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonIssueAdapterTests.cs
@@ -21,7 +21,7 @@
 using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 
@@ -295,7 +296,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private class DummyTextDocumentFactoryService : ITextDocumentFactoryService
         {
-            private Dictionary<ITextBuffer, ITextDocument> bufferToDocMapping = new Dictionary<ITextBuffer, ITextDocument>();
+            private readonly Dictionary<ITextBuffer, ITextDocument> bufferToDocMapping = new Dictionary<ITextBuffer, ITextDocument>();
 
             public void RegisterDocument(ITextDocument document)
             {

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Sonarlint;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 

--- a/src/Integration.Vsix.UnitTests/Suppression/RoslynSuppressionHandlerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Suppression/RoslynSuppressionHandlerTests.cs
@@ -25,8 +25,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Integration.Suppression;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression

--- a/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
+++ b/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
@@ -21,7 +21,7 @@
 using System;
 using System.ComponentModel.Composition;
 using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Integration.Suppression;
+using SonarLint.VisualStudio.Core.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
 {

--- a/src/Integration.Vsix/Delegates/SonarAnalyzerManager.cs
+++ b/src/Integration.Vsix/Delegates/SonarAnalyzerManager.cs
@@ -24,7 +24,7 @@ using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarAnalyzer.Helpers;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Suppression;

--- a/src/Integration.Vsix/SonarLintDaemon/DaemonIssueAdapter.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/DaemonIssueAdapter.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.InfoBar;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 
@@ -87,7 +88,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 IServiceProvider serviceProvider = this;
 
                 var activeSolutionBoundTracker = await this.GetMefServiceAsync<IActiveSolutionBoundTracker>();
-                var sonarQubeIssuesProvider = await this.GetMefServiceAsync<Core.ISonarQubeIssuesProvider>();
+                var sonarQubeIssuesProvider = await this.GetMefServiceAsync<ISonarQubeIssuesProvider>();
                 var workspace = await this.GetMefServiceAsync<VisualStudioWorkspace>();
 
                 var vsSolution = serviceProvider.GetService<SVsSolution, IVsSolution>();

--- a/src/Integration.Vsix/SonarLintTagger/IssueToFilterableIssueConverter.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueToFilterableIssueConverter.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
 using Sonarlint;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
 

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -26,6 +26,7 @@ using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Text;
 using Sonarlint;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Helpers;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
 
@@ -56,7 +57,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private readonly IIssueConverter issueConverter;
         private readonly string charset;
         private readonly ILogger logger;
-        private readonly Core.IIssuesFilter issuesFilter;
+        private readonly IIssuesFilter issuesFilter;
 
         public string FilePath { get; private set; }
         public SnapshotFactory Factory { get; }
@@ -66,13 +67,13 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private readonly ISet<IssueTagger> activeTaggers = new HashSet<IssueTagger>();
 
         public TextBufferIssueTracker(DTE dte, TaggerProvider provider, ITextDocument document,
-            IEnumerable<AnalysisLanguage> detectedLanguages, ILogger logger, Core.IIssuesFilter issuesFilter)
+            IEnumerable<AnalysisLanguage> detectedLanguages, ILogger logger, IIssuesFilter issuesFilter)
             : this(dte, provider, document, detectedLanguages, new IssueConverter(), logger, issuesFilter)
         {
         }
 
         internal TextBufferIssueTracker(DTE dte, TaggerProvider provider, ITextDocument document,
-            IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConverter issueConverter, ILogger logger, Core.IIssuesFilter issuesFilter)
+            IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConverter issueConverter, ILogger logger, IIssuesFilter issuesFilter)
         {
             this.dte = dte;
 

--- a/src/Integration.Vsix/Suppression/LiveIssue.cs
+++ b/src/Integration.Vsix/Suppression/LiveIssue.cs
@@ -19,7 +19,7 @@
  */
 
 using System.IO;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression

--- a/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
+++ b/src/Integration.Vsix/Suppression/RoslynSuppressionHandler.cs
@@ -20,7 +20,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
-using SonarLint.VisualStudio.Integration.Suppression;
+using SonarLint.VisualStudio.Core.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Suppression
 {

--- a/src/Integration/Suppression/IssuesFilter.cs
+++ b/src/Integration/Suppression/IssuesFilter.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Suppression
 {

--- a/src/Integration/Suppression/SonarQubeIssuesProvider.cs
+++ b/src/Integration/Suppression/SonarQubeIssuesProvider.cs
@@ -25,7 +25,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarQube.Client;
 using SonarQube.Client.Models;

--- a/src/Integration/Suppression/SuppressedIssueMatcher.cs
+++ b/src/Integration/Suppression/SuppressedIssueMatcher.cs
@@ -20,7 +20,7 @@
 
 using System;
 using System.Linq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 
 namespace SonarLint.VisualStudio.Integration.Suppression
 {

--- a/src/Integration/Suppression/SuppressedIssuesProvider.cs
+++ b/src/Integration/Suppression/SuppressedIssuesProvider.cs
@@ -21,7 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarQube.Client;


### PR DESCRIPTION
* no code changes
* move the suppression interfaces that don't depend on VS to Core
* moved interfaces are now in the namespace "SonarLint.VisualStudio.Core.Suppression"
* fixed up namespace references