### PR TITLE
DO NOT MERGE: dummy change to test change to baseline fails the build

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -3,7 +3,7 @@
   <!-- Manually set the version of the SonarC# and VB analyzers to embed.
        NB we assume that the SonarC# and SonarVB NuGet packages have the same version number. -->
   <PropertyGroup>
-    <EmbeddedSonarAnalyzerVersion>8.8.0.18411</EmbeddedSonarAnalyzerVersion>
+    <EmbeddedSonarAnalyzerVersion>8.3.0.14607</EmbeddedSonarAnalyzerVersion>
     <EmbeddedSonarCFamilyAnalyzerVersion>6.8.0.16475</EmbeddedSonarCFamilyAnalyzerVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This should change the set of referenced assemblies, which should cause the build to fail...