### PR TITLE
Moved analyzer options to Core

### DIFF
--- a/src/Core/CFamily/CFamilyAnalyzerOptions.cs
+++ b/src/Core/CFamily/CFamilyAnalyzerOptions.cs
@@ -18,25 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Threading;
-using EnvDTE;
-
-// TODO: decide whether both of these interfaces are required
-
-namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
+namespace SonarLint.VisualStudio.Core
 {
-    public interface IAnalyzer
+    public class CFamilyAnalyzerOptions : IAnalyzerOptions
     {
-        bool IsAnalysisSupported(IEnumerable<AnalysisLanguage> languages);
-
-        void ExecuteAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConsumer consumer, ProjectItem projectItem, CancellationToken cancellationToken);
-    }
-
-    // Marker interface used by for MEF exporting/importing
-    // (there are multiple implementations of IAnalyzer but only one implentation
-    // of this interface).
-    internal interface IAnalyzerController : IAnalyzer
-    {
+        public bool RunReproducer { get; set; }
     }
 }

--- a/src/Core/CFamily/CFamilyAnalyzerOptions.cs
+++ b/src/Core/CFamily/CFamilyAnalyzerOptions.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.CFamily
 {
     public class CFamilyAnalyzerOptions : IAnalyzerOptions
     {

--- a/src/Core/IAnalzyerOptions.cs
+++ b/src/Core/IAnalzyerOptions.cs
@@ -18,25 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Threading;
-using EnvDTE;
-
-// TODO: decide whether both of these interfaces are required
-
-namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
+namespace SonarLint.VisualStudio.Core
 {
-    public interface IAnalyzer
-    {
-        bool IsAnalysisSupported(IEnumerable<AnalysisLanguage> languages);
-
-        void ExecuteAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConsumer consumer, ProjectItem projectItem, CancellationToken cancellationToken);
-    }
-
-    // Marker interface used by for MEF exporting/importing
-    // (there are multiple implementations of IAnalyzer but only one implentation
-    // of this interface).
-    internal interface IAnalyzerController : IAnalyzer
+    /// <summary>
+    /// Marker interface for any analyzer-specific configuration options
+    /// </summary>
+    public interface IAnalyzerOptions
     {
     }
 }

--- a/src/Integration.Vsix/CFamily/CFamilyAnalyzerOptions.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyAnalyzerOptions.cs
@@ -1,9 +1,0 @@
-﻿using SonarLint.VisualStudio.Integration.Vsix.Analysis;
-
-namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
-{
-    public class CFamilyAnalyzerOptions : IAnalyzerOptions
-    {
-        public bool RunReproducer { get; set; }
-    }
-}


### PR DESCRIPTION
Move `IAnalyzerOptions` to Core so they are accessible to `IAnalysisRequester`

Relates to #1295 
