### PR TITLE
Extract solution file path generation to another class

### DIFF
--- a/src/Core.UnitTests/Binding/SolutionBindingFilePathGeneratorTests.cs
+++ b/src/Core.UnitTests/Binding/SolutionBindingFilePathGeneratorTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.Binding;
+
+namespace SonarLint.VisualStudio.Core.UnitTests.Binding
+{
+    [TestClass]
+    public class SolutionBindingFilePathGeneratorTests
+    {
+        [DataTestMethod]
+        [DataRow("", "", "", "")]
+        [DataRow("c:\\", "", "", "c:\\")]
+        [DataRow("", "key", "", "key")]
+        [DataRow("", "", "test.txt", "test.txt")]
+        [DataRow("c:\\", "MY_KEY", "NAME.txt", "c:\\my_keyname.txt")]
+        [DataRow("c:\\", "My<Key>", "N|a<m>e.txt", "c:\\my_key_n_a_m_e.txt")]
+        public void Generate_GeneratesCorrectFilePath(string rootDirectory, string projectKey, string fileNameSuffixAndExtension, string expectedPath)
+        {
+            var testSubject = new SolutionBindingFilePathGenerator();
+            var result = testSubject.Generate(rootDirectory, projectKey, fileNameSuffixAndExtension);
+
+            result.Should().Be(expectedPath);
+        }
+    }
+}

--- a/src/Core/Binding/ISolutionBindingFilePathGenerator.cs
+++ b/src/Core/Binding/ISolutionBindingFilePathGenerator.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Core.Binding
+{
+    public interface ISolutionBindingFilePathGenerator
+    {
+        string Generate(string rootDirectoryPath, string projectKey, string fileNameSuffixAndExtension);
+    }
+}

--- a/src/Core/Binding/ISolutionBindingFilePathGenerator.cs
+++ b/src/Core/Binding/ISolutionBindingFilePathGenerator.cs
@@ -22,6 +22,12 @@ namespace SonarLint.VisualStudio.Core.Binding
 {
     public interface ISolutionBindingFilePathGenerator
     {
+        /// <summary>
+        /// Generate a solution level file-path based on <paramref name="projectKey"/> and <see cref="fileNameSuffixAndExtension"/>
+        /// </summary>
+        /// <param name="rootDirectoryPath">Root directory to generate the full file path under</param>
+        /// <param name="projectKey">SonarQube project key to generate a file name path for</param>
+        /// <param name="fileNameSuffixAndExtension">Fixed file name suffix and extension (language-specific)</param>
         string Generate(string rootDirectoryPath, string projectKey, string fileNameSuffixAndExtension);
     }
 }

--- a/src/Core/Binding/SolutionBindingFilePathGenerator.cs
+++ b/src/Core/Binding/SolutionBindingFilePathGenerator.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using SonarLint.VisualStudio.Core.Helpers;
+
+namespace SonarLint.VisualStudio.Core.Binding
+{
+    public class SolutionBindingFilePathGenerator : ISolutionBindingFilePathGenerator
+    {
+        /// <summary>
+        /// Generate a solution level file-path based on <paramref name="projectKey"/> and <see cref="fileNameSuffixAndExtension"/>
+        /// </summary>
+        /// <param name="rootDirectoryPath">Root directory to generate the full file path under</param>
+        /// <param name="projectKey">SonarQube project key to generate a file name path for</param>
+        /// <param name="fileNameSuffixAndExtension">Fixed file name suffix and extension (language-specific)</param>
+        public string Generate(string rootDirectoryPath, string projectKey, string fileNameSuffixAndExtension)
+        {
+            // Cannot use Path.ChangeExtension here because if the sonar project name contains
+            // a dot (.) then everything after this will be replaced with .ruleset
+            var fileName = PathHelper.EscapeFileName(projectKey + fileNameSuffixAndExtension)
+                .ToLowerInvariant(); // Must be lower case - see https://github.com/SonarSource/sonarlint-visualstudio/issues/1068
+
+            return Path.Combine(rootDirectoryPath, fileName);
+        }
+    }
+}

--- a/src/Core/Binding/SolutionBindingFilePathGenerator.cs
+++ b/src/Core/Binding/SolutionBindingFilePathGenerator.cs
@@ -25,12 +25,6 @@ namespace SonarLint.VisualStudio.Core.Binding
 {
     public class SolutionBindingFilePathGenerator : ISolutionBindingFilePathGenerator
     {
-        /// <summary>
-        /// Generate a solution level file-path based on <paramref name="projectKey"/> and <see cref="fileNameSuffixAndExtension"/>
-        /// </summary>
-        /// <param name="rootDirectoryPath">Root directory to generate the full file path under</param>
-        /// <param name="projectKey">SonarQube project key to generate a file name path for</param>
-        /// <param name="fileNameSuffixAndExtension">Fixed file name suffix and extension (language-specific)</param>
         public string Generate(string rootDirectoryPath, string projectKey, string fileNameSuffixAndExtension)
         {
             // Cannot use Path.ChangeExtension here because if the sonar project name contains

--- a/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
@@ -27,6 +27,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Integration.Binding;
 using Language = SonarLint.VisualStudio.Core.Language;
 
@@ -65,7 +66,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.serviceProvider.RegisterService(typeof(ISourceControlledFileSystem), this.sccFileSystem);
             this.serviceProvider.RegisterService(typeof(IRuleSetSerializer), this.ruleSetFS);
             this.serviceProvider.RegisterService(typeof(ISolutionRuleSetsInformationProvider),
-                new SolutionRuleSetsInformationProvider(this.serviceProvider, new Mock<ILogger>().Object,  new MockFileSystem()));
+                new SolutionRuleSetsInformationProvider(this.serviceProvider, new Mock<ILogger>().Object,  new MockFileSystem(), new SolutionBindingFilePathGenerator()));
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystemHelper);
         }
 

--- a/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
@@ -62,7 +62,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.serviceProvider.RegisterService(typeof(SVsOutputWindow), outputWindow);
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), projectSystemHelper);
 
-            this.testSubject = new SolutionRuleSetsInformationProvider(this.serviceProvider, new SonarLintOutputLogger(serviceProvider), fileSystem);
+            this.testSubject = new SolutionRuleSetsInformationProvider(serviceProvider, new SonarLintOutputLogger(serviceProvider), fileSystem, new SolutionBindingFilePathGenerator());
         }
 
         #region Tests
@@ -70,15 +70,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         [TestMethod]
         public void SolutionRuleSetsInformationProvider_Ctor_ArgChecks()
         {
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(null, new Mock<ILogger>().Object, new MockFileSystem()));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(null, new Mock<ILogger>().Object, new MockFileSystem(), Mock.Of<ISolutionBindingFilePathGenerator>()));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), null, new MockFileSystem(), Mock.Of<ISolutionBindingFilePathGenerator>()));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), new Mock<ILogger>().Object, null, Mock.Of<ISolutionBindingFilePathGenerator>()));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), new Mock<ILogger>().Object, new MockFileSystem(), Mock.Of<ISolutionBindingFilePathGenerator>()));
         }
 
         [TestMethod]
         public void SolutionRuleSetsInformationProvider_GetProjectRuleSetsDeclarations_ArgChecks()
         {
-            // Arrange
-            var testSubject = new SolutionRuleSetsInformationProvider(this.serviceProvider, new Mock<ILogger>().Object, new MockFileSystem());
-
             // Act + Assert
             Exceptions.Expect<ArgumentNullException>(() => testSubject.GetProjectRuleSetsDeclarations(null).ToArray());
         }

--- a/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
@@ -73,7 +73,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(null, new Mock<ILogger>().Object, new MockFileSystem(), Mock.Of<ISolutionBindingFilePathGenerator>()));
             Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), null, new MockFileSystem(), Mock.Of<ISolutionBindingFilePathGenerator>()));
             Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), new Mock<ILogger>().Object, null, Mock.Of<ISolutionBindingFilePathGenerator>()));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), new Mock<ILogger>().Object, new MockFileSystem(), Mock.Of<ISolutionBindingFilePathGenerator>()));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionRuleSetsInformationProvider(Mock.Of<IServiceProvider>(), new Mock<ILogger>().Object, new MockFileSystem(), null));
         }
 
         [TestMethod]


### PR DESCRIPTION
ISolutionBindingFilePathGenerator contains the logic from SolutionRuleSetsInformationProvider.GenerateSolutionRuleSetPath. Extracted as-is and added a few tests.

Please note the base: let me know if I should merge this to my base branch instead.