### PR TITLE
Removed VS types from IAnalyzer interface

### DIFF
--- a/src/Integration.Vsix.UnitTests/Analysis/AnalyzerControllerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/AnalyzerControllerTests.cs
@@ -66,7 +66,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var controller = new AnalyzerController(new TestLogger(), analyzers, null);
 
             // Act
-            controller.ExecuteAnalysis("c:\\file.cpp", "charset1", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            controller.ExecuteAnalysis("c:\\file.cpp", "charset1", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             analyzers.Any(x => x.RequestAnalysisCalled).Should().BeFalse();
         }
@@ -87,7 +87,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
 
             // Act
             controller.ExecuteAnalysis("c:\\file.cpp", "charset1",
-                new[] { AnalysisLanguage.CFamily, AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+                new[] { AnalysisLanguage.CFamily, AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             analyzers[0].RequestAnalysisCalled.Should().BeFalse();
             analyzers[2].RequestAnalysisCalled.Should().BeFalse();
@@ -139,8 +139,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             }
 
             public void ExecuteAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages,
-                IIssueConsumer consumer,
-                ProjectItem projectItem, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
+                IIssueConsumer consumer, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
             {
                 detectedLanguages.Should().NotBeNull();
                 detectedLanguages.Any().Should().BeTrue();

--- a/src/Integration.Vsix.UnitTests/CFamily/CLangAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CLangAnalyzerTests.cs
@@ -18,9 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
+using System.Threading;
+using EnvDTE;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Integration.UnitTests;
 
@@ -29,21 +33,110 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
     [TestClass]
     public class CLangAnalyzerTests
     {
+        private Mock<ITelemetryManager> telemetryManagerMock;
+        private TestLogger testLogger;
+        private Mock<ICFamilyRulesConfigProvider> rulesConfigProviderMock;
+        private Mock<IServiceProvider> serviceProviderWithValidProjectItem;
+
+        private readonly ProjectItem ValidProjectItem = Mock.Of<ProjectItem>();
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            telemetryManagerMock = new Mock<ITelemetryManager>();
+            testLogger = new TestLogger();
+            rulesConfigProviderMock = new Mock<ICFamilyRulesConfigProvider>();
+            serviceProviderWithValidProjectItem = CreateServiceProviderReturningProjectItem(ValidProjectItem);
+        }
+
         [TestMethod]
         public void IsSupported()
         {
-            // Arrange
-            var telemetryManagerMock = new Mock<ITelemetryManager>();
-            var testLogger = new TestLogger();
-            var rulesConfigProviderMock = new Mock<ICFamilyRulesConfigProvider>();
+            var testSubject = new CLangAnalyzer(telemetryManagerMock.Object, new ConfigurableSonarLintSettings(),
+                rulesConfigProviderMock.Object, serviceProviderWithValidProjectItem.Object, testLogger);
 
-            var analyzer = new CLangAnalyzer(telemetryManagerMock.Object, new ConfigurableSonarLintSettings(),
-                rulesConfigProviderMock.Object, testLogger);
+            testSubject.IsAnalysisSupported(new[] { AnalysisLanguage.CFamily }).Should().BeTrue();
+            testSubject.IsAnalysisSupported(new[] { AnalysisLanguage.Javascript }).Should().BeFalse();
+            testSubject.IsAnalysisSupported(new[] { AnalysisLanguage.Javascript, AnalysisLanguage.CFamily }).Should().BeTrue();
+        }
 
-            // Act and Assert
-            analyzer.IsAnalysisSupported(new[] { AnalysisLanguage.CFamily }).Should().BeTrue();
-            analyzer.IsAnalysisSupported(new[] { AnalysisLanguage.Javascript }).Should().BeFalse();
-            analyzer.IsAnalysisSupported(new[] { AnalysisLanguage.Javascript, AnalysisLanguage.CFamily }).Should().BeTrue();
+        [TestMethod]
+        public void ExecuteAnalysis_MissingProjectItem_NoAnalysis()
+        {
+            serviceProviderWithValidProjectItem = CreateServiceProviderReturningProjectItem(null);
+
+            var testSubject = new TestableCLangAnalyzer(telemetryManagerMock.Object, new ConfigurableSonarLintSettings(),
+                rulesConfigProviderMock.Object, serviceProviderWithValidProjectItem.Object, testLogger);
+
+            testSubject.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.CFamily }, Mock.Of<IIssueConsumer>(), null, CancellationToken.None);
+
+            testSubject.CreateRequestCallCount.Should().Be(0);
+            testSubject.TriggerAnalysisCallCount.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ExecuteAnalysis_ValidProjectItem_RequestCannotBeCreated_NoAnalysis()
+        {
+            var testSubject = new TestableCLangAnalyzer(telemetryManagerMock.Object, new ConfigurableSonarLintSettings(),
+                rulesConfigProviderMock.Object, serviceProviderWithValidProjectItem.Object, testLogger);
+            testSubject.RequestToReturn = null;
+
+            testSubject.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.CFamily }, Mock.Of<IIssueConsumer>(), null, CancellationToken.None);
+
+            testSubject.CreateRequestCallCount.Should().Be(1);
+            testSubject.TriggerAnalysisCallCount.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ExecuteAnalysis_ValidProjectItem_RequestCanBeCreated_AnalysisIsTriggered()
+        {
+            var testSubject = new TestableCLangAnalyzer(telemetryManagerMock.Object, new ConfigurableSonarLintSettings(),
+                rulesConfigProviderMock.Object, serviceProviderWithValidProjectItem.Object, testLogger);
+            testSubject.RequestToReturn = new Request();
+
+            testSubject.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.CFamily }, Mock.Of<IIssueConsumer>(), null, CancellationToken.None);
+
+            testSubject.CreateRequestCallCount.Should().Be(1);
+            testSubject.TriggerAnalysisCallCount.Should().Be(1);
+        }
+
+        private static Mock<IServiceProvider> CreateServiceProviderReturningProjectItem(ProjectItem projectItemToReturn)
+        {
+            var mockSolution = new Mock<Solution>();
+            mockSolution.Setup(s => s.FindProjectItem(It.IsAny<string>())).Returns(projectItemToReturn);
+            var solution = mockSolution.Object;
+
+            var mockDTE = new Mock<DTE>();
+            mockDTE.Setup(d => d.Solution).Returns(solution);
+            var dte = mockDTE.Object;
+
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider.Setup(s => s.GetService(typeof(DTE))).Returns(dte);
+
+            return mockServiceProvider;
+        }
+
+        private class TestableCLangAnalyzer : CLangAnalyzer
+        {
+            public Request RequestToReturn { get; set; }
+            public int CreateRequestCallCount { get; private set; }
+            public int TriggerAnalysisCallCount { get; private set; }
+
+            public TestableCLangAnalyzer(ITelemetryManager telemetryManager, ISonarLintSettings settings, ICFamilyRulesConfigProvider cFamilyRulesConfigProvider, 
+                IServiceProvider serviceProvider, ILogger logger)
+                : base(telemetryManager, settings, cFamilyRulesConfigProvider, serviceProvider, logger)
+            {}
+
+            protected override Request CreateRequest(ILogger logger, ProjectItem projectItem, string absoluteFilePath, ICFamilyRulesConfigProvider cFamilyRulesConfigProvider, IAnalyzerOptions analyzerOptions)
+            {
+                CreateRequestCallCount++;
+                return RequestToReturn;
+            }
+
+            protected override void TriggerAnalysis(Request request, IIssueConsumer consumer, CancellationToken cancellationToken)
+            {
+                TriggerAnalysisCallCount++;
+            }
         }
     }
 }

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonAnalyzerTests.cs
@@ -80,7 +80,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = true;
 
             // Act
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             // Assert - analysis not called
             dummyDaemon.RequestAnalysisCallCount.Should().Be(0);
@@ -100,7 +100,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = true;
 
             // 1. Start
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             // Assert - only RequestAnalysis called
             dummyInstaller.InstallCallCount.Should().Be(0);
@@ -121,7 +121,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = false;
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             dummyDaemon.StartCallCount.Should().Be(1);
             dummyDaemon.RequestAnalysisCallCount.Should().Be(0); // should be waiting for the daemon to be ready
@@ -163,7 +163,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             };
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             dummyDaemon.StartCallCount.Should().Be(1);
             dummyDaemon.RequestAnalysisCallCount.Should().Be(0); // should be waiting for the daemon to be ready
@@ -192,7 +192,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = false;
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript}, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript}, null, null, CancellationToken.None);
 
             dummyInstaller.InstallCallCount.Should().Be(1);
             dummyDaemon.StartCallCount.Should().Be(0);  // should be waiting for the daemon to be installed
@@ -222,7 +222,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = false;
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             dummyInstaller.InstallCallCount.Should().Be(1);
             dummyDaemon.StartCallCount.Should().Be(0);  // should be waiting for the daemon to be installed
@@ -257,7 +257,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             };
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             dummyInstaller.InstallCallCount.Should().Be(1);
             dummyDaemon.StartCallCount.Should().Be(0);  // should be waiting for the daemon to be installed
@@ -284,7 +284,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = false;
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             dummyInstaller.InstallCallCount.Should().Be(1);
             dummyDaemon.StartCallCount.Should().Be(0);  // should be waiting for the daemon to be installed
@@ -310,7 +310,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
             dummyDaemon.IsRunning = false;
 
             // 1. Make the request
-            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, null, CancellationToken.None);
+            analyzer.ExecuteAnalysis("path", "charset", new[] { AnalysisLanguage.Javascript }, null, null, CancellationToken.None);
 
             dummyInstaller.InstallCallCount.Should().Be(1);
             dummyDaemon.StartCallCount.Should().Be(0);  // should be waiting for the daemon to be installed

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/Helpers/DummySonarLintDaemon.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/Helpers/DummySonarLintDaemon.cs
@@ -72,8 +72,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         public void ExecuteAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages,
-            IIssueConsumer consumer,
-            ProjectItem projectItem, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
+            IIssueConsumer consumer, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
         {
             RequestAnalysisCallCount++;
             RequestAnalysisOperation?.Invoke();

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -209,7 +209,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 .Throws<Exception>();
 
             Action act = () => 
-            provider.RequestAnalysis("doc1.js", "", new []{AnalysisLanguage.CFamily}, null, null, null);
+            provider.RequestAnalysis("doc1.js", "", new []{AnalysisLanguage.CFamily}, null, null);
 
             act.Should().NotThrow();
         }

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -79,7 +79,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // 2. Add a tagger -> analysis requested
             using (var tagger = new IssueTagger(testSubject))
             {
-                mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject, It.IsAny<ProjectItem>(),
+                mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject,
                     (IAnalyzerOptions)null /* no expecting any options when a new tagger is added */,
                     It.IsAny<CancellationToken>()), Times.Once);
             }
@@ -129,7 +129,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
 
             RaiseFileSavedEvent(mockedJavascriptDocumentFooJs);
-            mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject, It.IsAny<ProjectItem>(),
+            mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject,
                 (IAnalyzerOptions)null /* no expecting any options when the settings file is updated */,
                 It.IsAny<CancellationToken>()), Times.Once);
 
@@ -154,7 +154,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
                 // Sanity check (that the test setup is correct and that events are actually being handled)
                 RaiseFileSavedEvent(mockedJavascriptDocumentFooJs);
-                mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject, It.IsAny<ProjectItem>(), It.IsAny<IAnalyzerOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject, It.IsAny<IAnalyzerOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
@@ -179,7 +179,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private void CheckAnalysisWasNotRequested()
         {
             mockAnalyzerController.Verify(x => x.ExecuteAnalysis(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<AnalysisLanguage>>(),
-                It.IsAny<IIssueConsumer>(), It.IsAny<ProjectItem>(), It.IsAny<IAnalyzerOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+                It.IsAny<IIssueConsumer>(), It.IsAny<IAnalyzerOptions>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         #endregion

--- a/src/Integration.Vsix/Analysis/AnalyzerController.cs
+++ b/src/Integration.Vsix/Analysis/AnalyzerController.cs
@@ -59,8 +59,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
         }
 
         public void ExecuteAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages,
-            IIssueConsumer consumer,
-            ProjectItem projectItem, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
+            IIssueConsumer consumer, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
         {
             bool handled = false;
             foreach(var analyzer in analyzers)
@@ -68,7 +67,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
                 if (analyzer.IsAnalysisSupported(detectedLanguages))
                 {
                     handled = true;
-                    analyzer.ExecuteAnalysis(path, charset, detectedLanguages, consumer, projectItem, analyzerOptions, cancellationToken);
+                    analyzer.ExecuteAnalysis(path, charset, detectedLanguages, consumer, analyzerOptions, cancellationToken);
                 }
             }
 

--- a/src/Integration.Vsix/Analysis/AnalyzerController.cs
+++ b/src/Integration.Vsix/Analysis/AnalyzerController.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
-using EnvDTE;
 using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis

--- a/src/Integration.Vsix/Analysis/IAnalyzerController.cs
+++ b/src/Integration.Vsix/Analysis/IAnalyzerController.cs
@@ -20,7 +20,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using EnvDTE;
 using SonarLint.VisualStudio.Core;
 
 // TODO: decide whether both of these interfaces are required
@@ -35,7 +34,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             string charset,
             IEnumerable<AnalysisLanguage> detectedLanguages,
             IIssueConsumer consumer,
-            ProjectItem projectItem,
             IAnalyzerOptions analyzerOptions,
             CancellationToken cancellationToken);
     }

--- a/src/Integration.Vsix/SonarLintDaemon/DaemonAnalyzer.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/DaemonAnalyzer.cs
@@ -25,7 +25,6 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using EnvDTE;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;

--- a/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Grpc.Core;
-using Sonarlint;
-using SonarLint.VisualStudio.Integration.Vsix.Resources;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -28,12 +25,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using EnvDTE;
+using Grpc.Core;
+using Sonarlint;
 using SonarLint.VisualStudio.Core;
-using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
-using Process = System.Diagnostics.Process;
+using SonarLint.VisualStudio.Integration.Vsix.Resources;
 using DaemonIssueSeverity = Sonarlint.Issue.Types.Severity;
 using DaemonIssueType = Sonarlint.Issue.Types.Type;
+using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
+using Process = System.Diagnostics.Process;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
@@ -487,8 +487,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         }
 
         public void ExecuteAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages,
-            IIssueConsumer consumer,
-            ProjectItem projectItem, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
+            IIssueConsumer consumer, IAnalyzerOptions analyzerOptions, CancellationToken cancellationToken)
         {
             if (!settings.IsActivateMoreEnabled)
             {

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -166,13 +166,13 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         #endregion IViewTaggerProvider members
 
-        public void RequestAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConsumer issueConsumer, ProjectItem projectItem, IAnalyzerOptions analyzerOptions)
+        public void RequestAnalysis(string path, string charset, IEnumerable<AnalysisLanguage> detectedLanguages, IIssueConsumer issueConsumer, IAnalyzerOptions analyzerOptions)
         {
             // May be called on the UI thread -> unhandled exceptions will crash VS
             try
             {
                 scheduler.Schedule(path, cancellationToken =>
-                    analyzerController.ExecuteAnalysis(path, charset, detectedLanguages, issueConsumer, projectItem, analyzerOptions, cancellationToken));
+                    analyzerController.ExecuteAnalysis(path, charset, detectedLanguages, issueConsumer, analyzerOptions, cancellationToken));
             }
             catch (Exception ex) when (!Microsoft.VisualStudio.ErrorHandler.IsCriticalException(ex))
             {

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -260,7 +260,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         public void RequestAnalysis(IAnalyzerOptions options)
         {
-            Provider.RequestAnalysis(FilePath, charset, detectedLanguages, this, ProjectItem, options);
+            Provider.RequestAnalysis(FilePath, charset, detectedLanguages, this, options);
         }
 
         void IIssueConsumer.Accept(string path, IEnumerable<IAnalysisIssue> issues)


### PR DESCRIPTION
The `ProjectItem` parameter is only required by the CLangAnalyzer, and shouldn't be on the analyzer interface. I've refactored the `CLangAnalyzer` to fetch the `ProjectItem` instead.

The changes to all of the other files are just to remove the redundant `ProjectItem` parameter.