### PR TITLE
Fix bug of first time binding

### DIFF
--- a/src/Core.UnitTests/Binding/CompositeBindingConfigProviderTests.cs
+++ b/src/Core.UnitTests/Binding/CompositeBindingConfigProviderTests.cs
@@ -97,7 +97,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.Binding
             var testSubject = new CompositeBindingConfigProvider(otherProvider, cppProvider1, cppProvider2);
 
             // Act. Multiple matching providers -> config from the first matching provider returned
-            var actualConfig = await testSubject.GetConfigurationAsync(qp, Language.Cpp, CancellationToken.None);
+            var actualConfig = await testSubject.GetConfigurationAsync(qp, Language.Cpp, BindingConfiguration.Standalone, CancellationToken.None);
             actualConfig.Should().Be(cppProvider1.ConfigToReturn);
         }
 
@@ -111,7 +111,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.Binding
             var testSubject = new CompositeBindingConfigProvider(otherProvider);
 
             // 1. Multiple matching providers -> config from the first matching provider returned
-            Action act = () => testSubject.GetConfigurationAsync(qp, Language.Cpp, CancellationToken.None).Wait();
+            Action act = () => testSubject.GetConfigurationAsync(qp, Language.Cpp, BindingConfiguration.Standalone, CancellationToken.None).Wait();
 
             act.Should().ThrowExactly<AggregateException>().And.InnerException.Should().BeOfType<ArgumentOutOfRangeException>();
         }
@@ -135,7 +135,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.Binding
 
             #region IBindingConfigProvider implementation
 
-            public Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, CancellationToken cancellationToken)
+            public Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, BindingConfiguration bindingConfiguration, CancellationToken cancellationToken)
             {
                 return Task.FromResult(ConfigToReturn);
             }

--- a/src/Core.UnitTests/CFamily/CFamilyBindingConfigProviderTests.cs
+++ b/src/Core.UnitTests/CFamily/CFamilyBindingConfigProviderTests.cs
@@ -41,24 +41,15 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
         [TestMethod]
         public void Ctor_NullService_ArgumentNullException()
         {
-            Action act = () => new CFamilyBindingConfigProvider(null, BindingConfiguration.Standalone, Mock.Of<ILogger>());
+            Action act = () => new CFamilyBindingConfigProvider(null, Mock.Of<ILogger>());
 
             act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("sonarQubeService");
-        }
-
-
-        [TestMethod]
-        public void Ctor_NullBindingConfiguration_ArgumentNullException()
-        {
-            Action act = () => new CFamilyBindingConfigProvider(Mock.Of<ISonarQubeService>(), null, Mock.Of<ILogger>());
-
-            act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("bindingConfiguration");
         }
 
         [TestMethod]
         public void Ctor_NullLogger_ArgumentNullException()
         {
-            Action act = () => new CFamilyBindingConfigProvider(Mock.Of<ISonarQubeService>(), BindingConfiguration.Standalone, null);
+            Action act = () => new CFamilyBindingConfigProvider(Mock.Of<ISonarQubeService>(), null);
 
             act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
         }
@@ -142,10 +133,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
 
             var bindingConfiguration = new BindingConfiguration(new BoundSonarQubeProject { ProjectKey = "test" }, SonarLintMode.Connected, "c:\\");
 
-            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, bindingConfiguration, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, CancellationToken.None);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, bindingConfiguration, CancellationToken.None);
 
             // Assert
             result.Should().NotBeNull();
@@ -189,10 +180,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
 
             var bindingConfiguration = new BindingConfiguration(new BoundSonarQubeProject {ProjectKey = "test"}, SonarLintMode.Connected, "c:\\");
 
-            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, bindingConfiguration, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, CancellationToken.None);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, bindingConfiguration, CancellationToken.None);
 
             // Assert
             result.Should().NotBeNull();
@@ -216,10 +207,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             serviceMock.Setup(x => x.GetRulesAsync(It.IsAny<bool>(), It.IsAny<string>(), CancellationToken.None))
                 .ThrowsAsync(new InvalidOperationException("invalid op"));
 
-            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, BindingConfiguration.Standalone, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, CancellationToken.None);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, BindingConfiguration.Standalone, CancellationToken.None);
 
             // Assert
             result.Should().BeNull();
@@ -242,10 +233,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
                         return new List<SonarQubeRule>();
                     }) ;
 
-            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, BindingConfiguration.Standalone, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, cts.Token);
+            var result = await testSubject.GetConfigurationAsync(CreateQp(), Language.Cpp, BindingConfiguration.Standalone, cts.Token);
 
             // Assert
             result.Should().BeNull();
@@ -261,10 +252,10 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             CancellationTokenSource cts = new CancellationTokenSource();
             var serviceMock = new Mock<ISonarQubeService>();
 
-            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, BindingConfiguration.Standalone, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // Act
-            Action act = () => testSubject.GetConfigurationAsync(CreateQp(), Language.VBNET, cts.Token).Wait();
+            Action act = () => testSubject.GetConfigurationAsync(CreateQp(), Language.VBNET, BindingConfiguration.Standalone, cts.Token).Wait();
 
             // Assert
             act.Should().ThrowExactly<AggregateException>().And.InnerException.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -276,7 +267,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CFamily
             // Arrange
             var testLogger = new TestLogger();
             var serviceMock = new Mock<ISonarQubeService>();
-            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, BindingConfiguration.Standalone, testLogger);
+            var testSubject = new CFamilyBindingConfigProvider(serviceMock.Object, testLogger);
 
             // 1. Supported languages
             testSubject.IsLanguageSupported(Language.C).Should().BeTrue();

--- a/src/Core/Binding/CompositeBindingConfigProvider.cs
+++ b/src/Core/Binding/CompositeBindingConfigProvider.cs
@@ -50,7 +50,7 @@ namespace SonarLint.VisualStudio.Core.Binding
 
         #region IBindingConfigProvider methods
 
-        public async Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, CancellationToken cancellationToken)
+        public async Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, BindingConfiguration bindingConfiguration, CancellationToken cancellationToken)
         {
             var provider = Providers.FirstOrDefault(p => p.IsLanguageSupported(language));
 
@@ -61,7 +61,7 @@ namespace SonarLint.VisualStudio.Core.Binding
             IBindingConfig config = null;
             if (provider != null)
             {
-                config = await provider?.GetConfigurationAsync(qualityProfile, language, cancellationToken);
+                config = await provider?.GetConfigurationAsync(qualityProfile, language, bindingConfiguration, cancellationToken);
             }
 
             return config;

--- a/src/Core/Binding/IBindingConfigProvider.cs
+++ b/src/Core/Binding/IBindingConfigProvider.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Core.Binding
         /// <summary>
         /// Returns a configuration file for the specified language
         /// </summary>
-        Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, CancellationToken cancellationToken);
+        Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, BindingConfiguration bindingConfiguration, CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/src/Core/CFamily/CFamilyBindingConfigProvider.cs
+++ b/src/Core/CFamily/CFamilyBindingConfigProvider.cs
@@ -33,19 +33,17 @@ namespace SonarLint.VisualStudio.Core.CFamily
     public class CFamilyBindingConfigProvider : IBindingConfigProvider
     {
         private readonly ISonarQubeService sonarQubeService;
-        private readonly BindingConfiguration bindingConfiguration;
         private readonly ILogger logger;
         private readonly ISolutionBindingFilePathGenerator solutionBindingFilePathGenerator;
 
-        public CFamilyBindingConfigProvider(ISonarQubeService sonarQubeService, BindingConfiguration bindingConfiguration, ILogger logger)
-        :this(sonarQubeService, bindingConfiguration, logger, new SolutionBindingFilePathGenerator())
+        public CFamilyBindingConfigProvider(ISonarQubeService sonarQubeService, ILogger logger)
+            : this(sonarQubeService, logger, new SolutionBindingFilePathGenerator())
         {
         }
 
-        internal CFamilyBindingConfigProvider(ISonarQubeService sonarQubeService, BindingConfiguration bindingConfiguration, ILogger logger, ISolutionBindingFilePathGenerator solutionBindingFilePathGenerator)
+        internal CFamilyBindingConfigProvider(ISonarQubeService sonarQubeService, ILogger logger, ISolutionBindingFilePathGenerator solutionBindingFilePathGenerator)
         {
             this.sonarQubeService = sonarQubeService ?? throw new ArgumentNullException(nameof(sonarQubeService));
-            this.bindingConfiguration = bindingConfiguration ?? throw new ArgumentNullException(nameof(bindingConfiguration));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.solutionBindingFilePathGenerator = solutionBindingFilePathGenerator ?? throw new ArgumentNullException(nameof(solutionBindingFilePathGenerator));
         }
@@ -57,7 +55,7 @@ namespace SonarLint.VisualStudio.Core.CFamily
             return Language.Cpp.Equals(language) || Language.C.Equals(language);
         }
 
-        public async Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, CancellationToken cancellationToken)
+        public async Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language, BindingConfiguration bindingConfiguration, CancellationToken cancellationToken)
         {
             if (!IsLanguageSupported(language))
             {

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingConfigProviderTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingConfigProviderTests.cs
@@ -85,7 +85,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = builder.CreateTestSubject();
 
             // Act
-            Action act = () => testSubject.GetConfigurationAsync(validQualityProfile, Language.Cpp, CancellationToken.None).Wait();
+            Action act = () => testSubject.GetConfigurationAsync(validQualityProfile, Language.Cpp, BindingConfiguration.Standalone, CancellationToken.None).Wait();
 
             // Assert
             act.Should().ThrowExactly<ArgumentOutOfRangeException>().And.ParamName.Should().Be("language");
@@ -122,7 +122,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = builder.CreateTestSubject();
 
             // Act
-            var result = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, builder.BindingConfiguration, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
@@ -152,7 +152,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             };
             var testSubject = builder.CreateTestSubject();
 
-            var response = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, CancellationToken.None);
+            var response = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, builder.BindingConfiguration, CancellationToken.None);
             response.FilePath.Should().Be("expected file path");
         }
 
@@ -170,7 +170,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             var testSubject = builder.CreateTestSubject();
 
-            var result = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, builder.BindingConfiguration, CancellationToken.None)
                 .ConfigureAwait(false);
 
             result.Should().BeNull();
@@ -208,7 +208,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = builder.CreateTestSubject();
 
             // Act
-            var result = await testSubject.GetConfigurationAsync(validQualityProfile, Language.CSharp, CancellationToken.None)
+            var result = await testSubject.GetConfigurationAsync(validQualityProfile, Language.CSharp, builder.BindingConfiguration, CancellationToken.None)
                 .ConfigureAwait(false);
 
             // Assert
@@ -277,6 +277,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             }
 
             public string FilePathResponse { get; set; }
+            public BindingConfiguration BindingConfiguration { get; set; }
 
             public IList<SonarQubeRule> ActiveRulesResponse { get; set; }
 
@@ -334,7 +335,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
                 var bindingRootFolder = "c:\\test\\";
 
-                var bindingConfiguration = new BindingConfiguration(new BoundSonarQubeProject(new Uri(serverUrl), projectName, projectName),
+                BindingConfiguration = new BindingConfiguration(new BoundSonarQubeProject(new Uri(serverUrl), projectName, projectName),
                     SonarLintMode.Connected, bindingRootFolder);
 
                 var solutionBindingFilePathGeneratorMock = new Mock<ISolutionBindingFilePathGenerator>();
@@ -342,8 +343,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                     .Setup(x => x.Generate(bindingRootFolder, projectName, language.FileSuffixAndExtension))
                     .Returns(FilePathResponse);
 
-                return new CSharpVBBindingConfigProvider(sonarQubeServiceMock.Object, nugetBindingMock.Object,
-                    bindingConfiguration, Logger,
+                return new CSharpVBBindingConfigProvider(sonarQubeServiceMock.Object, nugetBindingMock.Object, Logger,
                     // inject the generator mocks
                     ruleGenMock.Object,
                     nugetGenMock.Object,

--- a/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
@@ -24,15 +24,12 @@ using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Threading;
-using EnvDTE;
 using FluentAssertions;
-using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Integration.Binding;
-using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Persistence;
 using SonarQube.Client.Models;
 using Language = SonarLint.VisualStudio.Core.Language;
@@ -341,14 +338,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             var projects = new[] { csProject, vbProject };
 
-            var testSubject = CreateTestSubject(ProjectKey);
+            var testSubject = CreateTestSubject();
 
             var languageToFileMap = new Dictionary<Language, IBindingConfig>();
             languageToFileMap[Language.CSharp] = csConfigFile.Object;
             languageToFileMap[Language.VBNET] = vbConfigFile.Object;
 
             testSubject.RegisterKnownConfigFiles(languageToFileMap);
-            testSubject.Initialize(projects, GetQualityProfiles());
+            testSubject.Initialize(projects);
 
             using (CancellationTokenSource src = new CancellationTokenSource())
             {

--- a/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
@@ -62,7 +62,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         private Mock<IProjectBinderFactory> projectBinderFactoryMock;
 
         private const string SolutionRoot = @"c:\solution";
-        private const string ProjectKey = "key";
 
         [TestInitialize]
         public void TestInitialize()
@@ -97,22 +96,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         [TestMethod]
         public void SolutionBindingOperation_ArgChecks()
         {
-            var connectionInformation = new ConnectionInformation(new Uri("http://valid"));
             var logger = new TestLogger();
-            var projectBinderFactory = Mock.Of<IProjectBinderFactory>();
-            var folderModifier = Mock.Of<ILegacyConfigFolderItemAdder>();
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(null, connectionInformation, ProjectKey, "name", SonarLintMode.LegacyConnected, logger));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(this.serviceProvider, null, ProjectKey, "name", SonarLintMode.LegacyConnected, logger));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, null, "name", SonarLintMode.LegacyConnected, logger));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, string.Empty, "name", SonarLintMode.LegacyConnected, logger));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(null, SonarLintMode.LegacyConnected, logger));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(this.serviceProvider, SonarLintMode.LegacyConnected, null));
 
-            Exceptions.Expect<ArgumentOutOfRangeException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, "123", "name", SonarLintMode.Standalone, logger));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, "123", "name", SonarLintMode.LegacyConnected, null));
-            Exceptions.Expect<ArgumentOutOfRangeException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, "123", "name", SonarLintMode.Standalone, null, folderModifier, new MockFileSystem()));
-            Exceptions.Expect<ArgumentOutOfRangeException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, "123", "name", SonarLintMode.Standalone, projectBinderFactory, null, new MockFileSystem()));
-            Exceptions.Expect<ArgumentOutOfRangeException>(() => new SolutionBindingOperation(this.serviceProvider, connectionInformation, "123", "name", SonarLintMode.Standalone, projectBinderFactory, folderModifier,null));
-
-            var testSubject = new SolutionBindingOperation(this.serviceProvider, connectionInformation, ProjectKey, "name", SonarLintMode.LegacyConnected, logger);
+            var testSubject = new SolutionBindingOperation(serviceProvider, SonarLintMode.LegacyConnected, logger);
             testSubject.Should().NotBeNull("Avoid 'testSubject' not used analysis warning");
         }
 
@@ -120,7 +108,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void SolutionBindingOperation_RegisterKnownRuleSets_ArgChecks()
         {
             // Arrange
-            SolutionBindingOperation testSubject = this.CreateTestSubject(ProjectKey);
+            SolutionBindingOperation testSubject = this.CreateTestSubject();
 
             // Act + Assert
             Exceptions.Expect<ArgumentNullException>(() => testSubject.RegisterKnownConfigFiles(null));
@@ -130,7 +118,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void SolutionBindingOperation_RegisterKnownRuleSets()
         {
             // Arrange
-            SolutionBindingOperation testSubject = this.CreateTestSubject(ProjectKey);
+            SolutionBindingOperation testSubject = this.CreateTestSubject();
             var languageToFileMap = new Dictionary<Language, IBindingConfig>();
             languageToFileMap[Language.CSharp] = CreateMockConfigFile("c:\\csharp.txt").Object;
             languageToFileMap[Language.VBNET] = CreateMockConfigFile("c:\\vbnet.txt").Object;
@@ -151,7 +139,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void SolutionBindingOperation_GetRuleSetInformation()
         {
             // Arrange
-            SolutionBindingOperation testSubject = this.CreateTestSubject(ProjectKey);
+            SolutionBindingOperation testSubject = this.CreateTestSubject();
 
             // Test case 1: unknown ruleset map
             var ruleSetMap = new Dictionary<Language, IBindingConfig>();
@@ -169,7 +157,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             ruleSetMap[Language.VBNET] = CreateMockConfigFile("c:\\vb.txt").Object;
 
             testSubject.RegisterKnownConfigFiles(ruleSetMap);
-            testSubject.Initialize(new ProjectMock[0], GetQualityProfiles());
+            testSubject.Initialize(new ProjectMock[0]);
             testSubject.Prepare(CancellationToken.None);
 
             // Act
@@ -184,11 +172,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void SolutionBindingOperation_Initialization_ArgChecks()
         {
             // Arrange
-            SolutionBindingOperation testSubject = this.CreateTestSubject(ProjectKey);
+            SolutionBindingOperation testSubject = this.CreateTestSubject();
 
             // Act + Assert
-            Exceptions.Expect<ArgumentNullException>(() => testSubject.Initialize(null, GetQualityProfiles()));
-            Exceptions.Expect<ArgumentNullException>(() => testSubject.Initialize(new Project[0], null));
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.Initialize(null));
         }
 
         [TestMethod]
@@ -204,14 +191,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var otherProjectType = this.solutionMock.AddOrGetProject("xxx.proj");
             otherProjectType.ProjectKind = "{" + Guid.NewGuid().ToString() + "}";
 
-            var testSubject = CreateTestSubject(ProjectKey);
+            var testSubject = CreateTestSubject();
             var projects = new[] { cs1Project, vbProject, cs2Project, otherProjectType };
 
             // Sanity
             testSubject.Binders.Should().BeEmpty("Not expecting any project binders");
 
             // Act
-            testSubject.Initialize(projects, GetQualityProfiles());
+            testSubject.Initialize(projects);
 
             // Assert
             testSubject.SolutionFullPath.Should().Be(Path.Combine(SolutionRoot, "xxx.sln"));
@@ -245,7 +232,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             var projects = new[] { csProject, vbProject };
 
-            var testSubject = CreateTestSubject(ProjectKey);
+            var testSubject = CreateTestSubject();
 
             var ruleSetMap = new Dictionary<Language, IBindingConfig>
             {
@@ -254,7 +241,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             };
 
             testSubject.RegisterKnownConfigFiles(ruleSetMap);
-            testSubject.Initialize(projects, GetQualityProfiles());
+            testSubject.Initialize(projects);
             var sonarQubeRulesDirectory = Path.Combine(SolutionRoot, ConfigurableSolutionRuleSetsInformationProvider.DummyLegacyModeFolderName);
 
             // Sanity
@@ -305,14 +292,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             var projects = new[] { csProject, vbProject };
 
-            var testSubject = CreateTestSubject(ProjectKey);
+            var testSubject = CreateTestSubject();
 
             var languageToFileMap = new Dictionary<Language, IBindingConfig>();
             languageToFileMap[Language.CSharp] = csConfigFile.Object;
             languageToFileMap[Language.VBNET] = vbConfigFile.Object;
 
             testSubject.RegisterKnownConfigFiles(languageToFileMap);
-            testSubject.Initialize(projects, GetQualityProfiles());
+            testSubject.Initialize(projects);
 
             using (CancellationTokenSource src = new CancellationTokenSource())
             {
@@ -358,9 +345,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         private void ExecuteCommitSolutionBindingTest(SonarLintMode bindingMode, string expectedFilePath)
         {
             // Arrange
-            var configPersister = new ConfigurableConfigurationProvider();
-            this.serviceProvider.RegisterService(typeof(IConfigurationPersister), configPersister);
-
             var csProject = solutionMock.AddOrGetProject("CS.csproj");
             csProject.SetCSProjectKind();
             var csConfigFile = CreateMockConfigFile(expectedFilePath);
@@ -376,7 +360,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var projects = new[] { csProject };
 
             var connectionInformation = new ConnectionInformation(new Uri("http://xyz"));
-            SolutionBindingOperation testSubject = this.CreateTestSubject(ProjectKey, connectionInformation, bindingMode);
+            SolutionBindingOperation testSubject = this.CreateTestSubject(bindingMode);
 
             var languageToFileMap = new Dictionary<Language, IBindingConfig>()
             {
@@ -384,15 +368,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             };
 
             testSubject.RegisterKnownConfigFiles(languageToFileMap);
-            var profiles = GetQualityProfiles();
 
             DateTime expectedTimeStamp = DateTime.Now;
-            profiles[Language.CSharp] = new SonarQubeQualityProfile("expected profile Key", "", "", false, expectedTimeStamp);
-            testSubject.Initialize(projects, profiles);
+            testSubject.Initialize(projects);
             testSubject.Prepare(CancellationToken.None);
-
-            // Sanity
-            configPersister.SavedProject.Should().BeNull();
 
             // Act
             var commitResult = testSubject.CommitSolutionBinding();
@@ -400,38 +379,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Assert
             commitResult.Should().BeTrue();
             csBinderCommitAction.Verify(x=> x(), Times.Once);
-
-            configPersister.SavedProject.Should().NotBeNull();
-            configPersister.SavedMode.Should().Be(bindingMode);
-
-            var savedProject = configPersister.SavedProject;
-            savedProject.ServerUri.Should().Be(connectionInformation.ServerUri);
-            savedProject.Profiles.Should().HaveCount(1);
-            savedProject.Profiles[Language.CSharp].ProfileKey.Should().Be("expected profile Key");
-            savedProject.Profiles[Language.CSharp].ProfileTimestamp.Should().Be(expectedTimeStamp);
         }
 
         #endregion Tests
 
         #region Helpers
 
-        private SolutionBindingOperation CreateTestSubject(string projectKey,
-            ConnectionInformation connection = null,
-            SonarLintMode bindingMode = SonarLintMode.LegacyConnected)
+        private SolutionBindingOperation CreateTestSubject(SonarLintMode bindingMode = SonarLintMode.LegacyConnected)
         {
             return new SolutionBindingOperation(serviceProvider,
-                connection ?? new ConnectionInformation(new Uri("http://host")),
-                projectKey,
-                projectKey,
                 bindingMode,
                 projectBinderFactoryMock.Object,
                 new LegacyConfigFolderItemAdder(serviceProvider, fileSystem),
                 fileSystem);
-        }
-
-        private static Dictionary<Language, SonarQubeQualityProfile> GetQualityProfiles()
-        {
-            return new Dictionary<Language, SonarQubeQualityProfile>();
         }
 
         private Mock<IBindingConfig> CreateMockConfigFile(string expectedFilePath)

--- a/src/Integration.UnitTests/NewConnectedMode/ConfigurationProviderTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/ConfigurationProviderTests.cs
@@ -233,10 +233,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Arrange
             var project = new BoundSonarQubeProject();
-            legacyPathProvider.Setup(x => x.Get()).Returns("old.txt");
+            legacyPathProvider.Setup(x => x.Get()).Returns("c:\\old.txt");
 
             solutionBindingSerializer
-                .Setup(x => x.Write("old.txt", project, legacyItemAdderMock.Object.AddToFolder))
+                .Setup(x => x.Write("c:\\old.txt", project, legacyItemAdderMock.Object.AddToFolder))
                 .Returns(true);
 
             // Act
@@ -246,7 +246,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             actual.Should().NotBe(null);
 
             solutionBindingSerializer.Verify(x =>
-                    x.Write("old.txt", project, legacyItemAdderMock.Object.AddToFolder),
+                    x.Write("c:\\old.txt", project, legacyItemAdderMock.Object.AddToFolder),
                 Times.Once);
         }
 
@@ -254,10 +254,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void Persist_NewConnectedModeConfig_SaveNewConfig()
         {
             var projectToWrite = new BoundSonarQubeProject();
-            newPathProvider.Setup(x => x.Get()).Returns("new.txt");
+            newPathProvider.Setup(x => x.Get()).Returns("c:\\new.txt");
 
             solutionBindingSerializer
-                .Setup(x => x.Write("new.txt", projectToWrite, null))
+                .Setup(x => x.Write("c:\\new.txt", projectToWrite, null))
                 .Returns(true);
 
             // Act
@@ -267,7 +267,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             actual.Should().NotBe(null);
 
             solutionBindingSerializer.Verify(x =>
-                    x.Write("new.txt", projectToWrite, null),
+                    x.Write("c:\\new.txt", projectToWrite, null),
                 Times.Once);
         }
     }

--- a/src/Integration.UnitTests/NewConnectedMode/ConfigurationProviderTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/ConfigurationProviderTests.cs
@@ -243,7 +243,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var actual = testSubject.Persist(project, SonarLintMode.LegacyConnected);
 
             // Assert
-            actual.Should().BeTrue();
+            actual.Should().NotBe(null);
 
             solutionBindingSerializer.Verify(x =>
                     x.Write("old.txt", project, legacyItemAdderMock.Object.AddToFolder),
@@ -264,7 +264,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var actual = testSubject.Persist(projectToWrite, SonarLintMode.Connected);
 
             // Assert
-            actual.Should().BeTrue();
+            actual.Should().NotBe(null);
 
             solutionBindingSerializer.Verify(x =>
                     x.Write("new.txt", projectToWrite, null),

--- a/src/Integration/Binding/BindingController.cs
+++ b/src/Integration/Binding/BindingController.cs
@@ -158,24 +158,20 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             var solutionBindingOp = new SolutionBindingOperation(
                 host,
-                bindingArgs.Connection,
-                bindingArgs.ProjectKey,
-                bindingArgs.ProjectName,
                 modeToBind,
                 host.Logger);
 
             var unboundProjectFinder = new UnboundProjectFinder(host, host.Logger);
 
-            var cSharpVBBindingConfigProvider = new CSharpVBBindingConfigProvider(host.SonarQubeService, nugetBindingOp, currentConfiguration, host.Logger);
-            
-            var cppConfigProvider = new CFamilyBindingConfigProvider(host.SonarQubeService, currentConfiguration, host.Logger);
+            var cSharpVBBindingConfigProvider = new CSharpVBBindingConfigProvider(host.SonarQubeService, nugetBindingOp, host.Logger);
+            var cppConfigProvider = new CFamilyBindingConfigProvider(host.SonarQubeService, host.Logger);
+           
             var ruleConfigProvider = new CompositeBindingConfigProvider(cSharpVBBindingConfigProvider, cppConfigProvider);
-
-            var bindingProcess = new BindingProcessImpl(host, bindingArgs, solutionBindingOp, nugetBindingOp, unboundProjectFinder, ruleConfigProvider, isFirstBinding);
+            var bindingProcess = new BindingProcessImpl(host, bindingArgs, solutionBindingOp, nugetBindingOp, unboundProjectFinder, ruleConfigProvider, modeToBind, isFirstBinding);
 
             return bindingProcess;
         }
-
+        
         internal /*for testing purposes*/ void SetBindingInProgress(IProgressEvents progressEvents, BindCommandArgs bindingArgs)
         {
             this.OnBindingStarted();

--- a/src/Integration/Binding/BindingProcessImpl.cs
+++ b/src/Integration/Binding/BindingProcessImpl.cs
@@ -27,6 +27,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Integration.NewConnectedMode;
+using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarQube.Client.Models;
 using Language = SonarLint.VisualStudio.Core.Language;
@@ -41,6 +43,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly ISolutionBindingOperation solutionBindingOperation;
         private readonly IUnboundProjectFinder unboundProjectFinder;
         private readonly IBindingConfigProvider bindingConfigProvider;
+        private readonly SonarLintMode bindingMode;
 
         internal /*for testing*/ INuGetBindingOperation NuGetBindingOperation { get; }
 
@@ -50,6 +53,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             INuGetBindingOperation nugetBindingOperation,
             IUnboundProjectFinder unboundProjectFinder,
             IBindingConfigProvider bindingConfigProvider,
+            SonarLintMode bindingMode,
             bool isFirstBinding = false)
         {
             this.host = host ?? throw new ArgumentNullException(nameof(host));
@@ -58,6 +62,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             this.NuGetBindingOperation = nugetBindingOperation ?? throw new ArgumentNullException(nameof(nugetBindingOperation));
             this.unboundProjectFinder = unboundProjectFinder ?? throw new ArgumentNullException(nameof(unboundProjectFinder));
             this.bindingConfigProvider = bindingConfigProvider ?? throw new ArgumentNullException(nameof(bindingConfigProvider));
+            this.bindingMode = bindingMode;
 
             Debug.Assert(bindingArgs.ProjectKey != null);
             Debug.Assert(bindingArgs.ProjectName != null);
@@ -122,8 +127,10 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 }
                 this.InternalState.QualityProfiles[language] = qualityProfileInfo;
 
+                var bindingConfiguration = WriteBindingInformation();
+
                 // Create the binding configuration for the language
-                var bindingConfig = await this.bindingConfigProvider.GetConfigurationAsync(qualityProfileInfo, language, cancellationToken);
+                var bindingConfig = await this.bindingConfigProvider.GetConfigurationAsync(qualityProfileInfo, language, bindingConfiguration, cancellationToken);
                 if (bindingConfig == null)
                 {
                     this.host.Logger.WriteLine(string.Format(Strings.SubTextPaddingFormat,
@@ -143,6 +150,40 @@ namespace SonarLint.VisualStudio.Integration.Binding
             return true;
         }
 
+        /// <summary>
+        /// Will add/edit the binding information for next time usage
+        /// </summary>
+        private BindingConfiguration WriteBindingInformation()
+        {
+            Debug.Assert(InternalState.QualityProfiles != null, "Initialize was expected to be called first");
+
+            var configurationPersister = host.GetService<IConfigurationPersister>();
+            configurationPersister.AssertLocalServiceIsNotNull();
+
+            BasicAuthCredentials credentials = bindingArgs.Connection.UserName == null ? null : new BasicAuthCredentials(bindingArgs.Connection.UserName, bindingArgs.Connection.Password);
+
+            Dictionary<Language, ApplicableQualityProfile> map = new Dictionary<Language, ApplicableQualityProfile>();
+
+            foreach (var keyValue in InternalState.QualityProfiles)
+            {
+                map[keyValue.Key] = new ApplicableQualityProfile
+                {
+                    ProfileKey = keyValue.Value.Key,
+                    ProfileTimestamp = keyValue.Value.TimeStamp
+                };
+            }
+
+            var bound = new BoundSonarQubeProject(bindingArgs.Connection.ServerUri,
+                bindingArgs.ProjectKey,
+                bindingArgs.ProjectName,
+                credentials,
+                bindingArgs.Connection.Organization);
+
+            bound.Profiles = map;
+
+            return configurationPersister.Persist(bound, bindingMode);
+        }
+
         public void PrepareToInstallPackages()
         {
             this.NuGetBindingOperation.PrepareOnUIThread();
@@ -160,7 +201,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             var projectsToUpdate = GetProjectsForRulesetBinding(this.InternalState.IsFirstBinding, this.InternalState.BindingProjects.ToArray(),
                 this.unboundProjectFinder, this.host.Logger);
 
-            this.solutionBindingOperation.Initialize(projectsToUpdate, this.InternalState.QualityProfiles);
+            this.solutionBindingOperation.Initialize(projectsToUpdate);
         }
 
         public void PrepareSolutionBinding(CancellationToken cancellationToken)

--- a/src/Integration/Binding/BindingProcessImpl.cs
+++ b/src/Integration/Binding/BindingProcessImpl.cs
@@ -127,7 +127,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 }
                 this.InternalState.QualityProfiles[language] = qualityProfileInfo;
 
-                var bindingConfiguration = WriteBindingInformation();
+                var bindingConfiguration = QueueWriteBindingInformation();
 
                 // Create the binding configuration for the language
                 var bindingConfig = await this.bindingConfigProvider.GetConfigurationAsync(qualityProfileInfo, language, bindingConfiguration, cancellationToken);
@@ -153,7 +153,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <summary>
         /// Will add/edit the binding information for next time usage
         /// </summary>
-        private BindingConfiguration WriteBindingInformation()
+        private BindingConfiguration QueueWriteBindingInformation()
         {
             Debug.Assert(InternalState.QualityProfiles != null, "Initialize was expected to be called first");
 

--- a/src/Integration/Binding/ISolutionBindingOperation.cs
+++ b/src/Integration/Binding/ISolutionBindingOperation.cs
@@ -21,8 +21,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using EnvDTE;
-using SonarQube.Client.Models;
-using Language = SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
@@ -36,7 +34,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
     /// </remarks>
     public interface ISolutionBindingOperation : ISolutionBindingConfigFileStore
     {
-        void Initialize(IEnumerable<Project> projects, IDictionary<Language, SonarQubeQualityProfile> profilesMap);
+        void Initialize(IEnumerable<Project> projects);
 
         void Prepare(CancellationToken token);
 

--- a/src/Integration/NewConnectedMode/ConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationProvider.cs
@@ -61,7 +61,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             return bindingConfiguration ?? BindingConfiguration.Standalone;
         }
 
-        public bool Persist(BoundSonarQubeProject project, SonarLintMode bindingMode)
+        public BindingConfiguration Persist(BoundSonarQubeProject project, SonarLintMode bindingMode)
         {
             if (project == null)
             {
@@ -70,8 +70,10 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 
             var writeSettings = GetWriteSettings(bindingMode);
 
-            return writeSettings.HasValue && 
+            var success = writeSettings.HasValue && 
                    solutionBindingSerializer.Write(writeSettings?.ConfigPath, project, writeSettings?.OnSuccessfulFileWrite);
+
+            return success ? TryGetBindingConfiguration(writeSettings?.ConfigPath, project, bindingMode) : null;
         }
 
         private BindingConfiguration TryGetBindingConfiguration(string bindingPath, SonarLintMode sonarLintMode)
@@ -82,7 +84,12 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             }
 
             var boundProject = solutionBindingSerializer.Read(bindingPath);
+            
+            return TryGetBindingConfiguration(bindingPath, boundProject, sonarLintMode);
+        }
 
+        private BindingConfiguration TryGetBindingConfiguration(string bindingPath, BoundSonarQubeProject boundProject, SonarLintMode sonarLintMode)
+        {
             if (boundProject == null)
             {
                 return null;

--- a/src/Integration/NewConnectedMode/ConfigurationProvider.cs
+++ b/src/Integration/NewConnectedMode/ConfigurationProvider.cs
@@ -73,7 +73,7 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
             var success = writeSettings.HasValue && 
                    solutionBindingSerializer.Write(writeSettings?.ConfigPath, project, writeSettings?.OnSuccessfulFileWrite);
 
-            return success ? TryGetBindingConfiguration(writeSettings?.ConfigPath, project, bindingMode) : null;
+            return success ? CreateBindingConfiguration(writeSettings?.ConfigPath, project, bindingMode) : null;
         }
 
         private BindingConfiguration TryGetBindingConfiguration(string bindingPath, SonarLintMode sonarLintMode)
@@ -85,10 +85,10 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 
             var boundProject = solutionBindingSerializer.Read(bindingPath);
             
-            return TryGetBindingConfiguration(bindingPath, boundProject, sonarLintMode);
+            return CreateBindingConfiguration(bindingPath, boundProject, sonarLintMode);
         }
 
-        private BindingConfiguration TryGetBindingConfiguration(string bindingPath, BoundSonarQubeProject boundProject, SonarLintMode sonarLintMode)
+        private BindingConfiguration CreateBindingConfiguration(string bindingPath, BoundSonarQubeProject boundProject, SonarLintMode sonarLintMode)
         {
             if (boundProject == null)
             {

--- a/src/Integration/NewConnectedMode/IConfigurationPersister.cs
+++ b/src/Integration/NewConnectedMode/IConfigurationPersister.cs
@@ -24,6 +24,6 @@ namespace SonarLint.VisualStudio.Integration.NewConnectedMode
 {
     public interface IConfigurationPersister : ILocalService
     {
-        bool Persist(BoundSonarQubeProject project, SonarLintMode bindingMode);
+        BindingConfiguration Persist(BoundSonarQubeProject project, SonarLintMode bindingMode);
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConfigurationProvider.cs
@@ -39,12 +39,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 : BindingConfiguration.CreateBoundConfiguration(ProjectToReturn, ModeToReturn, FolderPathToReturn);
         }
 
-        public bool Persist(BoundSonarQubeProject project, SonarLintMode bindingMode)
+        public BindingConfiguration Persist(BoundSonarQubeProject project, SonarLintMode bindingMode)
         {
             project.Should().NotBeNull();
             SavedProject = project;
             SavedMode = bindingMode;
-            return WriteResultToReturn;
+
+            return GetConfiguration();
         }
 
         #region Test helpers


### PR DESCRIPTION
I found a nasty bug during QA: I used the existing binding information in order to fetch the configurations, which caused a bug when there was no existing binding information (first time bind).
Hence I had to move the code that calculates the new binding configuration, and use that new configuration.