### PR TITLE
Added RoslynProfileExporter replacement classes to Core

### DIFF
--- a/src/Core.UnitTests/CSharpVB/NuGetPackageInfoGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/NuGetPackageInfoGeneratorTests.cs
@@ -1,0 +1,183 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.CSharpVB;
+using SonarQube.Client.Models;
+
+namespace SonarQube.Client.Tests.RoslynExporterAdapter
+{
+    [TestClass]
+    public class NuGetPackageInfoGeneratorTests
+    {
+        private static readonly IEnumerable<SonarQubeRule> ValidCSharpRules = new SonarQubeRule[]
+        {
+            CreateRule("csharpsquid", "rule1"),
+            CreateRule("csharpsquid", "rule2")
+        };
+
+        [TestMethod]
+        public void Get_NoActiveRules_NoPackageInfo()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.analyzerId", "my.analyzer" },
+                { "sonaranalyzer-cs.pluginVersion", "1.2.3" }
+            };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(Array.Empty<SonarQubeRule>(), properties);
+
+            actual.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Get_NoSonarProperties_NoPackageInfo()
+        {
+            var rules = new SonarQubeRule[]
+            {
+                CreateRule("csharpsquid", "rule1"),
+                CreateRule("csharpsquid", "rule2")
+            };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, new Dictionary<string, string>());
+
+            actual.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Get_MissingVersionProperty_NoPackageInfo()
+        {
+            var properties = new Dictionary<string, string> { { "sonaranalyzer-cs.analyzerId", "my.analyzer" } };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(ValidCSharpRules, properties);
+
+            actual.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Get_MissingPluginVerionProperty_NoPackageInfo()
+        {
+            var properties = new Dictionary<string, string> { { "sonaranalyzer-cs.pluginVersion", "1.2.3" } };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(ValidCSharpRules, properties);
+
+            actual.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Get_CSharp_WithPropertiesAndMatchingRules_ExpectedPackageReturned()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.analyzerId", "my.analyzer" },
+                { "sonaranalyzer-cs.pluginVersion", "3.2.1" }
+            };
+
+            var rules = new SonarQubeRule[]
+            {
+                CreateRule("csharpsquid", "rule2")
+            };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, properties);
+
+            actual.Count().Should().Be(1);
+            actual.First().Id.Should().Be("my.analyzer");
+            actual.First().Version.Should().Be("3.2.1");
+        }
+
+        [TestMethod]
+        public void Get_VBNet_WithPropertiesAndMatchingRules_ExpectedPackageReturned()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { "sonaranalyzer-vbnet.analyzerId", "sonarVB" },
+                { "sonaranalyzer-vbnet.pluginVersion", "1.2" }
+            };
+
+            var rules = new SonarQubeRule[]
+            {
+                CreateRule("vbnet", "rule1")
+            };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, properties);
+
+            actual.Count().Should().Be(1);
+            actual.First().Id.Should().Be("sonarVB");
+            actual.First().Version.Should().Be("1.2");
+        }
+
+        [TestMethod]
+        public void Get_MultiplePlugins_WithPropertiesAndMatchingRules_ExpectedPackageReturned()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                // Valid CSharp properties
+                { "sonaranalyzer-cs.analyzerId", "analyzer.csharp" },
+                { "sonaranalyzer-cs.pluginVersion", "version.csharp" },
+
+                // Valid VBNet properties
+                { "sonaranalyzer-vbnet.analyzerId", "analyzer.vb" },
+                { "sonaranalyzer-vbnet.pluginVersion", "version.vb" },
+
+                // First valid third-party analyzer properties
+                { "myanalyzer1.analyzerId", "analyzer.myanalyzer1" },
+                { "myanalyzer1.pluginVersion", "version.myanalyzer1" },
+
+                // Second valid third-party analyzer properties
+                { "wintellect.analyzerId", "analyzer.wintellect" },
+                { "wintellect.pluginVersion", "version.wintellect" },
+
+                // Invalid third-party analyzer properties - missing version
+                { "invalid.analyzerId", "analyzer.invalid" }
+            };
+
+            var rules = new SonarQubeRule[]
+            {
+                CreateRule("csharpsquid", "rule1"),
+                CreateRule("vbnet", "rule2"),
+                CreateRule("roslyn.myanalyzer1", "rule3"),
+                // no wintellect rule, so it should not be invluded
+                CreateRule("roslyn.invalid", "rule3"),
+            };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, properties);
+
+            actual.Count().Should().Be(3);
+            var packages = actual.ToArray();
+
+            packages[0].Id.Should().Be("analyzer.csharp");
+            packages[0].Version.Should().Be("version.csharp");
+
+            packages[1].Id.Should().Be("analyzer.vb");
+            packages[1].Version.Should().Be("version.vb");
+
+            packages[2].Id.Should().Be("analyzer.myanalyzer1");
+            packages[2].Version.Should().Be("version.myanalyzer1");
+        }
+
+
+        private static SonarQubeRule CreateRule(string repoKey, string ruleKey) =>
+            new SonarQubeRule(ruleKey, repoKey, true, SonarQubeIssueSeverity.Critical, null);
+    }
+}

--- a/src/Core.UnitTests/CSharpVB/RoslynPluginRuleKeyExtensionsTests.cs
+++ b/src/Core.UnitTests/CSharpVB/RoslynPluginRuleKeyExtensionsTests.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.CSharpVB;
+using SonarQube.Client.Models;
+
+namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
+{
+    [TestClass]
+    public class RoslynPluginRuleKeyExtensionsTests
+    {
+        [TestMethod]
+        [DataRow("roslyn.x", "x")]
+        [DataRow("roslyn.ANYTHING","ANYTHING")]
+        [DataRow("roslyn.", null)]
+        [DataRow("roslynx.wrongprefix", null)]
+        [DataRow("ROSLYN.case.sensitive", null)]
+        [DataRow("csharpsquid", "sonaranalyzer-cs")] // special case - SonarC#
+        [DataRow("vbnet", "sonaranalyzer-vbnet")] // special case for SonarVBNet
+        public void TryGetPrefix(string ruleKey, string expectedPrefix)
+        {
+            var rule = new SonarQubeRule("any", ruleKey, false, SonarQubeIssueSeverity.Unknown, null);
+
+            rule.TryGetRoslynPluginPropertyPrefix().Should().Be(expectedPrefix);
+        }
+    }
+}

--- a/src/Core.UnitTests/CSharpVB/RuleSetGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/RuleSetGeneratorTests.cs
@@ -1,0 +1,338 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.CSharpVB;
+using SonarQube.Client.Models;
+
+// Copied from the SonarScanner for MSBuild.
+// See https://github.com/SonarSource/sonar-scanner-msbuild/blob/9ccfdb648a0411014b29c7aee8e347aeab87ea71/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RuleSetGeneratorTests.cs#L29
+
+namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
+{
+    [TestClass]
+    public class RuleSetGeneratorTests
+    {
+        [TestMethod]
+        public void RoslynRuleSet_ConstructorArgumentChecks()
+        {
+            Action act = () => new RuleSetGenerator(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_GeneratorArgumentChecks()
+        {
+            var generator = new RuleSetGenerator(new Dictionary<string, string>());
+            IEnumerable<SonarQubeRule> activeRules = new List<SonarQubeRule>();
+            IEnumerable<SonarQubeRule> inactiveRules = new List<SonarQubeRule>();
+            var language = "cs";
+
+            Action act1 = () => generator.Generate(null, activeRules, inactiveRules);
+            act1.Should().ThrowExactly<ArgumentNullException>();
+
+            Action act2 = () => generator.Generate(language, activeRules, null);
+            act2.Should().ThrowExactly<ArgumentNullException>();
+
+            Action act3 = () => generator.Generate(language, null, inactiveRules);
+            act3.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_Empty()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>());
+            var activeRules = new List<SonarQubeRule>
+            {
+                CreateRule("repo", "key", false),
+            };
+            var inactiveRules = new List<SonarQubeRule>();
+
+            // Act
+            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+
+            // Assert
+            ruleSet.Rules.Should().BeEmpty(); // No analyzers
+            ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
+            ruleSet.ToolsVersion.Should().Be("14.0");
+            ruleSet.Name.Should().Be("Rules for SonarQube");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_ActiveRules_Always_Warning()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                ["sonaranalyzer-cs.analyzerId"] = "SonarAnalyzer.CSharp",
+                ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
+            });
+
+            var activeRules = new List<SonarQubeRule>
+            {
+                CreateRule("csharpsquid", "rule1", isActive: true),
+                CreateRule("csharpsquid", "rule2", isActive: true),
+            };
+
+            // Act
+            var ruleSet = generator.Generate("cs", activeRules, Enumerable.Empty<SonarQubeRule>());
+
+            // Assert
+            ruleSet.Rules.Should().HaveCount(1);
+            ruleSet.Rules[0].RuleList.Select(r => r.Action).Should().BeEquivalentTo("Warning", "Warning");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_InactiveRules_Always_None()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                ["sonaranalyzer-cs.analyzerId"] = "SonarAnalyzer.CSharp",
+                ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
+            });
+
+            var inactiveRules = new List<SonarQubeRule>
+            {
+                CreateRule("csharpsquid", "rule1", isActive: false),
+                CreateRule("csharpsquid", "rule2", isActive: false),
+            };
+
+            // Act
+            var ruleSet = generator.Generate("cs", Enumerable.Empty<SonarQubeRule>(), inactiveRules);
+
+            // Assert
+            ruleSet.Rules.Should().HaveCount(1);
+            ruleSet.Rules[0].RuleList.Select(r => r.Action).Should().BeEquivalentTo("None", "None");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_Unsupported_Rules_Ignored()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>());
+
+            var activeRules = new[]
+            {
+                CreateRule("other.repo", "other.rule1", true),
+            };
+            var inactiveRules = new[]
+            {
+                CreateRule("other.repo", "other.rule2", false),
+            };
+
+            // Act
+            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+
+            // Assert
+            ruleSet.Rules.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_RoslynSDK_Rules_Added()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                ["custom1.analyzerId"] = "CustomAnalyzer1",
+                ["custom1.ruleNamespace"] = "CustomNamespace1",
+                ["custom2.analyzerId"] = "CustomAnalyzer2",
+                ["custom2.ruleNamespace"] = "CustomNamespace2",
+            });
+
+            var activeRules = new[]
+            {
+                CreateRule("roslyn.custom1", "active1", true),
+                CreateRule("roslyn.custom2", "active2", true),
+            };
+            var inactiveRules = new[]
+            {
+                CreateRule("roslyn.custom1", "inactive1", false),
+                CreateRule("roslyn.custom2", "inactive2", false),
+            };
+
+            // Act
+            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+
+            // Assert
+            ruleSet.Rules.Should().HaveCount(2);
+
+            ruleSet.Rules[0].RuleNamespace.Should().Be("CustomNamespace1");
+            ruleSet.Rules[0].AnalyzerId.Should().Be("CustomAnalyzer1");
+            ruleSet.Rules[0].RuleList.Should().HaveCount(2);
+            ruleSet.Rules[0].RuleList.Select(r => r.Id).Should().BeEquivalentTo("active1", "inactive1");
+            ruleSet.Rules[0].RuleList.Select(r => r.Action).Should().BeEquivalentTo("Warning", "None");
+
+            ruleSet.Rules[1].RuleNamespace.Should().Be("CustomNamespace2");
+            ruleSet.Rules[1].AnalyzerId.Should().Be("CustomAnalyzer2");
+            ruleSet.Rules[1].RuleList.Should().HaveCount(2);
+            ruleSet.Rules[1].RuleList.Select(r => r.Id).Should().BeEquivalentTo("active2", "inactive2");
+            ruleSet.Rules[1].RuleList.Select(r => r.Action).Should().BeEquivalentTo("Warning", "None");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_Sonar_Rules_Added()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
+                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
+            });
+
+            var activeRules = new[]
+            {
+                CreateRule("csharpsquid", "active1", true),
+                // Even though this rule is for VB it will be added as C#, see NOTE below
+                CreateRule("vbnet", "active2", true),
+            };
+            var inactiveRules = new[]
+            {
+                CreateRule("csharpsquid", "inactive1", false),
+                // Even though this rule is for VB it will be added as C#, see NOTE below
+                CreateRule("vbnet", "inactive2", false),
+            };
+
+            // Act
+            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+
+            // Assert
+            ruleSet.Rules.Should().HaveCount(1);
+
+            // NOTE: The RuleNamespace and AnalyzerId are taken from the language parameter of the
+            // Generate method. The FetchArgumentsAndRulesets method will retrieve active/inactive
+            // rules from SonarQube per language/quality profile and mixture of VB-C# rules is not
+            // expected.
+            ruleSet.Rules[0].RuleNamespace.Should().Be("SonarAnalyzer.CSharp");
+            ruleSet.Rules[0].AnalyzerId.Should().Be("SonarAnalyzer.CSharp");
+            ruleSet.Rules[0].RuleList.Should().HaveCount(4);
+            ruleSet.Rules[0].RuleList.Select(r => r.Id).Should().BeEquivalentTo(
+                "active1", "active2", "inactive1", "inactive2");
+            ruleSet.Rules[0].RuleList.Select(r => r.Action).Should().BeEquivalentTo(
+                "Warning", "Warning", "None", "None");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_Common_Parameters()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>());
+
+            // Act
+            var ruleSet = generator.Generate("cs", Enumerable.Empty<SonarQubeRule>(), Enumerable.Empty<SonarQubeRule>());
+
+            // Assert
+            ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
+            ruleSet.ToolsVersion.Should().Be("14.0");
+            ruleSet.Name.Should().Be("Rules for SonarQube");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_AnalyzerId_Property_Missing()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
+            });
+
+            var activeRules = new[]
+            {
+                CreateRule("csharpsquid", "active1", true),
+            };
+
+            // Act & Assert
+            var action = new Action(() => generator.Generate("cs", activeRules, Enumerable.Empty<SonarQubeRule>()));
+            action.Should().ThrowExactly<InvalidOperationException>().And
+                .Message.Should().StartWith(
+                    "Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_RuleNamespace_Property_Missing()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
+            });
+
+            var activeRules = new[]
+            {
+                CreateRule("csharpsquid", "active1", true),
+            };
+
+            // Act & Assert
+            var action = new Action(() => generator.Generate("cs", activeRules, Enumerable.Empty<SonarQubeRule>()));
+            action.Should().ThrowExactly<InvalidOperationException>().And
+                .Message.Should().StartWith(
+                    "Property does not exist: sonaranalyzer-cs.ruleNamespace. This property should be set by the plugin in SonarQube.");
+        }
+
+        [TestMethod]
+        public void RoslynRuleSet_PropertyName_IsCaseSensitive()
+        {
+            // Arrange
+            var generator = new RuleSetGenerator(new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.ANALYZERId", "SonarAnalyzer.CSharp" },
+                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
+            });
+
+            var activeRules = new[]
+            {
+                CreateRule("csharpsquid", "active1", true),
+            };
+
+            // Act & Assert
+            var action = new Action(() => generator.Generate("cs", activeRules, Enumerable.Empty<SonarQubeRule>()));
+            action.Should().ThrowExactly<InvalidOperationException>().And
+                .Message.Should().StartWith(
+                    "Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
+        }
+
+
+        [TestMethod]
+        [DataRow(RuleAction.Info, "Info")]
+        [DataRow(RuleAction.Warning, "Warning")]
+        [DataRow(RuleAction.None, "None")]
+        [DataRow(RuleAction.Error, "Error")]
+        [DataRow(RuleAction.Hidden, "Hidden")]
+        public void GetActionText_Valid(RuleAction action, string expected)
+        {
+            RuleSetGenerator.GetActionText(action).Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void GetActionText_Invalid()
+        {
+            Action act = () =>RuleSetGenerator.GetActionText((RuleAction)(-1));
+            act.Should().Throw<NotSupportedException>();
+        }
+
+        private SonarQubeRule CreateRule(string repoKey, string ruleKey, bool isActive) =>
+            new SonarQubeRule(ruleKey, repoKey, isActive, SonarQubeIssueSeverity.Unknown, new Dictionary<string, string>());
+    }
+}

--- a/src/Core.UnitTests/CSharpVB/SerializerTests.cs
+++ b/src/Core.UnitTests/CSharpVB/SerializerTests.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.CSharpVB;
+
+namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
+{
+    [TestClass]
+    public class SerializerTests
+    {
+        [TestMethod]
+        public void Serializer_NullArg_Throws()
+        {
+            // Arrange
+            Action act = () => Serializer.ToString((MyDataClass)null);
+
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("model");
+        }
+
+        [TestMethod]
+        public void Serializer_ToString_Succeeds()
+        {
+            // Arrange
+            var inputData = new MyDataClass() { Value1 = "val1", Value2 = 22 };
+
+            // Act
+            var actual = Serializer.ToString(inputData);
+
+            // Assert
+            const string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<MyDataClass xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Value1>val1</Value1>
+  <Value2>22</Value2>
+</MyDataClass>";
+
+            actual.Should().Be(expected);
+        }
+
+        public class MyDataClass
+        {
+            public string Value1 { get; set; }
+            public int Value2 { get; set; }
+        }
+    }
+}

--- a/src/Core.UnitTests/CSharpVB/SonarLintConfigGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/SonarLintConfigGeneratorTests.cs
@@ -1,0 +1,201 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.CSharpVB;
+using SonarQube.Client.Models;
+
+namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
+{
+    [TestClass]
+    public class SonarLintConfigGeneratorTests
+    {
+        private static readonly IEnumerable<SonarQubeRule> EmptyRules = Array.Empty<SonarQubeRule>();
+        private static readonly IDictionary<string, string> EmptyProperties = new Dictionary<string, string>();
+        private const string ValidLanguage = "cs";
+
+        [TestMethod]
+        public void Generate_NullArguments_Throws()
+        {
+            Action act = () => SonarLintConfigGenerator.Generate(null, EmptyProperties, ValidLanguage);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("rules");
+
+            act = () => SonarLintConfigGenerator.Generate(EmptyRules, null, ValidLanguage);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("sonarProperties");
+
+            act = () => SonarLintConfigGenerator.Generate(EmptyRules, EmptyProperties, null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("language");
+        }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("xxx")]
+        [DataRow("CS")] // should be case-sensitive
+        [DataRow("vb")] // VB language key is "vbnet"
+        public void Generate_UnrecognisedLanguage_Throws(string language)
+        {
+            Action act = () => SonarLintConfigGenerator.Generate(EmptyRules, EmptyProperties, language);
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>().And.ParamName.Should().Be("language");
+        }
+
+        [TestMethod]
+        [DataRow("cs")]
+        [DataRow("vbnet")]
+        public void Generate_NoActiveRulesOrSettings_ValidLanguage_ReturnsValidConfig(string validLanguage)
+        {
+            var actual = SonarLintConfigGenerator.Generate(EmptyRules, EmptyProperties, validLanguage);
+
+            actual.Should().NotBeNull();
+            actual.Rules.Should().BeEmpty();
+            actual.Settings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Generate_ValidSettings_OnlyLanguageSpecificSettingsReturned()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                { "sonar.cs.property1", "valid setting 1"},
+                { "sonar.cs.property2", "valid setting 2"},
+                { "sonar.vbnet.property1", "wrong language - not returned"},
+                { "sonar.CS.property2", "wrong case - not returned"},
+                { "sonar.cs.", "incorrect prefix - not returned"},
+                { "xxx.cs.property1", "key does not match - not returned"},
+                { ".does.not.match", "not returned"}
+            };
+
+            // Act
+            var actual = SonarLintConfigGenerator.Generate(EmptyRules, properties, "cs");
+
+            // Assert
+            actual.Settings.Should().BeEquivalentTo(new Dictionary<string, string>
+            {
+                { "sonar.cs.property1", "valid setting 1"},
+                { "sonar.cs.property2", "valid setting 2"}
+            });
+        }
+
+        [TestMethod]
+        [DataRow("cs", "csharpsquid")]
+        [DataRow("vbnet", "vbnet")]
+        public void Generate_ValidRules_OnlyRulesFromKnownRepositoryReturned(string knownLanguage, string knownRepoKey)
+        {
+            var rules = new List<SonarQubeRule>()
+            {
+                CreateRule("valid1", knownRepoKey),
+                CreateRule("unknown1", "unknown.repo.key"),
+                CreateRule("valid2", knownRepoKey),
+                CreateRule("invalid2", "another.unknown.repo.key"),
+                CreateRule("valid3", knownRepoKey)
+            };
+
+            // Act
+            var actual = SonarLintConfigGenerator.Generate(rules, EmptyProperties, knownLanguage);
+
+            // Assert
+            actual.Rules.Select(r => r.Key).Should().BeEquivalentTo(new string[] { "valid1", "valid2", "valid3" });
+        }
+
+        [TestMethod]
+        public void Generate_RulesWithParameters_ExpectedConfigReturned()
+        {
+            var rule1Params = new Dictionary<string, string> { { "param1", "value1" }, { "param2", "value2" } };
+            var rule2Params = new Dictionary<string, string> { { "param3", "value4" } };
+
+            var rules = new List<SonarQubeRule>()
+            {
+                CreateRule("s111", "csharpsquid", rule1Params ),
+                CreateRule("s222", "csharpsquid", rule2Params ),
+            };
+
+            // Act
+            var actual = SonarLintConfigGenerator.Generate(rules, EmptyProperties, "cs");
+
+            // Assert
+            actual.Rules.Count.Should().Be(2);
+
+            actual.Rules[0].Key.Should().Be("s111");
+            actual.Rules[0].Parameters.Should().BeEquivalentTo(rule1Params);
+            actual.Rules[1].Parameters.Should().BeEquivalentTo(rule2Params);
+        }
+
+        [TestMethod]
+        public void Generate_Serialized_ReturnsExpectedXml()
+        {
+            var properties = new Dictionary<string, string>()
+            {
+                { "sonar.cs.prop1", "value 1"},
+                { "sonar.cs.prop2", "value 2"}
+            };
+
+            var rules = new List<SonarQubeRule>()
+            {
+                CreateRule("s111", "csharpsquid"),
+                CreateRule("s222", "csharpsquid",
+                    new Dictionary<string, string> { { "param1", "param value1" }, { "param2", "param value2" } }),
+            };
+
+            // Act
+            var actual = SonarLintConfigGenerator.Generate(rules, properties, "cs");
+            var actualXml = Serializer.ToString(actual);
+
+            // Assert
+            actualXml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<AnalysisInput xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <Settings>
+    <Setting>
+      <Key>sonar.cs.prop1</Key>
+      <Value>value 1</Value>
+    </Setting>
+    <Setting>
+      <Key>sonar.cs.prop2</Key>
+      <Value>value 2</Value>
+    </Setting>
+  </Settings>
+  <Rules>
+    <Rule>
+      <Key>s111</Key>
+    </Rule>
+    <Rule>
+      <Key>s222</Key>
+      <Parameters>
+        <Parameter>
+          <Key>param1</Key>
+          <Value>param value1</Value>
+        </Parameter>
+        <Parameter>
+          <Key>param2</Key>
+          <Value>param value2</Value>
+        </Parameter>
+      </Parameters>
+    </Rule>
+  </Rules>
+</AnalysisInput>");
+        }
+
+        private static SonarQubeRule CreateRule(string ruleKey, string repoKey, IDictionary<string, string> parameters = null) =>
+            new SonarQubeRule(ruleKey, repoKey, isActive: false, SonarQubeIssueSeverity.Blocker, parameters);
+    }
+}

--- a/src/Core/CSharpVB/NuGetPackageInfoGenerator.cs
+++ b/src/Core/CSharpVB/NuGetPackageInfoGenerator.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using SonarQube.Client.Messages;
+using SonarQube.Client.Models;
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    public static class NuGetPackageInfoGenerator
+    {
+        public static IEnumerable<NuGetPackageInfoResponse> GetNuGetPackageInfos(IEnumerable<SonarQubeRule> activeRules,
+            IDictionary<string, string> sonarProperties)
+        {
+            var propertyPrefixes = GetPluginPropertyPrefixes(activeRules);
+            var packages = new List<NuGetPackageInfoResponse>();
+
+            foreach (var partialRepoKey in propertyPrefixes)
+            {
+                if (!sonarProperties.TryGetValue($"{partialRepoKey}.analyzerId", out var analyzerId) ||
+                    !sonarProperties.TryGetValue($"{partialRepoKey}.pluginVersion", out var pluginVersion))
+                {
+                    continue;
+                }
+
+                packages.Add(new NuGetPackageInfoResponse { Id = analyzerId, Version = pluginVersion });
+            }
+
+            return packages;
+        }
+
+        private static IEnumerable<string> GetPluginPropertyPrefixes(IEnumerable<SonarQubeRule> rules) =>
+            rules.Select(r => r.TryGetRoslynPluginPropertyPrefix())
+                .Distinct()
+                .Where(r => !string.IsNullOrEmpty(r))
+                .ToArray();
+    }
+}

--- a/src/Core/CSharpVB/RoslynPluginRuleKeyExtensions.cs
+++ b/src/Core/CSharpVB/RoslynPluginRuleKeyExtensions.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarQube.Client.Models;
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    public static class RoslynPluginRuleKeyExtensions
+    {
+        private const string ROSLYN_REPOSITORY_PREFIX = "roslyn.";
+
+        private const string CSharpRepositoryKey = "csharpsquid";
+        private const string CSharpPropertyPrefix = "sonaranalyzer-cs";
+
+        private const string VBNetRepositoryKey = "vbnet";
+        private const string VBNetPropertyPrefix = "sonaranalyzer-vbnet";
+
+        public static string TryGetRoslynPluginPropertyPrefix(this SonarQubeRule rule)
+        {
+            // The SonarC# and Sonar VBNet repositories don't following the same prefix-naming rules
+            // as third-party plugins - they have their own custom prefixes.
+            if (CSharpRepositoryKey.Equals(rule.RepositoryKey))
+            {
+                return CSharpPropertyPrefix;
+            }
+
+            if (VBNetRepositoryKey.Equals(rule.RepositoryKey))
+            {
+                return VBNetPropertyPrefix;
+            }
+
+            // For plugins created by the SonarQube Roslyn SDK, the repository key is in the form
+            // "roslyn.MyCustomAnalyzer", and the Sonar properties added by the custom plugin will
+            // start with "MyCustomAnalyzer." e.g.
+            // * MyCustomAnalyzer.analyzerId
+            // * MyCustomAnalyzer.pluginVersion
+            if (rule.RepositoryKey.StartsWith(ROSLYN_REPOSITORY_PREFIX))
+            {
+                var propertyPrefix = rule.RepositoryKey.Substring(ROSLYN_REPOSITORY_PREFIX.Length);
+                return string.IsNullOrEmpty(propertyPrefix) ? null : propertyPrefix;
+            }
+
+            return null; // not a Roslyn-based rule
+        }
+    }
+}

--- a/src/Core/CSharpVB/RuleAction.cs
+++ b/src/Core/CSharpVB/RuleAction.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    // Copied from the SonarScanner for MSBuild.
+    // See https://github.com/SonarSource/sonar-scanner-msbuild/blob/9ccfdb648a0411014b29c7aee8e347aeab87ea71/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RuleAction.cs#L21
+    public enum RuleAction
+    {
+        None,
+        Hidden,
+        Info,
+        Warning,
+        Error,
+    }
+}

--- a/src/Core/CSharpVB/RuleSet.cs
+++ b/src/Core/CSharpVB/RuleSet.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    // XML data classes to serialize a RuleSet in VS format
+
+    // Data classes copied from the SonarScanner for MSBuild and merged into a single file.
+    // See https://github.com/SonarSource/sonar-scanner-msbuild/blob/5c23a7da9171e90a1970a31507dce3da3e8ee094/src/SonarScanner.MSBuild.Common/AnalysisConfig/RuleSet.cs#L27
+    // and the other data files in the same folder.
+    public class RuleSet
+    {
+        [XmlAttribute]
+        public string Name { get; set; }
+
+        [XmlAttribute]
+        public string Description { get; set; }
+
+        [XmlAttribute]
+        public string ToolsVersion { get; set; }
+
+        [XmlElement(ElementName = "Include")]
+        public List<Include> Includes { get; set; }
+
+        [XmlElement]
+        public List<Rules> Rules { get; set; } = new List<Rules>();
+    }
+
+    public class Include
+    {
+        [XmlAttribute]
+        public string Path { get; set; }
+
+        [XmlAttribute]
+        public string Action { get; set; }
+    }
+
+    public class Rule
+    {
+        public Rule()
+        {
+        }
+
+        public Rule(string id, string action)
+        {
+            Id = id;
+            Action = action;
+        }
+
+        [XmlAttribute]
+        public string Id { get; set; }
+
+        [XmlAttribute]
+        public string Action { get; set; }
+    }
+
+    public class Rules
+    {
+        [XmlAttribute]
+        public string AnalyzerId { get; set; }
+
+        [XmlAttribute]
+        public string RuleNamespace { get; set; }
+
+        [XmlElement("Rule")]
+        public List<Rule> RuleList { get; set; }
+    }
+}

--- a/src/Core/CSharpVB/RuleSetGenerator.cs
+++ b/src/Core/CSharpVB/RuleSetGenerator.cs
@@ -1,0 +1,157 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SonarQube.Client.Models;
+
+// Copied from the SonarScanner for MSBuild.
+// See https://github.com/SonarSource/sonar-scanner-msbuild/blob/9ccfdb648a0411014b29c7aee8e347aeab87ea71/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs#L28
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    public class RuleSetGenerator
+    {
+        private const string SONARANALYZER_PARTIAL_REPO_KEY = "sonaranalyzer-{0}";
+        private const string ROSLYN_REPOSITORY_PREFIX = "roslyn.";
+
+        private readonly IDictionary<string, string> sonarProperties;
+        private readonly string inactiveRuleActionText = GetActionText(RuleAction.None);
+
+        private readonly string activeRuleActionText = GetActionText(RuleAction.Warning);
+
+        public RuleSetGenerator(IDictionary<string, string> sonarProperties)
+        {
+            this.sonarProperties = sonarProperties ?? throw new ArgumentNullException(nameof(sonarProperties));
+        }
+
+        /// <summary>
+        /// Generates a RuleSet that is serializable (XML).
+        /// The ruleset can be empty if there are no active rules belonging to the repo keys "vbnet", "csharpsquid" or "roslyn.*".
+        /// </summary>
+        /// <exception cref="InvalidOperationException">if required properties that should be associated with the repo key are missing.</exception>
+        public RuleSet Generate(string language, IEnumerable<SonarQubeRule> activeRules, IEnumerable<SonarQubeRule> inactiveRules)
+        {
+            if (activeRules == null)
+            {
+                throw new ArgumentNullException(nameof(activeRules));
+            }
+            if (inactiveRules == null)
+            {
+                throw new ArgumentNullException(nameof(inactiveRules));
+            }
+            if (language == null)
+            {
+                throw new ArgumentNullException(nameof(language));
+            }
+
+            var rulesElements = activeRules.Concat(inactiveRules)
+                .GroupBy(
+                    rule => GetPartialRepoKey(rule, language),
+                    rule => rule)
+                .Where(IsSupportedRuleRepo)
+                .Select(CreateRulesElement);
+
+            var ruleSet = new RuleSet
+            {
+                Name = "Rules for SonarQube",
+                Description = "This rule set was automatically generated from SonarQube",
+                ToolsVersion = "14.0"
+            };
+
+            ruleSet.Rules.AddRange(rulesElements);
+
+            return ruleSet;
+        }
+
+        private static bool IsSupportedRuleRepo(IGrouping<string, SonarQubeRule> analyzerRules)
+        {
+            var partialRepoKey = analyzerRules.Key;
+            return !string.IsNullOrEmpty(partialRepoKey);
+        }
+
+        private Rules CreateRulesElement(IGrouping<string, SonarQubeRule> analyzerRules)
+        {
+            var partialRepoKey = analyzerRules.Key;
+            return new Rules
+            {
+                AnalyzerId = GetRequiredPropertyValue($"{partialRepoKey}.analyzerId"),
+                RuleNamespace = GetRequiredPropertyValue($"{partialRepoKey}.ruleNamespace"),
+                RuleList = analyzerRules.Select(CreateRuleElement).ToList()
+            };
+        }
+
+        private Rule CreateRuleElement(SonarQubeRule sonarRule) =>
+            new Rule(sonarRule.Key, sonarRule.IsActive ? activeRuleActionText : inactiveRuleActionText);
+
+        internal /* for testing */ static string GetActionText(RuleAction ruleAction)
+        {
+            switch (ruleAction)
+            {
+                case RuleAction.None:
+                    return "None";
+                case RuleAction.Info:
+                    return "Info";
+                case RuleAction.Warning:
+                    return "Warning";
+                case RuleAction.Error:
+                    return "Error";
+                case RuleAction.Hidden:
+                    return "Hidden";
+                default:
+                    throw new NotSupportedException($"{ruleAction} is not a supported RuleAction.");
+            }
+        }
+
+        private static string GetPartialRepoKey(SonarQubeRule rule, string language)
+        {
+            if (rule.RepositoryKey.StartsWith(ROSLYN_REPOSITORY_PREFIX))
+            {
+                return rule.RepositoryKey.Substring(ROSLYN_REPOSITORY_PREFIX.Length);
+            }
+            else if ("csharpsquid".Equals(rule.RepositoryKey) || "vbnet".Equals(rule.RepositoryKey))
+            {
+                return string.Format(SONARANALYZER_PARTIAL_REPO_KEY, language);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private string GetRequiredPropertyValue(string propertyKey)
+        {
+            if (!this.sonarProperties.TryGetValue(propertyKey, out var propertyValue))
+            {
+                var message = $"Property does not exist: {propertyKey}. This property should be set by the plugin in SonarQube.";
+
+                if (propertyKey.StartsWith(string.Format(SONARANALYZER_PARTIAL_REPO_KEY, "vbnet")))
+                {
+                    message += " Possible cause: this Scanner is not compatible with SonarVB 2.X. If necessary, upgrade SonarVB latest in SonarQube.";
+                }
+
+                throw new InvalidOperationException(message);
+            }
+
+            return propertyValue;
+        }
+    }
+}

--- a/src/Core/CSharpVB/Serializer.cs
+++ b/src/Core/CSharpVB/Serializer.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    /// <summary>
+    /// Helper class to serialize objects to and from XML
+    /// </summary>
+    internal static class Serializer
+    {
+        /// <summary>
+        /// Return the object as an XML string
+        /// </summary>
+        public static string ToString<T>(T model) where T : class
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            {
+                Write(model, writer);
+                var data = stream.ToArray();
+                return Encoding.UTF8.GetString(data);
+            }
+        }
+
+        private static void Write<T>(T model, TextWriter writer) where T : class
+        {
+            var serializer = new XmlSerializer(typeof(T));
+
+            var settings = new XmlWriterSettings
+            {
+                CloseOutput = true,
+                ConformanceLevel = ConformanceLevel.Document,
+                Indent = true,
+                NamespaceHandling = NamespaceHandling.OmitDuplicates,
+                OmitXmlDeclaration = false,
+                Encoding = Encoding.UTF8
+            };
+
+            using (var xmlWriter = XmlWriter.Create(writer, settings))
+            {
+                serializer.Serialize(xmlWriter, model);
+                xmlWriter.Flush();
+            }
+        }
+    }
+}

--- a/src/Core/CSharpVB/SonarLintConfigGenerator.cs
+++ b/src/Core/CSharpVB/SonarLintConfigGenerator.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SonarQube.Client.Models;
+
+// Logically equivalent to the SonarScanner for MSBuild class "RoslynSonarLint"
+// See https://github.com/SonarSource/sonar-scanner-msbuild/blob/9ccfdb648a0411014b29c7aee8e347aeab87ea71/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynSonarLint.cs#L29
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    internal static class SonarLintConfigGenerator
+    {
+        private const string CSharpRepoKey = "csharpsquid";
+        private const string VBRepoKey = "vbnet";
+
+        public static SonarLintConfiguration Generate(IEnumerable<SonarQubeRule> rules, IDictionary<string, string> sonarProperties,
+            string language)
+        {
+            if (rules == null) { throw new ArgumentNullException(nameof(rules)); }
+            if (sonarProperties == null) { throw new ArgumentNullException(nameof(sonarProperties)); }
+            if (language == null) { throw new ArgumentNullException(nameof(language)); }
+
+            var slvsSettings = GetSettingsForLanguage(language, sonarProperties);
+
+            // We don't expect third-party rules to look for their settings in SonarLint.xml so we
+            // only fetch parameters for SonarC#/VB rules.
+            var sonarRepoKey = GetSonarRepoKey(language);
+            var slvsRules = GetRulesForRepo(sonarRepoKey, rules);
+
+            return new SonarLintConfiguration()
+            {
+                Settings = slvsSettings,
+                Rules = slvsRules
+            };
+        }
+
+        private static string GetSonarRepoKey(string language)
+        {
+            if (language == SonarQubeLanguage.CSharp.Key)
+            {
+                return CSharpRepoKey;
+            }
+
+            if (language == SonarQubeLanguage.VbNet.Key)
+            {
+                return VBRepoKey;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(language));
+        }
+
+        private static List<SonarLintKeyValuePair> GetSettingsForLanguage(string language, IDictionary<string, string> sonarProperties) =>
+            sonarProperties.Where(kvp => IsSettingForLanguage(language, kvp.Key))
+                .Select(ToSonarLintKeyValue)
+                .ToList();
+
+        private static bool IsSettingForLanguage (string language, string propertyKey)
+        {
+            var prefix = $"sonar.{language}.";
+
+            return propertyKey.StartsWith(prefix) &&
+                propertyKey.Length > prefix.Length;
+        }
+
+        private static List<SonarLintRule> GetRulesForRepo(string sonarRepoKey, IEnumerable<SonarQubeRule> sqRules) =>
+            sqRules.Where(ar => sonarRepoKey.Equals(ar.RepositoryKey))
+                .Select(ToSonarLintRule)
+                .ToList();
+
+        private static SonarLintRule ToSonarLintRule(SonarQubeRule sqRule)
+        {
+            List<SonarLintKeyValuePair> slvsParameters = null;
+            if (sqRule.Parameters != null && sqRule.Parameters.Count > 0 )
+            {
+                slvsParameters = sqRule.Parameters.Select(ToSonarLintKeyValue).ToList();
+            }
+
+            return new SonarLintRule()
+            {
+                Key = sqRule.Key,
+                Parameters = slvsParameters
+            };
+        }
+
+        private static SonarLintKeyValuePair ToSonarLintKeyValue(KeyValuePair<string, string> setting) =>
+            new SonarLintKeyValuePair() { Key = setting.Key, Value = setting.Value };
+    }
+}

--- a/src/Core/CSharpVB/SonarLintConfiguration.cs
+++ b/src/Core/CSharpVB/SonarLintConfiguration.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    /* XML-serializable classes to create a SonarLint.xml file.
+        Example:
+
+<?xml version=""1.0"" encoding=""UTF-8""?>
+<AnalysisInput>
+
+  <Settings>
+    <Setting>
+      <Key>sonar.cs.prop1</Key>
+      <Value>value 1</Value>
+    </Setting>
+    <!-- more settings ... -->
+  </Settings>
+
+  <Rules>
+    <Rule>
+      <Key>s111</Key>
+    </Rule>
+
+    <Rule>
+      <Key>s222</Key>
+      <Parameters>
+        <Parameter>
+          <Key>param1</Key>
+          <Value>param value1</Value>
+        </Parameter>
+        <!-- more parameters ... -->
+      </Parameters>
+    </Rule>
+  </Rules>
+</AnalysisInput>
+
+         */
+
+    [XmlType(TypeName = "AnalysisInput")]
+    public class SonarLintConfiguration
+    {
+        [XmlArrayItem(ElementName = "Setting")]
+        public List<SonarLintKeyValuePair> Settings { get; set; } = new List<SonarLintKeyValuePair>();
+
+        [ XmlArrayItem(ElementName = "Rule")]
+        public List<SonarLintRule> Rules { get; set; } = new List<SonarLintRule>();
+    }
+
+    public class SonarLintRule
+    {
+        [XmlElement]
+        public string Key { get; set; }
+
+        [XmlArrayItem(ElementName = "Parameter")]
+        public List<SonarLintKeyValuePair> Parameters { get; set; } = new List<SonarLintKeyValuePair>();
+    }
+
+    // The SonarLint.xml file has Settings elements and 
+    public class SonarLintKeyValuePair
+    {
+        [XmlElement]
+        public string Key { get; set; }
+
+        [XmlElement]
+        public string Value { get; set; }
+    }
+}


### PR DESCRIPTION
Relates to #1129 

Moved previously reviewed classes from the web client branch.
* no code changes
* changed copyright notices
* added classes to `Core` in the namespace `SonarLint.VisualStudio.Core.CSharpVB`.

Core already has a namespace called `SonarLint.VisualStudio.Core.CFamily`, so I went with `SonarLint.VisualStudio.Core.CSharpVB` for the sub-folder containing the  C#/VB-specific classes.
I'm trying to find an alternative to using `Roslyn` for code that doesn't actually use/reference any of the Roslyn assemblies. `DotNet` is an alternative, but it isn't strictly accurate either so I though I'd try `CSharpVB` to see how it feels.
 