### PR TITLE
Removed INuGetBindingOperation dependency on RoslynExportProfile

### DIFF
--- a/src/Core.UnitTests/CSharpVB/NuGetPackageInfoTests.cs
+++ b/src/Core.UnitTests/CSharpVB/NuGetPackageInfoTests.cs
@@ -19,30 +19,32 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using EnvDTE;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.VisualStudio.Core.CSharpVB;
-using Language = SonarLint.VisualStudio.Core.Language;
 
-namespace SonarLint.VisualStudio.Integration.Binding
+namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
 {
-    /// <summary>
-    /// Encapsulate the workflow steps to install NuGet packages during binding
-    /// </summary>
-    internal interface INuGetBindingOperation
+    [TestClass]
+    public class NuGetPackageInfoTests
     {
-        void PrepareOnUIThread();
+        [TestMethod]
+        public void Ctor_InvalidArguments_Throws()
+        {
+            Action act = () => new NuGetPackageInfo(null, "123");
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("id");
 
-        /// <summary>
-        /// Returns true if the operation completed succcessfully, otherwise false
-        /// </summary>
-        bool InstallPackages(ISet<Project> projectsToBind, IProgress<FixedStepsProgress> progress, CancellationToken token);
+            act = () => new NuGetPackageInfo("my.package", null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("version");
+        }
 
-        /// <summary>
-        /// Extracts any required information from the supplied Roslyn export profile
-        /// </summary>
-        /// <returns>True if processing was successful, otherwise false</returns>
-        bool ProcessExport(Language language, IEnumerable<NuGetPackageInfo> nugetPackages);
+        [TestMethod]
+        public void Ctor_ValidArguments_PropertiesSet()
+        {
+            var testSubject = new NuGetPackageInfo("my id", "my version");
+
+            testSubject.Id.Should().Be("my id");
+            testSubject.Version.Should().Be("my version");
+        }
     }
 }

--- a/src/Core/CSharpVB/NuGetPackageInfo.cs
+++ b/src/Core/CSharpVB/NuGetPackageInfo.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+
+namespace SonarLint.VisualStudio.Core.CSharpVB
+{
+    public class NuGetPackageInfo
+    {
+        public NuGetPackageInfo(string id, string version)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+        }
+
+        public string Id { get; }
+        public string Version { get; }
+    }
+}

--- a/src/Core/CSharpVB/NuGetPackageInfoGenerator.cs
+++ b/src/Core/CSharpVB/NuGetPackageInfoGenerator.cs
@@ -20,18 +20,17 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using SonarQube.Client.Messages;
 using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Core.CSharpVB
 {
     public static class NuGetPackageInfoGenerator
     {
-        public static IEnumerable<NuGetPackageInfoResponse> GetNuGetPackageInfos(IEnumerable<SonarQubeRule> activeRules,
+        public static IEnumerable<NuGetPackageInfo> GetNuGetPackageInfos(IEnumerable<SonarQubeRule> activeRules,
             IDictionary<string, string> sonarProperties)
         {
             var propertyPrefixes = GetPluginPropertyPrefixes(activeRules);
-            var packages = new List<NuGetPackageInfoResponse>();
+            var packages = new List<NuGetPackageInfo>();
 
             foreach (var partialRepoKey in propertyPrefixes)
             {
@@ -41,7 +40,7 @@ namespace SonarLint.VisualStudio.Core.CSharpVB
                     continue;
                 }
 
-                packages.Add(new NuGetPackageInfoResponse { Id = analyzerId, Version = pluginVersion });
+                packages.Add(new NuGetPackageInfo(analyzerId, pluginVersion));
             }
 
             return packages;

--- a/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
@@ -27,9 +27,9 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet;
 using NuGet.VisualStudio;
+using SonarLint.VisualStudio.Core.CSharpVB;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Resources;
-using SonarQube.Client.Messages;
 using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
@@ -256,18 +256,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private ConfigurablePackageInstaller PrepareInstallPackagesTest(NuGetBindingOperation testSubject, Dictionary<Language, IEnumerable<PackageName>> nugetPackagesByLanguage)
         {
-            var exportResponse = new RoslynExportProfileResponse
-            {
-                Deployment = new DeploymentResponse
-                {
-                    NuGetPackages = new List<NuGetPackageInfoResponse>()
-                }
-            };
-
             foreach (var nugetPackagesForLanguage in nugetPackagesByLanguage)
             {
                 testSubject.NuGetPackages.Add(nugetPackagesForLanguage.Key,
-                    nugetPackagesForLanguage.Value.Select(x => new NuGetPackageInfoResponse { Id = x.Id, Version = x.Version.ToNormalizedString() }).ToList());
+                    nugetPackagesForLanguage.Value.Select(x => new NuGetPackageInfo(x.Id, x.Version.ToNormalizedString())).ToList());
             }
 
 

--- a/src/Integration.UnitTests/NewConnectedMode/NoOpNuGetBindingOperationTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/NoOpNuGetBindingOperationTests.cs
@@ -21,6 +21,7 @@
 using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.CSharpVB;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using Language = SonarLint.VisualStudio.Core.Language;
 
@@ -45,7 +46,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Act & Assert
             testSubject.ProcessExport(null, null).Should().BeTrue();
-            testSubject.ProcessExport(Language.CSharp, new SonarQube.Client.Messages.RoslynExportProfileResponse()).Should().BeTrue();
+            testSubject.ProcessExport(Language.CSharp, Array.Empty<NuGetPackageInfo>()).Should().BeTrue();
         }
     }
 }

--- a/src/Integration/Binding/DotNetBindingConfigProvider.cs
+++ b/src/Integration/Binding/DotNetBindingConfigProvider.cs
@@ -96,8 +96,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 return null;
             }
 
+            // duncanp - WIP - next line will be removed when the RoslynProfileExporter is removed
+            var nugetPackages = roslynProfileExporter.Deployment.NuGetPackages.Select(x => new Core.CSharpVB.NuGetPackageInfo(x.Id, x.Version));
+
             // Add the NuGet reference, if appropriate (only in legacy connected mode, and only C#/VB)
-            if (!this.nuGetBindingOperation.ProcessExport(language, roslynProfileExporter))
+            if (!this.nuGetBindingOperation.ProcessExport(language, nugetPackages))
             {
                 return null;
             }

--- a/src/Integration/NewConnectedMode/NoOpNuGetBindingOperation.cs
+++ b/src/Integration/NewConnectedMode/NoOpNuGetBindingOperation.cs
@@ -22,9 +22,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using EnvDTE;
+using SonarLint.VisualStudio.Core.CSharpVB;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Resources;
-using SonarQube.Client.Messages;
 using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.NewConnectedMode
@@ -64,7 +64,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             return true;
         }
 
-        public bool ProcessExport(Language language, RoslynExportProfileResponse exportProfileResponse)
+        public bool ProcessExport(Language language, IEnumerable<NuGetPackageInfo> nugetPackages)
         {
             // Nothing to do - just return success
             return true;


### PR DESCRIPTION
A small refactoring to remove one of the dependencies on the data class returned by the call to the soon-to-be-obsolete `GetRoslynExportProfileAsync` method.

I've changed the data types used in the interface from `RoslynProfileExportResponse` to `IEnumerable<NuGetPackageInfo>` and fixed up the tests.

There's a one-line temporary hack in the binding code to translate from the old to the new data type.