### PR TITLE
Moved IAnalyzer and AnalysisLanguage to Core

### DIFF
--- a/src/Core.UnitTests/Analysis/FilterableIssueAdapterTests.cs
+++ b/src/Core.UnitTests/Analysis/FilterableIssueAdapterTests.cs
@@ -21,6 +21,7 @@
 using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.UnitTests;
 

--- a/src/Core/Analysis/AnalysisIssue.cs
+++ b/src/Core/Analysis/AnalysisIssue.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     public class AnalysisIssue : IAnalysisIssue
     {

--- a/src/Core/Analysis/AnalysisLanguage.cs
+++ b/src/Core/Analysis/AnalysisLanguage.cs
@@ -18,10 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Integration.Vsix
+namespace SonarLint.VisualStudio.Core
 {
     /// <summary>
-    /// Enum of languages supported by the SonarLint tagger
+    /// Enum of languages supported by the analyzers
     /// </summary>
     public enum AnalysisLanguage
     {

--- a/src/Core/Analysis/AnalysisLanguage.cs
+++ b/src/Core/Analysis/AnalysisLanguage.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     /// <summary>
     /// Enum of languages supported by the analyzers

--- a/src/Core/Analysis/FilterableIssueAdapter.cs
+++ b/src/Core/Analysis/FilterableIssueAdapter.cs
@@ -21,7 +21,7 @@
 using System;
 using SonarLint.VisualStudio.Core.Suppression;
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     public class FilterableIssueAdapter : IFilterableIssue
     {

--- a/src/Core/Analysis/IAnalysisIssue.cs
+++ b/src/Core/Analysis/IAnalysisIssue.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     public interface IAnalysisIssue
     {

--- a/src/Core/Analysis/IAnalysisRequester.cs
+++ b/src/Core/Analysis/IAnalysisRequester.cs
@@ -21,7 +21,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     public interface IAnalysisRequester
     {

--- a/src/Core/Analysis/IAnalyzer.cs
+++ b/src/Core/Analysis/IAnalyzer.cs
@@ -19,13 +19,19 @@
  */
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using System.Threading;
 
-namespace SonarLint.VisualStudio.Integration.Vsix
+namespace SonarLint.VisualStudio.Core
 {
-    internal interface ISonarLanguageRecognizer
+    public interface IAnalyzer
     {
-        IEnumerable<AnalysisLanguage> Detect(ITextDocument textDocument, ITextBuffer buffer);
+        bool IsAnalysisSupported(IEnumerable<AnalysisLanguage> languages);
+
+        void ExecuteAnalysis(string path,
+            string charset,
+            IEnumerable<AnalysisLanguage> detectedLanguages,
+            IIssueConsumer consumer,
+            IAnalyzerOptions analyzerOptions,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Core/Analysis/IAnalyzer.cs
+++ b/src/Core/Analysis/IAnalyzer.cs
@@ -21,7 +21,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     public interface IAnalyzer
     {

--- a/src/Core/Analysis/IAnalyzerOptions.cs
+++ b/src/Core/Analysis/IAnalyzerOptions.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     /// <summary>
     /// Marker interface for any analyzer-specific configuration options

--- a/src/Core/Analysis/IIssueConsumer.cs
+++ b/src/Core/Analysis/IIssueConsumer.cs
@@ -20,7 +20,7 @@
 
 using System.Collections.Generic;
 
-namespace SonarLint.VisualStudio.Core
+namespace SonarLint.VisualStudio.Core.Analysis
 {
     public interface IIssueConsumer
     {

--- a/src/Core/CFamily/CFamilyAnalyzerOptions.cs
+++ b/src/Core/CFamily/CFamilyAnalyzerOptions.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarLint.VisualStudio.Core.Analysis;
+
 namespace SonarLint.VisualStudio.Core.CFamily
 {
     public class CFamilyAnalyzerOptions : IAnalyzerOptions

--- a/src/Integration.Vsix.UnitTests/Analysis/AnalysisConfigMonitorTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/AnalysisConfigMonitorTests.cs
@@ -23,6 +23,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.UnitTests;

--- a/src/Integration.Vsix.UnitTests/Analysis/AnalysisRequesterTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/AnalysisRequesterTests.cs
@@ -22,7 +22,7 @@ using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.UnitTests;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests

--- a/src/Integration.Vsix.UnitTests/Analysis/AnalyzerControllerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/AnalyzerControllerTests.cs
@@ -22,11 +22,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using EnvDTE;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.UnitTests;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelperTests.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.VCProjectEngine;
 using Moq;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Integration.UnitTests;
 using SonarLint.VisualStudio.Integration.UnitTests.CFamily;

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyReproducerCommandTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyReproducerCommandTests.cs
@@ -25,7 +25,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Integration.UnitTests;
 using ThreadHelper = SonarLint.VisualStudio.Integration.UnitTests.ThreadHelper;

--- a/src/Integration.Vsix.UnitTests/CFamily/CLangAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CLangAnalyzerTests.cs
@@ -24,7 +24,7 @@ using EnvDTE;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Integration.UnitTests;
 

--- a/src/Integration.Vsix.UnitTests/ErrorList/IssuesSnapshotTests.cs
+++ b/src/Integration.Vsix.UnitTests/ErrorList/IssuesSnapshotTests.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Moq;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix;
 using DaemonSeverity = Sonarlint.Issue.Types.Severity;
 

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonAnalyzerTests.cs
@@ -18,14 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
-using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Integration.Vsix;
 using System;
 using System.ComponentModel;
 using System.Threading;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintDaemon
 {

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/DaemonAnalyzerTests.cs
@@ -21,6 +21,7 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Vsix;
 using System;
 using System.ComponentModel;

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/Helpers/DummySonarLintDaemon.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/Helpers/DummySonarLintDaemon.cs
@@ -18,13 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using EnvDTE;
-using SonarLint.VisualStudio.Integration.Vsix;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/Helpers/DummySonarLintDaemon.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/Helpers/DummySonarLintDaemon.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests

--- a/src/Integration.Vsix.UnitTests/SonarLintDaemon/SonarLintDaemonTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintDaemon/SonarLintDaemonTests.cs
@@ -25,7 +25,7 @@ using System.Threading;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Sonarlint;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
 using Daemon = SonarLint.VisualStudio.Integration.Vsix.SonarLintDaemon;

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueToFilterableIssueConverterTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueToFilterableIssueConverterTests.cs
@@ -24,7 +24,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/SonarLanguageRecognizerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/SonarLanguageRecognizerTests.cs
@@ -27,7 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/SonarLanguageRecognizerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/SonarLanguageRecognizerTests.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Vsix;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -31,7 +31,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -30,7 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;

--- a/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
+++ b/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
@@ -21,6 +21,7 @@
 using System;
 using System.ComponentModel.Composition;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Suppression;
 

--- a/src/Integration.Vsix/Analysis/AnalysisRequester.cs
+++ b/src/Integration.Vsix/Analysis/AnalysisRequester.cs
@@ -21,6 +21,7 @@
 using System;
 using System.ComponentModel.Composition;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
 {

--- a/src/Integration.Vsix/Analysis/AnalyzerController.cs
+++ b/src/Integration.Vsix/Analysis/AnalyzerController.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
 {

--- a/src/Integration.Vsix/Analysis/IAnalyzerController.cs
+++ b/src/Integration.Vsix/Analysis/IAnalyzerController.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
 {

--- a/src/Integration.Vsix/Analysis/IAnalyzerController.cs
+++ b/src/Integration.Vsix/Analysis/IAnalyzerController.cs
@@ -18,26 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using System.Threading;
 using SonarLint.VisualStudio.Core;
-
-// TODO: decide whether both of these interfaces are required
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
 {
-    public interface IAnalyzer
-    {
-        bool IsAnalysisSupported(IEnumerable<AnalysisLanguage> languages);
-
-        void ExecuteAnalysis(string path,
-            string charset,
-            IEnumerable<AnalysisLanguage> detectedLanguages,
-            IIssueConsumer consumer,
-            IAnalyzerOptions analyzerOptions,
-            CancellationToken cancellationToken);
-    }
-
     // Marker interface used by for MEF exporting/importing
     // (there are multiple implementations of IAnalyzer but only one implentation
     // of this interface).

--- a/src/Integration.Vsix/CFamily/CFamilyHelper.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyHelper.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Threading;
 using EnvDTE;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.CFamily;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.CFamily

--- a/src/Integration.Vsix/CFamily/CFamilyReproducerCommand.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyReproducerCommand.cs
@@ -26,6 +26,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.CFamily;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Integration.Vsix/CFamily/CLangAnalyzer.cs
+++ b/src/Integration.Vsix/CFamily/CLangAnalyzer.cs
@@ -28,9 +28,8 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.CFamily;
-using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using Task = System.Threading.Tasks.Task;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.CFamily

--- a/src/Integration.Vsix/ErrorList/IssuesSnapshot.cs
+++ b/src/Integration.Vsix/ErrorList/IssuesSnapshot.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/Helpers/IIssueConverter.cs
+++ b/src/Integration.Vsix/Helpers/IIssueConverter.cs
@@ -19,7 +19,7 @@
  */
 
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Helpers
 {

--- a/src/Integration.Vsix/Helpers/IssueConverter.cs
+++ b/src/Integration.Vsix/Helpers/IssueConverter.cs
@@ -20,7 +20,7 @@
 
 using System;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Helpers
 {

--- a/src/Integration.Vsix/SonarLintDaemon/DaemonAnalyzer.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/DaemonAnalyzer.cs
@@ -25,8 +25,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Integration.Vsix.Analysis;
+using SonarLint.VisualStudio.Core.Analysis;
 using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
 
 namespace SonarLint.VisualStudio.Integration.Vsix

--- a/src/Integration.Vsix/SonarLintDaemon/ISonarLintDaemon.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/ISonarLintDaemon.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintDaemon/ISonarLintDaemon.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/ISonarLintDaemon.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using SonarLint.VisualStudio.Integration.Vsix.Analysis;
+using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
+++ b/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Threading;
 using Grpc.Core;
 using Sonarlint;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;
 using DaemonIssueSeverity = Sonarlint.Issue.Types.Severity;
 using DaemonIssueType = Sonarlint.Issue.Types.Type;

--- a/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintTagger/ISonarLanguageRecognizer.cs
+++ b/src/Integration.Vsix/SonarLintTagger/ISonarLanguageRecognizer.cs
@@ -20,7 +20,7 @@
 
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintTagger/IssueMarker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueMarker.cs
@@ -19,7 +19,7 @@
  */
 
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintTagger/IssueToFilterableIssueConverter.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueToFilterableIssueConverter.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Suppression;
 

--- a/src/Integration.Vsix/SonarLintTagger/SonarLanguageRecognizer.cs
+++ b/src/Integration.Vsix/SonarLintTagger/SonarLanguageRecognizer.cs
@@ -25,7 +25,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintTagger/SonarLanguageRecognizer.cs
+++ b/src/Integration.Vsix/SonarLintTagger/SonarLanguageRecognizer.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
+using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -30,7 +30,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -24,7 +24,7 @@ using System.Diagnostics;
 using System.Linq;
 using EnvDTE;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppression;
 using SonarLint.VisualStudio.Integration.Vsix.Helpers;
 using SonarLint.VisualStudio.Integration.Vsix.Resources;

--- a/src/TestInfrastructure/DummyAnalysisIssue.cs
+++ b/src/TestInfrastructure/DummyAnalysisIssue.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {


### PR DESCRIPTION
Two commits:
1) moved IAnalyzer to Core
2)  moved the analysis types into a sub namespace called `SonarLint.VisualStudio.Core.Analysis` and fixed up code.

No product changes.
