### PR TITLE
Add CFamily reproducer command

### DIFF
--- a/src/Integration.Vsix.UnitTests/Analysis/DisableRuleCommandTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/DisableRuleCommandTests.cs
@@ -437,26 +437,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             #endregion ITableEntriesSnapshot methods
         }
 
-        private class DummyMenuCommandService : IMenuCommandService
-        {
-            public IList<MenuCommand> AddedMenuCommands { get; } = new List<MenuCommand>();
-
-            #region IMenuCommandService methods 
-
-            public DesignerVerbCollection Verbs => throw new NotImplementedException();
-
-            public void AddCommand(MenuCommand command) => AddedMenuCommands.Add(command);
-
-            public void AddVerb(DesignerVerb verb) => throw new NotImplementedException();
-            public MenuCommand FindCommand(CommandID commandID) => throw new NotImplementedException();
-            public bool GlobalInvoke(CommandID commandID) => throw new NotImplementedException();
-            public void RemoveCommand(MenuCommand command) => throw new NotImplementedException();
-            public void RemoveVerb(DesignerVerb verb) => throw new NotImplementedException();
-            public void ShowContextMenu(CommandID menuID, int x, int y) => throw new NotImplementedException();
-
-            #endregion IMenuCommandService methods 
-        }
-
         #endregion Helper classes
     }
 }

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyReproducerCommandTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyReproducerCommandTests.cs
@@ -1,0 +1,239 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.ComponentModel.Design;
+using FluentAssertions;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.Integration.UnitTests;
+using ThreadHelper = SonarLint.VisualStudio.Integration.UnitTests.ThreadHelper;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
+{
+    [TestClass]
+    public class CFamilyReproducerCommandTests
+    {
+        private Mock<IActiveDocumentLocator> docLocatorMock;
+        private Mock<ISonarLanguageRecognizer> languageRecognizerMock;
+        private TestLogger logger;
+
+        private ITextDocument ValidTextDocument;
+
+        private MenuCommand testSubject;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            docLocatorMock = new Mock<IActiveDocumentLocator>();
+            languageRecognizerMock = new Mock<ISonarLanguageRecognizer>();
+            logger = new TestLogger();
+            testSubject = CreateCFamilyReproducerCommand(docLocatorMock.Object, languageRecognizerMock.Object, logger);
+
+            ValidTextDocument = CreateValidTextDocument("c:\\subdir1\\file.txt");
+        }
+
+        [TestMethod]
+        public void Ctor_NullArguments()
+        {
+            var menuCommandService = new DummyMenuCommandService();
+
+            Action act = () => new CFamilyReproducerCommand(null, docLocatorMock.Object, languageRecognizerMock.Object, logger);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("menuCommandService");
+
+            act = () => new CFamilyReproducerCommand(menuCommandService, null, languageRecognizerMock.Object, logger);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("activeDocumentLocator");
+
+            act = () => new CFamilyReproducerCommand(menuCommandService, docLocatorMock.Object, null, logger);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("languageRecognizer");
+
+            act = () => new CFamilyReproducerCommand(menuCommandService, docLocatorMock.Object, languageRecognizerMock.Object, null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
+        }
+
+        [TestMethod]
+        public void CommandRegistration()
+        {
+            testSubject.CommandID.ID.Should().Be(CFamilyReproducerCommand.CommandId);
+            testSubject.CommandID.Guid.Should().Be(CFamilyReproducerCommand.CommandSet);
+        }
+
+        [TestMethod]
+        public void CheckStatus_NoActiveDocument_NotEnabled()
+        {
+            // Arrange
+            SetActiveDocument(null);
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            // Act
+            var result = testSubject.OleStatus;
+
+            // Assert
+            result.Should().Be((int)(OLECMDF.OLECMDF_SUPPORTED | OLECMDF.OLECMDF_INVISIBLE));
+            testSubject.Enabled.Should().BeFalse();
+            testSubject.Visible.Should().BeFalse();
+
+            VerifyDocumentLocatorCalled();
+            VerifyLanguageRecognizerNotCalled();
+        }
+
+        [TestMethod]
+        public void CheckStatus_ActiveDocument_NotCFamilyDocument_NotEnabled()
+        {
+            // Arrange
+            SetActiveDocument(ValidTextDocument, AnalysisLanguage.Javascript);
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            // Act
+            var result = testSubject.OleStatus;
+
+            // Assert
+            result.Should().Be((int)(OLECMDF.OLECMDF_SUPPORTED | OLECMDF.OLECMDF_INVISIBLE));
+            testSubject.Enabled.Should().BeFalse();
+            testSubject.Visible.Should().BeFalse();
+
+            VerifyDocumentLocatorCalled();
+            VerifyLanguageRecognizerCalled();
+        }
+
+        [TestMethod]
+        public void CheckStatus_ActiveDocument_IsCFamilyDocument_Enabled()
+        {
+            // Arrange
+            SetActiveDocument(ValidTextDocument, AnalysisLanguage.Javascript, AnalysisLanguage.CFamily);
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            // Act
+            var result = testSubject.OleStatus;
+
+            // Assert
+            result.Should().Be((int)(OLECMDF.OLECMDF_SUPPORTED | OLECMDF.OLECMDF_INVISIBLE | OLECMDF.OLECMDF_ENABLED));
+            testSubject.Enabled.Should().BeTrue();
+            testSubject.Visible.Should().BeFalse();
+
+            VerifyDocumentLocatorCalled();
+            VerifyLanguageRecognizerCalled();
+        }
+
+        [TestMethod]
+        public void Execute_ReanalysisTriggered()
+        {
+            // Arrange
+            SetActiveDocument(ValidTextDocument, AnalysisLanguage.CFamily);
+
+            // Act
+            testSubject.Invoke();
+
+            // Assert
+            // TODO: product code still to be implemented
+            logger.AssertOutputStringExists(CFamilyStrings.ReproCmd_ExecutingReproducer);
+        }
+
+        [TestMethod]
+        public void QueryStatus_NonCriticalErrorSuppressed()
+        {
+            // Arrange
+            docLocatorMock.Setup(x => x.FindActiveDocument()).Throws(new InvalidOperationException("exception xxx"));
+
+            // Act - should not throw
+            var _ = testSubject.OleStatus;
+            logger.AssertPartialOutputStringExists("exception xxx");
+        }
+
+        [TestMethod]
+        public void QueryStatus_CriticalErrorNotSuppressed()
+        {
+            // Arrange
+            docLocatorMock.Setup(x => x.FindActiveDocument()).Throws(new StackOverflowException("exception xxx"));
+            Action act = () => _ = testSubject.OleStatus;
+
+            // Act
+            act.Should().ThrowExactly<StackOverflowException>().And.Message.Should().Be("exception xxx");
+            logger.AssertPartialOutputStringDoesNotExist("exception xxx");
+        }
+
+        [TestMethod]
+        public void Execute_NonCriticalErrorSuppressed()
+        {
+            // Arrange
+            docLocatorMock.Setup(x => x.FindActiveDocument()).Throws(new InvalidOperationException("exception xxx"));
+
+            // Act - should not throw
+            testSubject.Invoke();
+            logger.AssertPartialOutputStringExists("exception xxx");
+        }
+
+        [TestMethod]
+        public void Execute_CriticalErrorNotSuppressed()
+        {
+            // Arrange
+            docLocatorMock.Setup(x => x.FindActiveDocument()).Throws(new StackOverflowException("exception xxx"));
+            Action act = () => testSubject.Invoke();
+
+            // Act 
+            act.Should().ThrowExactly<StackOverflowException>().And.Message.Should().Be("exception xxx");
+            logger.AssertPartialOutputStringDoesNotExist("exception xxx");
+        }
+
+        private static MenuCommand CreateCFamilyReproducerCommand(IActiveDocumentLocator documentLocator, ISonarLanguageRecognizer languageRecognizer, ILogger logger)
+        {
+            var dummyMenuService = new DummyMenuCommandService();
+            new CFamilyReproducerCommand(dummyMenuService, documentLocator, languageRecognizer, logger);
+
+            dummyMenuService.AddedMenuCommands.Count.Should().Be(1);
+            return dummyMenuService.AddedMenuCommands[0];
+        }
+
+        private static ITextDocument CreateValidTextDocument(string filePath)
+        {
+            var documentMock = new Mock<ITextDocument>();
+            var textBufferMock = new Mock<ITextBuffer>();
+            documentMock.Setup(x => x.TextBuffer).Returns(textBufferMock.Object);
+            documentMock.Setup(x => x.FilePath).Returns(filePath);
+            return documentMock.Object;
+        }
+
+        private void SetActiveDocument(ITextDocument document, params AnalysisLanguage[] recognizedLanguages)
+        {
+            docLocatorMock.Setup(x => x.FindActiveDocument()).Returns(document);
+            if (document != null)
+            {
+                languageRecognizerMock.Setup(x => x.Detect(document, document.TextBuffer)).Returns(recognizedLanguages);
+            }
+        }
+
+        private void VerifyDocumentLocatorCalled()
+        {
+            docLocatorMock.Verify(x => x.FindActiveDocument(), Times.AtLeastOnce);
+        }
+
+        private void VerifyLanguageRecognizerNotCalled()
+        {
+            languageRecognizerMock.Verify(x => x.Detect(It.IsAny<ITextDocument>(), It.IsAny<ITextBuffer>()), Times.Never);
+        }
+
+        private void VerifyLanguageRecognizerCalled()
+        {
+            languageRecognizerMock.Verify(x => x.Detect(It.IsAny<ITextDocument>(), It.IsAny<ITextBuffer>()), Times.AtLeastOnce);
+        }
+    }
+}

--- a/src/Integration.Vsix.UnitTests/Framework/DummyMenuCommandService.cs
+++ b/src/Integration.Vsix.UnitTests/Framework/DummyMenuCommandService.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    internal class DummyMenuCommandService : IMenuCommandService
+    {
+        public IList<MenuCommand> AddedMenuCommands { get; } = new List<MenuCommand>();
+
+        #region IMenuCommandService methods 
+
+        public DesignerVerbCollection Verbs => throw new NotImplementedException();
+
+        public void AddCommand(MenuCommand command) => AddedMenuCommands.Add(command);
+
+        public void AddVerb(DesignerVerb verb) => throw new NotImplementedException();
+        public MenuCommand FindCommand(CommandID commandID) => throw new NotImplementedException();
+        public bool GlobalInvoke(CommandID commandID) => throw new NotImplementedException();
+        public void RemoveCommand(MenuCommand command) => throw new NotImplementedException();
+        public void RemoveVerb(DesignerVerb verb) => throw new NotImplementedException();
+        public void ShowContextMenu(CommandID menuID, int x, int y) => throw new NotImplementedException();
+
+        #endregion IMenuCommandService methods 
+    }
+}

--- a/src/Integration.Vsix.UnitTests/Helpers/ActiveDocumentLocatorTests.cs
+++ b/src/Integration.Vsix.UnitTests/Helpers/ActiveDocumentLocatorTests.cs
@@ -1,0 +1,225 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Moq;
+using SonarLint.VisualStudio.Integration.Vsix;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.Helpers
+{
+    [TestClass]
+    public class ActiveDocumentLocatorTests
+    {
+        private Mock<IVsMonitorSelection> monitorSelectionMock;
+        private Mock<IVsEditorAdaptersFactoryService> adapterServiceMock;
+        private Mock<IVsWindowFrame> frameMock;
+        private Mock<IVsTextBuffer> vsTextBufferMock;
+
+        private IVsWindowFrame ValidVsWindowFrame => frameMock.Object;
+        private IVsTextBuffer ValidVsTextBuffer => vsTextBufferMock.Object;
+
+        private ActiveDocumentLocator testSubject;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            monitorSelectionMock = new Mock<IVsMonitorSelection>();
+            adapterServiceMock = new Mock<IVsEditorAdaptersFactoryService>();
+
+            testSubject = new ActiveDocumentLocator(monitorSelectionMock.Object, adapterServiceMock.Object);
+
+            frameMock = new Mock<IVsWindowFrame>();
+            vsTextBufferMock = new Mock<IVsTextBuffer>();
+        }
+
+        [TestMethod]
+        public void Find_NoOpenDocuments()
+        {
+            // Arrange
+            Configure(activeFrame: null);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().BeNull();
+            VerifyMonitorSelectionServiceCalled(null);
+        }
+
+        [TestMethod]
+        public void Find_OpenDocument_NotanIVsWindowFrame()
+        {
+            // Arrange
+            var notAWindowFrame = new object();
+            Configure(activeFrame: notAWindowFrame);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().BeNull();
+            VerifyMonitorSelectionServiceCalled(notAWindowFrame);
+        }
+
+        [TestMethod]
+        public void Find_OpenDocument_FrameDoesNotHaveDocData()
+        {
+            // Arrange
+            Configure(
+                activeFrame: ValidVsWindowFrame,
+                activeFrameDocDataObject: null);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().BeNull();
+            VerifyMonitorSelectionServiceCalled(ValidVsWindowFrame);
+            VerifyFrameGetPropertyCalled(null);
+        }
+
+        [TestMethod]
+        public void Find_OpenDocument_FrameDocDataIsNotVsTextBuffer()
+        {
+            // Arrange
+            var notVsTextBuffer = new object();
+
+            Configure(
+                activeFrame: ValidVsWindowFrame,
+                activeFrameDocDataObject: notVsTextBuffer);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().BeNull();
+            VerifyMonitorSelectionServiceCalled(ValidVsWindowFrame);
+            VerifyFrameGetPropertyCalled(notVsTextBuffer);
+            VerifyAdapterServiceNotCalled();
+        }
+
+        [TestMethod]
+        public void Find_OpenDocument_FrameDocDataIsTextBuffer_AdapterServiceReturnsNull()
+        {
+            // Arrange            
+            Configure(
+                activeFrame: ValidVsWindowFrame,
+                activeFrameDocDataObject: ValidVsTextBuffer);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().BeNull();
+            VerifyMonitorSelectionServiceCalled(ValidVsWindowFrame);
+            VerifyFrameGetPropertyCalled(ValidVsTextBuffer);
+            VerifyAdapterServiceCalled(ValidVsTextBuffer);
+        }
+
+
+        [TestMethod]
+        public void Find_OpenDocument_NewTextBuffer_NoTextDoc()
+        {
+            // Arrange
+            var newTextBuffer = CreateValidMefTextBuffer(null);
+
+            Configure(
+                activeFrame: ValidVsWindowFrame,
+                activeFrameDocDataObject: ValidVsTextBuffer,
+                adapterServiceConvertedTextBuffer: newTextBuffer);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().Be(null);
+
+            VerifyMonitorSelectionServiceCalled(ValidVsWindowFrame);
+            VerifyFrameGetPropertyCalled(ValidVsTextBuffer);
+            VerifyAdapterServiceCalled(ValidVsTextBuffer);
+        }
+
+
+        [TestMethod]
+        public void Find_OpenDocument_NewTextBuffer_HasTextDoc()
+        {
+            // Arrange
+            var newTextDoc = new Mock<ITextDocument>().Object;
+            var newTextBuffer = CreateValidMefTextBuffer(newTextDoc);
+
+            Configure(
+                activeFrame: ValidVsWindowFrame,
+                activeFrameDocDataObject: ValidVsTextBuffer,
+                adapterServiceConvertedTextBuffer: newTextBuffer);
+
+            // Act
+            var result = testSubject.FindActiveDocument();
+
+            // Assert
+            result.Should().Be(newTextDoc);
+
+            VerifyMonitorSelectionServiceCalled(ValidVsWindowFrame);
+            VerifyFrameGetPropertyCalled(ValidVsTextBuffer);
+            VerifyAdapterServiceCalled(ValidVsTextBuffer);
+        }
+
+        private void Configure(
+            object activeFrame = null,
+            object activeFrameDocDataObject = null,
+            ITextBuffer adapterServiceConvertedTextBuffer = null
+            )
+        {
+            monitorSelectionMock.Setup(x => x.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out activeFrame));
+            frameMock.Setup(x => x.GetProperty((int)__VSFPROPID.VSFPROPID_DocData, out activeFrameDocDataObject));
+            adapterServiceMock.Setup(x => x.GetDocumentBuffer(activeFrameDocDataObject as IVsTextBuffer)).Returns(adapterServiceConvertedTextBuffer);
+        }
+
+        private ITextBuffer CreateValidMefTextBuffer(ITextDocument textDocument)
+        {
+            var newTextBufferMock = new Mock<ITextBuffer>();
+
+            var bufferProps = new Microsoft.VisualStudio.Utilities.PropertyCollection();
+            bufferProps.AddProperty(typeof(ITextDocument), textDocument);
+            newTextBufferMock.Setup(x => x.Properties).Returns(bufferProps);
+
+            return newTextBufferMock.Object;
+        }
+
+        private void VerifyMonitorSelectionServiceCalled(object obj) =>
+            monitorSelectionMock.Verify(x => x.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out obj), Times.Once);
+
+        private void VerifyFrameGetPropertyCalled(object obj) =>
+            frameMock.Verify(x => x.GetProperty((int)__VSFPROPID.VSFPROPID_DocData, out obj),Times.Once);
+
+        private void VerifyAdapterServiceCalled(IVsTextBuffer inputVsBuffer) =>
+            adapterServiceMock.Verify(x => x.GetDocumentBuffer(inputVsBuffer), Times.Once);
+
+        private void VerifyAdapterServiceNotCalled() =>
+            adapterServiceMock.Verify(x => x.GetDocumentBuffer(It.IsAny<IVsTextBuffer>()), Times.Never);
+    }
+}

--- a/src/Integration.Vsix/Analysis/CFamilyReproducerCommand.cs
+++ b/src/Integration.Vsix/Analysis/CFamilyReproducerCommand.cs
@@ -1,0 +1,130 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.ComponentModel.Design;
+using System.Linq;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.CFamily;
+using Task = System.Threading.Tasks.Task;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
+{
+    /// <summary>
+    /// Command handler
+    /// </summary>
+    internal sealed class CFamilyReproducerCommand
+    {
+        // Command set guid and command id. Must match those in DaemonCommands.vsct
+        public static readonly Guid CommandSet = new Guid("1F83EA11-3B07-45B3-BF39-307FD4F42194");
+        public const int CommandId = 0x0300;
+
+        private readonly OleMenuCommand menuItem;
+        private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Initializes the singleton instance of the command.
+        /// </summary>
+        /// <param name="package">Owner package, not null.</param>
+        public static async Task InitializeAsync(AsyncPackage package, ILogger logger)
+        {
+            // Switch to the main thread - the call to AddCommand in Command1's constructor requires
+            // the UI thread.
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
+
+            var tracker = await package.GetMefServiceAsync<IActiveSolutionBoundTracker>();
+
+            IMenuCommandService commandService = (IMenuCommandService)await package.GetServiceAsync(typeof(IMenuCommandService));
+            Instance = new CFamilyReproducerCommand(commandService, tracker, logger);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisableRuleCommand"/> class.
+        /// Adds our command handlers for menu (commands must exist in the command table file)
+        /// </summary>
+        /// <param name="package">Owner package, not null.</param>
+        /// <param name="menuCommandService">Command service to add command to, not null.</param>
+        internal /* for testing */ CFamilyReproducerCommand(IMenuCommandService menuCommandService,
+            IActiveSolutionBoundTracker activeSolutionBoundTracker, ILogger logger)
+        {
+            if (menuCommandService == null)
+            {
+                throw new ArgumentNullException(nameof(menuCommandService));
+            }
+            this.activeSolutionBoundTracker = activeSolutionBoundTracker ?? throw new ArgumentNullException(nameof(activeSolutionBoundTracker));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            var menuCommandID = new CommandID(CommandSet, CommandId);
+            menuItem = new OleMenuCommand(Execute, null, QueryStatus, menuCommandID);
+            menuCommandService.AddCommand(menuItem);
+        }
+
+        private void QueryStatus(object sender, EventArgs args)
+        {
+            // Settings enabled to false will stop the command being executed.
+            // VS will print "The command is not available" in the Command window.
+            try
+            {
+                menuItem.Visible = false;
+                menuItem.Enabled = true;
+            }
+            catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+            {
+                logger.WriteLine(AnalysisStrings.DisableRule_ErrorCheckingCommandStatus, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Gets the instance of the command.
+        /// </summary>
+        public static CFamilyReproducerCommand Instance
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// This function is the callback used to execute the command when the menu item is clicked.
+        /// See the constructor to see how the menu item is associated with this function using
+        /// OleMenuCommandService service and MenuCommand class.
+        /// </summary>
+        /// <param name="sender">Event sender.</param>
+        /// <param name="e">Event args.</param>
+        private void Execute(object sender, EventArgs e)
+        {
+            string errorCode = null;
+            try
+            {
+                // Do stuff
+                logger.WriteLine("Executing Sonar CFamily reproducer...");
+
+            }
+            catch(Exception ex) when (!Microsoft.VisualStudio.ErrorHandler.IsCriticalException(ex))
+            {
+                logger.WriteLine(AnalysisStrings.DisableRule_ErrorDisablingRule, errorCode ?? AnalysisStrings.DisableRule_UnknownErrorCode, ex.Message);
+            }
+        }
+    }
+}

--- a/src/Integration.Vsix/CFamily/CFamilyReproducerCommand.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyReproducerCommand.cs
@@ -25,8 +25,6 @@ using System.Linq;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-
-
 using SonarLint.VisualStudio.Core;
 using Task = System.Threading.Tasks.Task;
 
@@ -160,6 +158,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
 
             if (activeDoc != null)
             {
+                // TODO: implement the trigger code
                 logger.WriteLine(CFamilyStrings.ReproCmd_ExecutingReproducer);
             }
         }

--- a/src/Integration.Vsix/CFamily/CFamilyStrings.Designer.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyStrings.Designer.cs
@@ -146,6 +146,62 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Active document can be analyzed by the CFamily analyzer: {0}.
+        /// </summary>
+        internal static string ReproCmd_DocumentIsAnalyzable {
+            get {
+                return ResourceManager.GetString("ReproCmd_DocumentIsAnalyzable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot run SonarLint CFamily reproducer - the active document is not analyzable by the CFamily analyzer: {0}.
+        /// </summary>
+        internal static string ReproCmd_DocumentIsNotAnalyzable {
+            get {
+                return ResourceManager.GetString("ReproCmd_DocumentIsNotAnalyzable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error executing the SonarLint CFamily reproducer command:
+        ///  Error: {0}.
+        /// </summary>
+        internal static string ReproCmd_Error_Execute {
+            get {
+                return ResourceManager.GetString("ReproCmd_Error_Execute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error in calculating whether the SonarLint CFamily reproducer command is available:
+        ///  Error: {0}.
+        /// </summary>
+        internal static string ReproCmd_Error_QueryStatus {
+            get {
+                return ResourceManager.GetString("ReproCmd_Error_QueryStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Calling the SonarLint CFamily reproducer....
+        /// </summary>
+        internal static string ReproCmd_ExecutingReproducer {
+            get {
+                return ResourceManager.GetString("ReproCmd_ExecutingReproducer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot run SonarLint CFamily reproducer - no active document..
+        /// </summary>
+        internal static string ReproCmd_NoActiveDocument {
+            get {
+                return ResourceManager.GetString("ReproCmd_NoActiveDocument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Timed out after waiting {0} ms for process {1} to complete: it has been terminated, but its child processes may still be running..
         /// </summary>
         internal static string WARN_ExecutionTimedOutKilled {

--- a/src/Integration.Vsix/CFamily/CFamilyStrings.resx
+++ b/src/Integration.Vsix/CFamily/CFamilyStrings.resx
@@ -148,6 +148,26 @@
   <data name="MSG_Runner_SettingEnvVar" xml:space="preserve">
     <value>Setting environment variable '{0}'. Value: {1}</value>
   </data>
+  <data name="ReproCmd_DocumentIsAnalyzable" xml:space="preserve">
+    <value>Active document can be analyzed by the CFamily analyzer: {0}</value>
+  </data>
+  <data name="ReproCmd_DocumentIsNotAnalyzable" xml:space="preserve">
+    <value>Cannot run SonarLint CFamily reproducer - the active document is not analyzable by the CFamily analyzer: {0}</value>
+  </data>
+  <data name="ReproCmd_Error_Execute" xml:space="preserve">
+    <value>Error executing the SonarLint CFamily reproducer command:
+  Error: {0}</value>
+  </data>
+  <data name="ReproCmd_Error_QueryStatus" xml:space="preserve">
+    <value>Error in calculating whether the SonarLint CFamily reproducer command is available:
+  Error: {0}</value>
+  </data>
+  <data name="ReproCmd_ExecutingReproducer" xml:space="preserve">
+    <value>Calling the SonarLint CFamily reproducer...</value>
+  </data>
+  <data name="ReproCmd_NoActiveDocument" xml:space="preserve">
+    <value>Cannot run SonarLint CFamily reproducer - no active document.</value>
+  </data>
   <data name="WARN_ExecutionTimedOutKilled" xml:space="preserve">
     <value>Timed out after waiting {0} ms for process {1} to complete: it has been terminated, but its child processes may still be running.</value>
   </data>

--- a/src/Integration.Vsix/Helpers/ActiveDocumentLocator.cs
+++ b/src/Integration.Vsix/Helpers/ActiveDocumentLocator.cs
@@ -67,8 +67,10 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
             // Finally, convert from the legacy VS editor interface to the new-style interface
             var textBuffer = editorAdapterService.GetDocumentBuffer(vsTextBuffer);
-            textBuffer.Properties.TryGetProperty(
-                typeof(ITextDocument), out ITextDocument newTextDocument);
+
+            ITextDocument newTextDocument = null;
+            textBuffer?.Properties?.TryGetProperty(
+                typeof(ITextDocument), out newTextDocument);
 
             return newTextDocument;
         }

--- a/src/Integration.Vsix/Helpers/ActiveDocumentLocator.cs
+++ b/src/Integration.Vsix/Helpers/ActiveDocumentLocator.cs
@@ -32,7 +32,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         /// <summary>
         /// Returns the current active document, or null if there is no active document
         /// </summary>
-        /// <returns></returns>
         ITextDocument FindActiveDocument();
     }
 

--- a/src/Integration.Vsix/Helpers/ActiveDocumentLocator.cs
+++ b/src/Integration.Vsix/Helpers/ActiveDocumentLocator.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace SonarLint.VisualStudio.Integration.Vsix
+{
+    internal interface IActiveDocumentLocator
+    {
+        /// <summary>
+        /// Returns the current active document, or null if there is no active document
+        /// </summary>
+        /// <returns></returns>
+        ITextDocument FindActiveDocument();
+    }
+
+    internal class ActiveDocumentLocator : IActiveDocumentLocator
+    {
+        private readonly IVsMonitorSelection monitorSelection;
+        private readonly IVsEditorAdaptersFactoryService editorAdapterService;
+
+        public ActiveDocumentLocator(IVsMonitorSelection monitorSelection, IVsEditorAdaptersFactoryService editorAdapterService)
+        {
+            this.monitorSelection = monitorSelection;
+            this.editorAdapterService = editorAdapterService;
+        }
+
+        public ITextDocument FindActiveDocument()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // Get the current doc frame, if there is one
+            monitorSelection.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out var pvarValue);
+            if (!(pvarValue is IVsWindowFrame frame))
+            {
+                return null;
+            }
+
+            // Now get the doc data, which should also be a text buffer
+            frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocData, out var docData);
+            if (!(docData is IVsTextBuffer vsTextBuffer))
+            {
+                return null;
+            }
+
+            // Finally, convert from the legacy VS editor interface to the new-style interface
+            var textBuffer = editorAdapterService.GetDocumentBuffer(vsTextBuffer);
+            textBuffer.Properties.TryGetProperty(
+                typeof(ITextDocument), out ITextDocument newTextDocument);
+
+            return newTextDocument;
+        }
+    }
+}

--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -92,6 +92,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <PackageReference Include="Grpc" Version="1.4.1" />
     <PackageReference Include="Grpc.Tools" Version="1.4.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="14.0.23205" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="1.3.2" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="10.0.30319" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />

--- a/src/Integration.Vsix/SonarLintDaemon/DaemonCommands.vsct
+++ b/src/Integration.Vsix/SonarLintDaemon/DaemonCommands.vsct
@@ -2,11 +2,11 @@
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <Commands package="guidDaemonPackagePkgString">
-    <Groups>
+    <!--<Groups>
       <Group guid="guidDaemonCmdSet" id="grpDaemonErrorList" priority="0x1600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ERRORLIST" />
       </Group>
-    </Groups>
+    </Groups>-->
 
     <Buttons>
       <Button guid="guidDaemonCmdSet" id="cmdidErrorListDisableSonarLintRule" priority="0x0100" type="Button">
@@ -18,6 +18,22 @@
           <ButtonText>Disable SonarLint rule</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="guidDaemonCmdSet" id="cmdidCreateCFamilyReproducer" priority="0x0200" type="Button">
+        <!-- It looks like the command needs to belong to a parent menu group, even though it only
+             appears in the command window.
+             We're adding it to the top-level Analye menu, so the command the user types will be
+               "Analyze.SonarCFamilyReproducer" -->
+        <Parent guid="guidCodeAnalysisMenuGroup" id="IDG_CODEANALYSIS_TOPLEVEL"/>
+        
+        <CommandFlag>CommandWellOnly</CommandFlag>
+        <Strings>
+          <ButtonText>Sonar CFamily Reproducer</ButtonText>
+          <!--<CanonicalName>Sonar.CFamily.Reproducer</CanonicalName>
+          <CommandName>XXX.Sonar</CommandName>-->
+        </Strings>
+      </Button>
+
     </Buttons>
   </Commands>
   
@@ -26,6 +42,7 @@
     <GuidSymbol name="guidDaemonCmdSet" value="{1F83EA11-3B07-45B3-BF39-307FD4F42194}">
       <IDSymbol name="cmdidErrorListDisableSonarLintRule" value="0x200"/>
       <IDSymbol name="grpDaemonErrorList" value="0x100" />
+      <IDSymbol name="cmdidCreateCFamilyReproducer" value="0x300" />
     </GuidSymbol>
         
   </Symbols>

--- a/src/Integration.Vsix/SonarLintDaemon/DaemonCommands.vsct
+++ b/src/Integration.Vsix/SonarLintDaemon/DaemonCommands.vsct
@@ -23,14 +23,12 @@
         <!-- It looks like the command needs to belong to a parent menu group, even though it only
              appears in the command window.
              We're adding it to the top-level Analye menu, so the command the user types will be
-               "Analyze.SonarCFamilyReproducer" -->
+               "Analyze.SonarLint.CFamily.Reproducer" -->
         <Parent guid="guidCodeAnalysisMenuGroup" id="IDG_CODEANALYSIS_TOPLEVEL"/>
         
         <CommandFlag>CommandWellOnly</CommandFlag>
         <Strings>
-          <ButtonText>Sonar CFamily Reproducer</ButtonText>
-          <!--<CanonicalName>Sonar.CFamily.Reproducer</CanonicalName>
-          <CommandName>XXX.Sonar</CommandName>-->
+          <ButtonText>SonarLint.CFamily.Reproducer</ButtonText>
         </Strings>
       </Button>
 

--- a/src/Integration.Vsix/SonarLintDaemon/DaemonCommands.vsct
+++ b/src/Integration.Vsix/SonarLintDaemon/DaemonCommands.vsct
@@ -2,11 +2,11 @@
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <Commands package="guidDaemonPackagePkgString">
-    <!--<Groups>
+    <Groups>
       <Group guid="guidDaemonCmdSet" id="grpDaemonErrorList" priority="0x1600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ERRORLIST" />
       </Group>
-    </Groups>-->
+    </Groups>
 
     <Buttons>
       <Button guid="guidDaemonCmdSet" id="cmdidErrorListDisableSonarLintRule" priority="0x0100" type="Button">
@@ -22,13 +22,13 @@
       <Button guid="guidDaemonCmdSet" id="cmdidCreateCFamilyReproducer" priority="0x0200" type="Button">
         <!-- It looks like the command needs to belong to a parent menu group, even though it only
              appears in the command window.
-             We're adding it to the top-level Analye menu, so the command the user types will be
-               "Analyze.SonarLint.CFamily.Reproducer" -->
+             We're adding it to the top-level Analyze menu, so the command the user types will be
+               "Analyze.SonarLint.CFamily.RunReproducer" -->
         <Parent guid="guidCodeAnalysisMenuGroup" id="IDG_CODEANALYSIS_TOPLEVEL"/>
         
         <CommandFlag>CommandWellOnly</CommandFlag>
         <Strings>
-          <ButtonText>SonarLint.CFamily.Reproducer</ButtonText>
+          <ButtonText>SonarLint.CFamily.RunReproducer</ButtonText>
         </Strings>
       </Button>
 

--- a/src/Integration.Vsix/SonarLintDaemonPackage.cs
+++ b/src/Integration.Vsix/SonarLintDaemonPackage.cs
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
+using SonarLint.VisualStudio.Integration.Vsix.CFamily;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
 
 namespace SonarLint.VisualStudio.Integration.Vsix

--- a/src/Integration.Vsix/SonarLintDaemonPackage.cs
+++ b/src/Integration.Vsix/SonarLintDaemonPackage.cs
@@ -87,6 +87,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 logger.WriteLine(Resources.Strings.Daemon_Initializing);
 
                 await DisableRuleCommand.InitializeAsync(this, logger);
+                await CFamilyReproducerCommand.InitializeAsync(this, logger);
 
                 daemon = await this.GetMefServiceAsync<ISonarLintDaemon>();
 


### PR DESCRIPTION
Relates to #1295.

Adds the menu command. The command is only enabled if document that can be analysed by the CFamily analyser is active.

TODO: trigger the reproducer.