### PR TITLE
Embed SonarC# 8.7 and SonarVB 8.7

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -3,7 +3,7 @@
   <!-- Manually set the version of the SonarC# and VB analyzers to embed.
        NB we assume that the SonarC# and SonarVB NuGet packages have the same version number. -->
   <PropertyGroup>
-    <EmbeddedSonarAnalyzerVersion>8.4.0.15306</EmbeddedSonarAnalyzerVersion>
+    <EmbeddedSonarAnalyzerVersion>8.7.0.17535</EmbeddedSonarAnalyzerVersion>
     <EmbeddedSonarCFamilyAnalyzerVersion>6.8.0.16475</EmbeddedSonarCFamilyAnalyzerVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #1400

I checked that my manual repro of the bug that was blocking the analyzer update no longer repros.
The DotNet team now have an automated test to check the analyzers run on the minimum supported .NET version to catch similar problems in the future.