### PR TITLE
Added IEnvironmentSettings to abstract access to environment variables

### DIFF
--- a/src/Core.UnitTests/CSharpVB/RuleSetGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/RuleSetGeneratorTests.cs
@@ -90,7 +90,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var activeRules = new List<SonarQubeRule>
             {
                 CreateSonarCSharpRule("rule1", isActive: true, sqSeverity: SonarQubeIssueSeverity.Info),
@@ -110,7 +110,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-          
+
             var inactiveRules = new List<SonarQubeRule>
             {
                 CreateSonarCSharpRule("rule1", isActive: false, sqSeverity: SonarQubeIssueSeverity.Major),
@@ -190,7 +190,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var rules = new[]
             {
                 CreateRule("csharpsquid", "active1", true, SonarQubeIssueSeverity.Major),
@@ -228,7 +228,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var properties = new Dictionary<string, string>
             {
                 [$"sonaranalyzer.security.{language}.analyzerId"] = "SonarAnalyzer.Security",
@@ -253,7 +253,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var properties = new Dictionary<string, string>
             {
                 // The rules should be grouped by the analyzer id
@@ -274,7 +274,6 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
                 CreateRule("roslyn.wintellect", "win2", true),
                 CreateRule("roslyn.wintellect", "win1", true),
                 CreateRule("roslyn.wintellect", "win0", false),
-
 
                 CreateRule("csharpsquid", "S999", true),
                 CreateRule("csharpsquid", "S111", false),
@@ -322,7 +321,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var properties = new Dictionary<string, string>
             {
                 { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
@@ -340,7 +339,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var properties = new Dictionary<string, string>
             {
                 { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
@@ -358,7 +357,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         {
             // Arrange
             var generator = new RuleSetGenerator();
-            
+
             var properties = new Dictionary<string, string>
             {
                 { "sonaranalyzer-cs.ANALYZERId", "SonarAnalyzer.CSharp" },
@@ -397,7 +396,9 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         [DataRow(SonarQubeIssueSeverity.Critical, RuleAction.Warning)]
         public void GetVSSeverity_NotBlocker_CorrectlyMapped(SonarQubeIssueSeverity sqSeverity, RuleAction expectedVsSeverity)
         {
-            new RuleSetGenerator().GetVsSeverity(sqSeverity).Should().Be(expectedVsSeverity);
+            var testSubject = new RuleSetGenerator();
+
+            testSubject.GetVsSeverity(sqSeverity).Should().Be(expectedVsSeverity);
         }
 
         [TestMethod]
@@ -408,7 +409,9 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
             var envSettingsMock = new Mock<IEnvironmentSettings>();
             envSettingsMock.Setup(x => x.TreatBlockerSeverityAsError()).Returns(shouldTreatBlockerAsError);
 
-            new RuleSetGenerator().GetVsSeverity(SonarQubeIssueSeverity.Blocker).Should().Be(expectedVsSeverity);
+            var testSubject = new RuleSetGenerator(envSettingsMock.Object);
+
+            testSubject.GetVsSeverity(SonarQubeIssueSeverity.Blocker).Should().Be(expectedVsSeverity);
         }
 
         [TestMethod]

--- a/src/Core.UnitTests/EnvironmentSettingsTests.cs
+++ b/src/Core.UnitTests/EnvironmentSettingsTests.cs
@@ -31,12 +31,12 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         [DataRow(null, false)]
         [DataRow("true", true)]
         [DataRow("TRUE", true)]
-        [DataRow("false", true)]
-        [DataRow("FALSE", true)]
-        [DataRow("1", true)]
-        [DataRow("0", true)]
+        [DataRow("false", false)]
+        [DataRow("FALSE", false)]
+        [DataRow("1", false)]
+        [DataRow("0", false)]
         [DataRow("not a boolean", false)]
-        public void GetVSSeverity_Blocker_CorrectlyMapped(string envVarValue, bool expected)
+        public void TreatBlockerSeverityAsError_CorrectlyMapped(string envVarValue, bool expected)
         {
             using (var scope = new EnvironmentVariableScope())
             {

--- a/src/Core.UnitTests/EnvironmentSettingsTests.cs
+++ b/src/Core.UnitTests/EnvironmentSettingsTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.UnitTests;
+
+namespace SonarLint.VisualStudio.Core.UnitTests
+{
+    [TestClass]
+    public class EnvironmentSettingsTests
+    {
+        [TestMethod]
+        [DataRow(null, false)]
+        [DataRow("true", true)]
+        [DataRow("TRUE", true)]
+        [DataRow("false", true)]
+        [DataRow("FALSE", true)]
+        [DataRow("1", true)]
+        [DataRow("0", true)]
+        [DataRow("not a boolean", false)]
+        public void GetVSSeverity_Blocker_CorrectlyMapped(string envVarValue, bool expected)
+        {
+            using (var scope = new EnvironmentVariableScope())
+            {
+                scope.SetVariable(EnvironmentSettings.TreatBlockerAsErrorEnvVar, envVarValue);
+                new EnvironmentSettings().TreatBlockerSeverityAsError().Should().Be(expected);
+            }
+        }
+    }
+}

--- a/src/Core/EnvironmentSettings.cs
+++ b/src/Core/EnvironmentSettings.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+
+namespace SonarLint.VisualStudio.Core
+{
+    public class EnvironmentSettings : IEnvironmentSettings
+    {
+        internal const string TreatBlockerAsErrorEnvVar = "SONAR_INTERNAL_TREAT_BLOCKER_AS_ERROR";
+
+        public  bool TreatBlockerSeverityAsError()
+        {
+            if (bool.TryParse(Environment.GetEnvironmentVariable(TreatBlockerAsErrorEnvVar), out var result))
+            {
+                return result;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Core/IEnvironmentSettings.cs
+++ b/src/Core/IEnvironmentSettings.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Core
+{
+    /// <summary>
+    /// Optional additional settings used to modify the behaviour of specific features
+    /// </summary>
+    public interface IEnvironmentSettings
+    {
+        bool TreatBlockerSeverityAsError();
+    }
+}


### PR DESCRIPTION
Adding the interface improves testability and makes the 'TreatBlockerSeverityAsError` check re-usable (it will also need to be called by the CFamily code).