### PR TITLE
Updated NuGet info generator to exclude taint-analysis packages

### DIFF
--- a/src/Core.UnitTests/CSharpVB/NuGetPackageInfoGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/NuGetPackageInfoGeneratorTests.cs
@@ -109,6 +109,30 @@ namespace SonarQube.Client.Tests.RoslynExporterAdapter
         }
 
         [TestMethod]
+        [DataRow("cs")]
+        [DataRow("vbnet")]
+        public void Get_SonarSecurityAnalyzer_WithPropertiesAndMatchingRules_SecurityPackageAreNotReturned(string language)
+        {
+            string propertyPrefix = $"sonaranalyzer.security.{language}";
+            string repoKey = $"roslyn.{propertyPrefix}";
+
+            var properties = new Dictionary<string, string>
+            {
+                { $"{propertyPrefix}.analyzerId", "AAA" },
+                { $"{propertyPrefix}.pluginVersion", "1.2" }
+            };
+
+            var rules = new SonarQubeRule[]
+            {
+                CreateRule($"{repoKey}", "rule1")
+            };
+
+            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, properties);
+
+            actual.Should().BeEmpty();
+        }
+
+        [TestMethod]
         public void Get_MultiplePlugins_WithPropertiesAndMatchingRules_ExpectedPackageReturned()
         {
             var properties = new Dictionary<string, string>

--- a/src/Core.UnitTests/CSharpVB/NuGetPackageInfoGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/NuGetPackageInfoGeneratorTests.cs
@@ -76,7 +76,7 @@ namespace SonarQube.Client.Tests.RoslynExporterAdapter
         }
 
         [TestMethod]
-        public void Get_MissingPluginVerionProperty_NoPackageInfo()
+        public void Get_MissingPluginVersionProperty_NoPackageInfo()
         {
             var properties = new Dictionary<string, string> { { "sonaranalyzer-cs.pluginVersion", "1.2.3" } };
 
@@ -86,44 +86,25 @@ namespace SonarQube.Client.Tests.RoslynExporterAdapter
         }
 
         [TestMethod]
-        public void Get_CSharp_WithPropertiesAndMatchingRules_ExpectedPackageReturned()
+        [DataRow("cs", "csharpsquid")]
+        [DataRow("vbnet", "vbnet")]
+        public void Get_SonarAnalyzer_WithPropertiesAndMatchingRules_ExpectedPackageReturned(string language, string repositoryKey)
         {
             var properties = new Dictionary<string, string>
             {
-                { "sonaranalyzer-cs.analyzerId", "my.analyzer" },
-                { "sonaranalyzer-cs.pluginVersion", "3.2.1" }
+                { $"sonaranalyzer-{language}.analyzerId", "AAA" },
+                { $"sonaranalyzer-{language}.pluginVersion", "1.2" }
             };
 
             var rules = new SonarQubeRule[]
             {
-                CreateRule("csharpsquid", "rule2")
+                CreateRule(repositoryKey, "rule1")
             };
 
             var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, properties);
 
             actual.Count().Should().Be(1);
-            actual.First().Id.Should().Be("my.analyzer");
-            actual.First().Version.Should().Be("3.2.1");
-        }
-
-        [TestMethod]
-        public void Get_VBNet_WithPropertiesAndMatchingRules_ExpectedPackageReturned()
-        {
-            var properties = new Dictionary<string, string>
-            {
-                { "sonaranalyzer-vbnet.analyzerId", "sonarVB" },
-                { "sonaranalyzer-vbnet.pluginVersion", "1.2" }
-            };
-
-            var rules = new SonarQubeRule[]
-            {
-                CreateRule("vbnet", "rule1")
-            };
-
-            var actual = NuGetPackageInfoGenerator.GetNuGetPackageInfos(rules, properties);
-
-            actual.Count().Should().Be(1);
-            actual.First().Id.Should().Be("sonarVB");
+            actual.First().Id.Should().Be("AAA");
             actual.First().Version.Should().Be("1.2");
         }
 
@@ -175,7 +156,6 @@ namespace SonarQube.Client.Tests.RoslynExporterAdapter
             packages[2].Id.Should().Be("analyzer.myanalyzer1");
             packages[2].Version.Should().Be("version.myanalyzer1");
         }
-
 
         private static SonarQubeRule CreateRule(string repoKey, string ruleKey) =>
             new SonarQubeRule(ruleKey, repoKey, true, SonarQubeIssueSeverity.Critical, null);

--- a/src/Core.UnitTests/CSharpVB/RoslynPluginRuleKeyExtensionsTests.cs
+++ b/src/Core.UnitTests/CSharpVB/RoslynPluginRuleKeyExtensionsTests.cs
@@ -42,5 +42,18 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
 
             rule.TryGetRoslynPluginPropertyPrefix().Should().Be(expectedPrefix);
         }
+
+        [TestMethod]
+        [DataRow("roslyn.sonaranalyzer.security.cs", true)]
+        [DataRow("roslyn.sonaranalyzer.security.vb", true)]
+        [DataRow("sonaranalyzer.security", true)]
+        [DataRow("SONARANALYZER.SECURITY", true)]
+        [DataRow("roslyn.wintellect", false)]
+        [DataRow("sonaranalyzer-cs", false)]
+        [DataRow("sonaranalyzer-vbnet", false)]
+        public void IsExcludedRuleRepository(string partialRepoKey, bool expected)
+        {
+            RoslynPluginRuleKeyExtensions.IsExcludedRuleRepository(partialRepoKey).Should().Be(expected);
+        }
     }
 }

--- a/src/Core/CSharpVB/NuGetPackageInfoGenerator.cs
+++ b/src/Core/CSharpVB/NuGetPackageInfoGenerator.cs
@@ -49,7 +49,7 @@ namespace SonarLint.VisualStudio.Core.CSharpVB
         private static IEnumerable<string> GetPluginPropertyPrefixes(IEnumerable<SonarQubeRule> rules) =>
             rules.Select(r => r.TryGetRoslynPluginPropertyPrefix())
                 .Distinct()
-                .Where(r => !string.IsNullOrEmpty(r))
+                .Where(r => !string.IsNullOrEmpty(r) && !RoslynPluginRuleKeyExtensions.IsExcludedRuleRepository(r))
                 .ToArray();
     }
 }

--- a/src/Core/CSharpVB/RoslynPluginRuleKeyExtensions.cs
+++ b/src/Core/CSharpVB/RoslynPluginRuleKeyExtensions.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Core.CSharpVB
@@ -59,5 +60,8 @@ namespace SonarLint.VisualStudio.Core.CSharpVB
 
             return null; // not a Roslyn-based rule
         }
+
+        public static bool IsExcludedRuleRepository(string partialRepoKey) =>
+            partialRepoKey.IndexOf("sonaranalyzer.security", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/src/Core/CSharpVB/RuleSetGenerator.cs
+++ b/src/Core/CSharpVB/RuleSetGenerator.cs
@@ -94,11 +94,8 @@ namespace SonarLint.VisualStudio.Core.CSharpVB
         private static bool IsSupportedRuleRepo(IGrouping<string, SonarQubeRule> analyzerRules)
         {
             var partialRepoKey = analyzerRules.Key;
-            return !string.IsNullOrEmpty(partialRepoKey) && !IsExcludedRuleRepo(partialRepoKey);
+            return !string.IsNullOrEmpty(partialRepoKey) && !RoslynPluginRuleKeyExtensions.IsExcludedRuleRepository(partialRepoKey);
         }
-
-        private static bool IsExcludedRuleRepo(string partialRepoKey) =>
-            partialRepoKey.IndexOf("sonaranalyzer.security", StringComparison.OrdinalIgnoreCase) >= 0;
 
         private Rules CreateRulesElement(IGrouping<string, SonarQubeRule> analyzerRules)
         {


### PR DESCRIPTION
There are two small commits. It might be easier to look at them separate in the GitHub web UI.
The first just changes an existing test to be data-driven.
The second fixes the bug in the NuGet generator.