### PR TITLE
Don't generate project-level ruleset when project has no rulesets

### DIFF
--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperation.WriterTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperation.WriterTests.cs
@@ -378,6 +378,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.ruleSetFS.AssertRuleSetsAreEqual(actualPath, expectedRuleSet);
         }
 
+
         [TestMethod]
         public void ProjectBindingOperation_QueueWriteProjectLevelRuleSet_NewBinding()
         {
@@ -392,31 +393,22 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             RuleSet expectedRuleSet = TestRuleSetHelper.CreateTestRuleSet
             (
                 numRules: 0,
-                includes: new[] { expectedSolutionRuleSetInclude }
+                includes: new[] { expectedSolutionRuleSetInclude, "ConcurrencyRules.ruleset" }
             );
             var csharpVbConfig = CreateCSharpVbBindingConfig(solutionRuleSetPath, expectedRuleSet);
 
-            List<string> filesPending = new List<string>();
-            foreach (var currentRuleSet in new[] { null, string.Empty, CSharpVBBindingOperation.DefaultProjectRuleSet })
-            {
-                // Act
-                string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetFileName, csharpVbConfig, currentRuleSet);
-                filesPending.Add(actualPath);
+            // Act
+            string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetFileName, csharpVbConfig, "ConcurrencyRules.ruleset");
 
-                // Assert
-                this.ruleSetFS.AssertRuleSetNotExists(actualPath);
-                actualPath.Should().NotBe(solutionRuleSetPath, "Expecting a new rule set to be created once pending were written");
-            }
+            // Assert
+            this.ruleSetFS.AssertRuleSetNotExists(actualPath);
+            actualPath.Should().NotBe(solutionRuleSetPath, "Expecting a new rule set to be created once pending were written");
 
             // Act (write pending)
             this.sccFileSystem.WritePendingNoErrorsExpected();
 
             // Assert
-            foreach (var pending in filesPending)
-            {
-                // Assert
-                this.ruleSetFS.AssertRuleSetsAreEqual(pending, expectedRuleSet);
-            }
+            this.ruleSetFS.AssertRuleSetsAreEqual(actualPath, expectedRuleSet);
         }
 
         [DataTestMethod]
@@ -467,7 +459,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 @"..\..\relativeSolutionLevel.ruleset",
                 @"X:\SolutionDir\Sonar\absolutionSolutionRooted.ruleset",
                 @"c:\OtherPlaceEntirey\rules.ruleset",
-                CSharpVBBindingOperation.DefaultProjectRuleSet,
+                "ConcurrencyRules.ruleset",
                 null,
                 string.Empty
             };

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperation.WriterTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperation.WriterTests.cs
@@ -139,19 +139,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         }
 
         [TestMethod]
-        public void ProjectBindingOperation_ShouldIgnoreConfigureRuleSetValue()
+        public void ProjectBindingOperation_IsDefaultRuleSet()
         {
             // Test case 1: not ignored
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue("My awesome rule set.ruleset").Should().BeFalse();
+            CSharpVBBindingOperation.IsDefaultRuleSet("My awesome rule set.ruleset").Should().BeFalse();
 
             // Test case 2: ignored
             // Act
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue(null).Should().BeTrue();
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue(" ").Should().BeTrue();
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue("\t").Should().BeTrue();
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue(CSharpVBBindingOperation.DefaultProjectRuleSet.ToLower(CultureInfo.CurrentCulture)).Should().BeTrue();
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue(CSharpVBBindingOperation.DefaultProjectRuleSet.ToUpper(CultureInfo.CurrentCulture)).Should().BeTrue();
-            CSharpVBBindingOperation.ShouldIgnoreConfigureRuleSetValue(CSharpVBBindingOperation.DefaultProjectRuleSet).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultRuleSet(null).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultRuleSet(" ").Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultRuleSet("\t").Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet.ToLower(CultureInfo.CurrentCulture)).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet.ToUpper(CultureInfo.CurrentCulture)).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet).Should().BeTrue();
         }
 
         [TestMethod]
@@ -393,12 +393,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             RuleSet expectedRuleSet = TestRuleSetHelper.CreateTestRuleSet
             (
                 numRules: 0,
-                includes: new[] { expectedSolutionRuleSetInclude, "ConcurrencyRules.ruleset" }
+                includes: new[] { expectedSolutionRuleSetInclude, "MyCustomRuleSet.ruleset" }
             );
             var csharpVbConfig = CreateCSharpVbBindingConfig(solutionRuleSetPath, expectedRuleSet);
 
             // Act
-            string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetFileName, csharpVbConfig, "ConcurrencyRules.ruleset");
+            string actualPath = testSubject.QueueWriteProjectLevelRuleSet(projectFullPath, ruleSetFileName, csharpVbConfig, "MyCustomRuleSet.ruleset");
 
             // Assert
             this.ruleSetFS.AssertRuleSetNotExists(actualPath);
@@ -459,9 +459,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 @"..\..\relativeSolutionLevel.ruleset",
                 @"X:\SolutionDir\Sonar\absolutionSolutionRooted.ruleset",
                 @"c:\OtherPlaceEntirey\rules.ruleset",
-                "ConcurrencyRules.ruleset",
-                null,
-                string.Empty
+                "MyCustomRuleSet.ruleset"
             };
 
             foreach (var currentRuleSet in cases)

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperation.WriterTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperation.WriterTests.cs
@@ -139,19 +139,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         }
 
         [TestMethod]
-        public void ProjectBindingOperation_IsDefaultRuleSet()
+        public void ProjectBindingOperation_IsDefaultMicrosoftRuleSet()
         {
             // Test case 1: not ignored
-            CSharpVBBindingOperation.IsDefaultRuleSet("My awesome rule set.ruleset").Should().BeFalse();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet("My awesome rule set.ruleset").Should().BeFalse();
 
             // Test case 2: ignored
             // Act
-            CSharpVBBindingOperation.IsDefaultRuleSet(null).Should().BeTrue();
-            CSharpVBBindingOperation.IsDefaultRuleSet(" ").Should().BeTrue();
-            CSharpVBBindingOperation.IsDefaultRuleSet("\t").Should().BeTrue();
-            CSharpVBBindingOperation.IsDefaultRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet.ToLower(CultureInfo.CurrentCulture)).Should().BeTrue();
-            CSharpVBBindingOperation.IsDefaultRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet.ToUpper(CultureInfo.CurrentCulture)).Should().BeTrue();
-            CSharpVBBindingOperation.IsDefaultRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet(null).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet(" ").Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet("\t").Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet.ToLower(CultureInfo.CurrentCulture)).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet.ToUpper(CultureInfo.CurrentCulture)).Should().BeTrue();
+            CSharpVBBindingOperation.IsDefaultMicrosoftRuleSet(CSharpVBBindingOperation.DefaultProjectRuleSet).Should().BeTrue();
         }
 
         [TestMethod]

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
@@ -210,10 +210,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             testSubject.Prepare(CancellationToken.None);
 
             // Assert
-            string expectedRuleSetFileForPropertiesWithDefaultRulSets = cSharpVBBindingConfig.RuleSet.Path;
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().NotBe(null);
-            testSubject.PropertyInformationMap[defaultRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected all the properties with default ruleset to have the same new ruleset");
-            testSubject.PropertyInformationMap[defaultRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected all the properties with default ruleset to have the same new ruleset");
+            string expectedRuleSetFileForPropertiesWithDefaultRuleSets = cSharpVBBindingConfig.RuleSet.Path;
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().NotBe(null);
+            testSubject.PropertyInformationMap[defaultRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRuleSets, "Expected all the properties with default ruleset to have the same new ruleset");
+            testSubject.PropertyInformationMap[defaultRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRuleSets, "Expected all the properties with default ruleset to have the same new ruleset");
 
             string expectedRulesetFilePath = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
 
@@ -247,16 +247,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             testSubject.Prepare(CancellationToken.None);
 
             // Assert
-            string expectedRuleSetFileForPropertiesWithDefaultRulSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().Be(null);
-            testSubject.PropertyInformationMap[customRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected different rule set path for properties with custom rulesets");
-            testSubject.PropertyInformationMap[customRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected different rule set path for properties with custom rulesets");
+            string expectedRuleSetFileForPropertiesWithDefaultRuleSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().Be(null);
+            testSubject.PropertyInformationMap[customRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRuleSets, "Expected different rule set path for properties with custom rulesets");
+            testSubject.PropertyInformationMap[customRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRuleSets, "Expected different rule set path for properties with custom rulesets");
 
             // Act (write pending)
             this.sccFileSystem.WritePendingNoErrorsExpected();
 
             // Assert that written
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().NotBe(null);
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().NotBe(null);
         }
 
         [TestMethod]
@@ -265,8 +265,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             CSharpVBBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
-            PropertyMock defaultRuleSetProperty1 = CreateProperty(this.projectMock, "config1", "ConcurrencyRules.ruleset");
-            PropertyMock defaultRuleSetProperty2 = CreateProperty(this.projectMock, "config2", "ConcurrencyRules.ruleset");
+            PropertyMock firstRuleSet = CreateProperty(this.projectMock, "config1", "MyCustomRuleSet.ruleset");
+            PropertyMock secondRuleSet = CreateProperty(this.projectMock, "config2", "MyCustomRuleSet.ruleset");
             testSubject.Initialize();
 
             // Act
@@ -274,16 +274,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
 
             // Assert
-            string expectedRuleSetFileForPropertiesWithDefaultRulSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().Be(null);
-            testSubject.PropertyInformationMap[defaultRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected different rule set path for properties with custom rulesets");
-            testSubject.PropertyInformationMap[defaultRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected different rule set path for properties with custom rulesets");
+            string expectedRuleSetFileForPropertiesWithDefaultRuleSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().Be(null);
+            testSubject.PropertyInformationMap[firstRuleSet].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRuleSets, "Expected different rule set path for properties with custom rulesets");
+            testSubject.PropertyInformationMap[secondRuleSet].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRuleSets, "Expected different rule set path for properties with custom rulesets");
 
             // Act (write pending)
             this.sccFileSystem.WritePendingNoErrorsExpected();
 
             // Assert that written
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().NotBe(null);
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().NotBe(null);
         }
 
         [TestMethod]
@@ -304,14 +304,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             testSubject.Commit();
 
             // Assert
-            string expectedRuleSetFileForPropertiesWithDefaultRulSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().Be(null);
+            string expectedRuleSetFileForPropertiesWithDefaultRuleSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().Be(null);
 
             // Act (write pending)
             this.sccFileSystem.WritePendingNoErrorsExpected();
 
             // Assert that not written
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().Be(null);
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRuleSets).Should().Be(null);
         }
 
         [TestMethod]
@@ -400,7 +400,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             CSharpVBBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            PropertyMock prop = CreateProperty(this.projectMock, "config1", "ConcurrencyRules.ruleset");
+            PropertyMock prop = CreateProperty(this.projectMock, "config1", "MyCustomRuleSet.ruleset");
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);
 
@@ -449,7 +449,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             CSharpVBBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            PropertyMock prop = CreateProperty(this.projectMock, "config1", "ConcurrencyRules.ruleset");
+            PropertyMock prop = CreateProperty(this.projectMock, "config1", "MyCustomRuleSet.ruleset");
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);
 

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
@@ -31,6 +31,7 @@ using Moq;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.CSharpVB;
+using SonarLint.VisualStudio.Core.Helpers;
 using SonarLint.VisualStudio.Integration.Binding;
 using Language = SonarLint.VisualStudio.Core.Language;
 using RuleSet = Microsoft.VisualStudio.CodeAnalysis.RuleSets.RuleSet;
@@ -209,16 +210,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             testSubject.Prepare(CancellationToken.None);
 
             // Assert
-            string expectedRuleSetFileForPropertiesWithDefaultRulSets = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().Be(null);
+            string expectedRuleSetFileForPropertiesWithDefaultRulSets = cSharpVBBindingConfig.RuleSet.Path;
+            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().NotBe(null);
             testSubject.PropertyInformationMap[defaultRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected all the properties with default ruleset to have the same new ruleset");
             testSubject.PropertyInformationMap[defaultRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetFileForPropertiesWithDefaultRulSets, "Expected all the properties with default ruleset to have the same new ruleset");
 
-            string expectedRuleSetForConfig1 = Path.ChangeExtension(expectedRuleSetFileForPropertiesWithDefaultRulSets, "config1.ruleset");
+            string expectedRulesetFilePath = Path.Combine(Path.GetDirectoryName(this.projectMock.FilePath), Path.GetFileNameWithoutExtension(this.projectMock.FilePath) + ".ruleset");
+
+            string expectedRuleSetForConfig1 = Path.ChangeExtension(expectedRulesetFilePath, "config1.ruleset");
             testSubject.PropertyInformationMap[customRuleSetProperty1].NewRuleSetFilePath.Should().Be(expectedRuleSetForConfig1, "Expected different rule set path for properties with custom rulesets");
             fileSystem.GetFile(expectedRuleSetForConfig1).Should().Be(null);
 
-            string expectedRuleSetForConfig2 = Path.ChangeExtension(expectedRuleSetFileForPropertiesWithDefaultRulSets, "config2.ruleset");
+            string expectedRuleSetForConfig2 = Path.ChangeExtension(expectedRulesetFilePath, "config2.ruleset");
             testSubject.PropertyInformationMap[customRuleSetProperty2].NewRuleSetFilePath.Should().Be(expectedRuleSetForConfig2, "Expected different rule set path for properties with custom rulesets");
             fileSystem.GetFile(expectedRuleSetForConfig2).Should().Be(null);
 
@@ -226,7 +229,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.sccFileSystem.WritePendingNoErrorsExpected();
 
             // Assert that written
-            fileSystem.GetFile(expectedRuleSetFileForPropertiesWithDefaultRulSets).Should().NotBe(null);
             fileSystem.GetFile(expectedRuleSetForConfig1).Should().NotBe(null);
             fileSystem.GetFile(expectedRuleSetForConfig2).Should().NotBe(null);
         }
@@ -263,8 +265,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             CSharpVBBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
-            PropertyMock defaultRuleSetProperty1 = CreateProperty(this.projectMock, "config1", CSharpVBBindingOperation.DefaultProjectRuleSet);
-            PropertyMock defaultRuleSetProperty2 = CreateProperty(this.projectMock, "config2", CSharpVBBindingOperation.DefaultProjectRuleSet);
+            PropertyMock defaultRuleSetProperty1 = CreateProperty(this.projectMock, "config1", "ConcurrencyRules.ruleset");
+            PropertyMock defaultRuleSetProperty2 = CreateProperty(this.projectMock, "config2", "ConcurrencyRules.ruleset");
             testSubject.Initialize();
 
             // Act
@@ -398,7 +400,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Arrange
             CSharpVBBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            PropertyMock prop = CreateProperty(this.projectMock, "config1", CSharpVBBindingOperation.DefaultProjectRuleSet);
+            PropertyMock prop = CreateProperty(this.projectMock, "config1", "ConcurrencyRules.ruleset");
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);
 
@@ -417,12 +419,37 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         }
 
         [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void ProjectBindingOperation_Commit_ShouldNotGenerateProjectRuleSetWhenRuleSetIsDefault(bool isLegacySystem)
+        {
+            // Arrange
+            var testSubject = CreateTestSubject();
+            projectMock.SetCSProjectKind();
+            var prop = CreateProperty(this.projectMock, "config1", CSharpVBBindingOperation.DefaultProjectRuleSet);
+            testSubject.Initialize();
+            testSubject.Prepare(CancellationToken.None);
+
+            projectSystemHelper.SetIsLegacyProjectSystem(isLegacySystem);
+
+            // Act
+            using (new AssertIgnoreScope()) // Ignore that the file is not on disk
+            {
+                testSubject.Commit();
+            }
+
+            // Assert
+            prop.Value.ToString().Should().Be(PathHelper.CalculateRelativePath(testSubject.ProjectFullPath, cSharpVBBindingConfig.RuleSet.Path), "Should update the property value");
+            projectMock.Files.ContainsKey(cSharpVBBindingConfig.RuleSet.Path).Should().Be(isLegacySystem, "Should add the file to the project only if legacy system");
+        }
+
+        [TestMethod]
         public void ProjectBindingOperation_Commit_LegacyProjectSystem_DoesAddFile()
         {
             // Arrange
             CSharpVBBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            PropertyMock prop = CreateProperty(this.projectMock, "config1", CSharpVBBindingOperation.DefaultProjectRuleSet);
+            PropertyMock prop = CreateProperty(this.projectMock, "config1", "ConcurrencyRules.ruleset");
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);
 

--- a/src/Integration/Binding/CSharpVBBindingOperation.Writer.cs
+++ b/src/Integration/Binding/CSharpVBBindingOperation.Writer.cs
@@ -70,9 +70,13 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 return existingRuleSetPath;
             }
 
+            if (ShouldIgnoreConfigureRuleSetValue(currentRuleSetPath))
+            {
+                return cSharpVBBindingConfig.RuleSet.Path;
+            }
+
             // Create a new project level rule set
-            string solutionIncludePath = PathHelper.CalculateRelativePath(ruleSetRoot, cSharpVBBindingConfig.RuleSet.Path);
-            
+            var solutionIncludePath = PathHelper.CalculateRelativePath(ruleSetRoot, cSharpVBBindingConfig.RuleSet.Path);
             RuleSet newRuleSet = GenerateNewProjectRuleSet(solutionIncludePath, currentRuleSetPath, cSharpVBBindingConfig.RuleSet.Content.DisplayName);
             string newRuleSetPath = this.GenerateNewProjectRuleSetPath(ruleSetRoot, ruleSetFileName);
 

--- a/src/Integration/Binding/CSharpVBBindingOperation.Writer.cs
+++ b/src/Integration/Binding/CSharpVBBindingOperation.Writer.cs
@@ -47,7 +47,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <returns>Full file path of the file that we expect to write to</returns>
         internal /*for testing purposes*/ string QueueWriteProjectLevelRuleSet(string projectFullPath, string ruleSetFileName, ICSharpVBBindingConfig cSharpVBBindingConfig, string currentRuleSetPath)
         {
-            if (IsDefaultRuleSet(currentRuleSetPath))
+            if (IsDefaultMicrosoftRuleSet(currentRuleSetPath))
             {
                 return cSharpVBBindingConfig.RuleSet.Path;
             }
@@ -135,7 +135,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             // default rule set property value. The idea here is that we would like to preserve any explicit setting by the user
             // and we assume that the default rule set can be safely ignored since wasn't set explicitly by the user (or even if it was
             // it has low value in comparison to what is configured in SQ).
-            if (!IsDefaultRuleSet(currentRuleSetPath))
+            if (!IsDefaultMicrosoftRuleSet(currentRuleSetPath))
             {
                 ruleSet.RuleSetIncludes.Add(new RuleSetInclude(currentRuleSetPath, RuleAction.Default));
             }
@@ -145,7 +145,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <summary>
         /// Returns whether the given RuleSet path is the default predefined RuleSet
         /// </summary>
-        internal static bool IsDefaultRuleSet(string ruleSet)
+        internal static bool IsDefaultMicrosoftRuleSet(string ruleSet)
         {
             return string.IsNullOrWhiteSpace(ruleSet) || StringComparer.OrdinalIgnoreCase.Equals(DefaultProjectRuleSet, ruleSet);
         }

--- a/src/Integration/Binding/CSharpVBBindingOperation.cs
+++ b/src/Integration/Binding/CSharpVBBindingOperation.cs
@@ -266,7 +266,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 var targetRuleSetName = projectBasedRuleSetName;
                 var currentRuleSetValue = useSameTargetName ? sameRuleSetCandidate : singleRuleSetInfo.RuleSetPath;
 
-                if (!useSameTargetName && !IsDefaultRuleSet(currentRuleSetValue))
+                if (!useSameTargetName && !IsDefaultMicrosoftRuleSet(currentRuleSetValue))
                 {
                     targetRuleSetName = string.Join(".", targetRuleSetName, singleRuleSetInfo.ConfigurationContext);
                 }

--- a/src/Integration/Binding/CSharpVBBindingOperation.cs
+++ b/src/Integration/Binding/CSharpVBBindingOperation.cs
@@ -266,7 +266,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 var targetRuleSetName = projectBasedRuleSetName;
                 var currentRuleSetValue = useSameTargetName ? sameRuleSetCandidate : singleRuleSetInfo.RuleSetPath;
 
-                if (!useSameTargetName && !ShouldIgnoreConfigureRuleSetValue(currentRuleSetValue))
+                if (!useSameTargetName && !IsDefaultRuleSet(currentRuleSetValue))
                 {
                     targetRuleSetName = string.Join(".", targetRuleSetName, singleRuleSetInfo.ConfigurationContext);
                 }


### PR DESCRIPTION
Fixes #817

I think we can only point to the Solution's ruleset when the user has no ruleset at all.
If there is a ruleset, we might not be able to amend it -- for example, if it's a pre-defined MS ruleset (under C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Team Tools\Static Analysis Tools\Rule Sets).
I think that if there is any ruleset in the project, we should continue with the previous behavior: create a new ruleset that references our ruleset + the project's. It also solves the problem if the ruleset is some global ruleset that is shared across multiple solutions.