### PR TITLE
Removed VS RuleSet param from IRuleSetReferenceChecker interface

### DIFF
--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
@@ -291,7 +291,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             CreateProperty(projectMock, "config1", CSharpVBBindingOperation.DefaultProjectRuleSet);
             projectMock.SetVBProjectKind();
             ruleSetReferenceChecker
-                .Setup(x => x.IsReferenced(projectMock, cSharpVBBindingConfig.RuleSet.Content))
+                .Setup(x => x.IsReferenced(projectMock, cSharpVBBindingConfig.RuleSet.Path))
                 .Returns(true);
 
             var testSubject = CreateTestSubject();

--- a/src/Integration/Binding/CSharpVBBindingOperation.cs
+++ b/src/Integration/Binding/CSharpVBBindingOperation.cs
@@ -248,7 +248,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             var slnRuleSetFilePath = cSharpVBBindingConfig.RuleSet.Path;
             var solutionRuleSet = ruleSetSerializer.LoadRuleSet(slnRuleSetFilePath);
 
-            if (solutionRuleSet != null // null is file is missing or can't be loaded
+            if (solutionRuleSet != null // null means file is missing or can't be loaded
                 && ruleSetReferenceChecker.IsReferenced(initializedProject, slnRuleSetFilePath))
             {
                 return;

--- a/src/Integration/Binding/CSharpVBBindingOperation.cs
+++ b/src/Integration/Binding/CSharpVBBindingOperation.cs
@@ -53,9 +53,9 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
         }
 
-        internal CSharpVBBindingOperation(IServiceProvider serviceProvider, 
+        internal CSharpVBBindingOperation(IServiceProvider serviceProvider,
             Project project,
-            ICSharpVBBindingConfig cSharpVBBindingConfig, 
+            ICSharpVBBindingConfig cSharpVBBindingConfig,
             IFileSystem fileSystem,
             IAdditionalFileConflictChecker additionalFileConflictChecker,
             IRuleSetReferenceChecker ruleSetReferenceChecker)
@@ -138,7 +138,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
             AddRuleset();
             EnsureAdditionalFileIsReferenced();
         }
-
 
         #region Helpers
 
@@ -232,7 +231,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
-                var message = string.Format(BindingStrings.CSharpVB_FailedToSetSonarLintXmlItemType, projectItem.ContainingProject.FileName, 
+                var message = string.Format(BindingStrings.CSharpVB_FailedToSetSonarLintXmlItemType, projectItem.ContainingProject.FileName,
                     Constants.AdditionalFilesItemTypeName, ex.Message);
                 throw new SonarLintException(message, ex);
             }
@@ -246,9 +245,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         private void CalculateRuleSetInformation()
         {
-            var solutionRuleSet = ruleSetSerializer.LoadRuleSet(cSharpVBBindingConfig.RuleSet.Path);
+            var slnRuleSetFilePath = cSharpVBBindingConfig.RuleSet.Path;
+            var solutionRuleSet = ruleSetSerializer.LoadRuleSet(slnRuleSetFilePath);
 
-            if (solutionRuleSet != null && ruleSetReferenceChecker.IsReferenced(initializedProject, solutionRuleSet))
+            if (solutionRuleSet != null // null is file is missing or can't be loaded
+                && ruleSetReferenceChecker.IsReferenced(initializedProject, slnRuleSetFilePath))
             {
                 return;
             }

--- a/src/Integration/Binding/CSharpVBProjectBinder.cs
+++ b/src/Integration/Binding/CSharpVBProjectBinder.cs
@@ -87,7 +87,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         private bool IsFullyBoundProject(BindingConfiguration binding, Project project, Language language)
         {
-            if (!IsSolutionBound(binding, language, out var solutionRuleSet, out var additionalFilePath))
+            if (!IsSolutionBound(binding, language, out var solutionRuleSetFilePath, out var additionalFilePath))
             {
                 return false;
             }
@@ -99,14 +99,13 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 return false;
             }
 
-            var isRuleSetBound = ruleSetReferenceChecker.IsReferenced(project, solutionRuleSet);
-
+            var isRuleSetBound = ruleSetReferenceChecker.IsReferenced(project, solutionRuleSetFilePath);
             return isRuleSetBound;
         }
 
-        private bool IsSolutionBound(BindingConfiguration binding, Language language, out RuleSet solutionRuleSet, out string additionalFilePath)
+        private bool IsSolutionBound(BindingConfiguration binding, Language language, out string solutionRuleSetFilePath, out string additionalFilePath)
         {
-            solutionRuleSet = null;
+            solutionRuleSetFilePath = null;
             additionalFilePath = CSharpVBBindingConfigProvider.GetSolutionAdditionalFilePath(language, binding);
 
             if (!fileSystem.File.Exists(additionalFilePath))
@@ -114,7 +113,8 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 return false;
             }
 
-            solutionRuleSet = GetSolutionRuleSet(binding, language);
+            var solutionRuleSet = GetSolutionRuleSet(binding, language);
+            solutionRuleSetFilePath = solutionRuleSet?.FilePath;
 
             return solutionRuleSet != null;
         }

--- a/src/Integration/Binding/IRuleSetReferenceChecker.cs
+++ b/src/Integration/Binding/IRuleSetReferenceChecker.cs
@@ -19,17 +19,16 @@
  */
 
 using EnvDTE;
-using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
     internal interface IRuleSetReferenceChecker
     {
         /// <summary>
-        /// Return true if the the project's ruleSets directly include the target ruleSet, otherwise false
+        /// Return true if the project's ruleSets directly include the target ruleSet, otherwise false
         /// </summary>
         /// <remarks>We don't currently check nested includes in RuleSet
         /// i.e. if Project has RuleSet A which includes RuleSet B that includes RuleSet C, IsReferenced(Project, C) returns false.</remarks>
-        bool IsReferenced(Project project, RuleSet ruleSet);
+        bool IsReferenced(Project project, string targetRuleSetFilePath);
     }
 }

--- a/src/Integration/Binding/RuleSetReferenceChecker.cs
+++ b/src/Integration/Binding/RuleSetReferenceChecker.cs
@@ -46,21 +46,21 @@ namespace SonarLint.VisualStudio.Integration.Binding
             ruleSetSerializer.AssertLocalServiceIsNotNull();
         }
 
-        public bool IsReferenced(Project project, RuleSet ruleSet)
+        public bool IsReferenced(Project project, string targetRuleSetFilePath)
         {
             var declarations = ruleSetInfoProvider.GetProjectRuleSetsDeclarations(project).ToArray();
 
             var isRuleSetBound = declarations.Length > 0 &&
-                                 declarations.All(declaration => IsRuleSetReferenced(project, declaration, ruleSet));
+                                 declarations.All(declaration => IsRuleSetReferenced(project, declaration, targetRuleSetFilePath));
 
             return isRuleSetBound;
         }
 
-        private bool IsRuleSetReferenced(Project project, RuleSetDeclaration declaration, RuleSet ruleSet)
+        private bool IsRuleSetReferenced(Project project, RuleSetDeclaration declaration, string targetRuleSetFilePath)
         {
             var projectRuleSet = FindDeclarationRuleSet(project, declaration);
 
-            return projectRuleSet != null && HasInclude(projectRuleSet, ruleSet);
+            return projectRuleSet != null && HasInclude(projectRuleSet, targetRuleSetFilePath);
         }
 
         private RuleSet FindDeclarationRuleSet(Project project, RuleSetDeclaration declaration)
@@ -74,15 +74,15 @@ namespace SonarLint.VisualStudio.Integration.Binding
             return ruleSetSerializer.LoadRuleSet(ruleSetFilePath);
         }
 
-        private bool HasInclude(RuleSet source, RuleSet target)
+        private bool HasInclude(RuleSet source, string targetRuleSetFilePath)
         {
             Debug.Assert(Path.IsPathRooted(source.FilePath));
-            Debug.Assert(Path.IsPathRooted(target.FilePath));
+            Debug.Assert(Path.IsPathRooted(targetRuleSetFilePath));
 
             // The path in the RuleSetInclude could be relative or absolute.
             // If relative, we assume it's relative to the source ruleset file.
             var sourceDirectory = Path.GetDirectoryName(source.FilePath);
-            var canonicalTargetFilePath = Path.GetFullPath(target.FilePath);
+            var canonicalTargetFilePath = Path.GetFullPath(targetRuleSetFilePath);
 
             // Special case: the target ruleset is the one we are looking for
             if (IsMatchingPath(source.FilePath, canonicalTargetFilePath, sourceDirectory))


### PR DESCRIPTION
We only need the file path, not an actual ruleset object.