### PR TITLE
Simplified IIssueTracker and IssueTagger

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
@@ -32,9 +32,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
     [TestClass]
     public class IssueTaggerTests
     {
-        private readonly IEnumerable<IssueMarker> ValidMarkerList = new[] { CreateValidMarker() };
-
-        private readonly SnapshotSpan ValidSnapshotSpan = new SnapshotSpan();
+        private static readonly IEnumerable<IssueMarker> ValidMarkerList = new[] { CreateValidMarker() };
+        private static readonly ITextSnapshot ValidTextSnapshot = Mock.Of<ITextSnapshot>();
+        private static readonly SnapshotSpan ValidSnapshotSpan = new SnapshotSpan(ValidTextSnapshot, 0, 0);
 
         [TestMethod]
         public void UpdateMarkers_NoSpan_EventNotRaised()
@@ -76,6 +76,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
         }
 
         [TestMethod]
+        public void GetTags_NullIssues_ReturnEmptyList()
+        {
+            var testSubject = new IssueTagger(null, null);
+            var normalizedSpans = new NormalizedSnapshotSpanCollection();
+
+            var result = testSubject.GetTags(normalizedSpans);
+
+            result.Should().BeEmpty();
+        }
+
+        [TestMethod]
         public void Dispose_CallsDelegateOnlyOnce()
         {
             var delegateCallCount = 0;
@@ -102,6 +113,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
         }
 
         private static IssueMarker CreateValidMarker() =>
-            new IssueMarker(Mock.Of<IAnalysisIssue>(), new SnapshotSpan());
+            new IssueMarker(Mock.Of<IAnalysisIssue>(), ValidSnapshotSpan);
     }
 }

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
@@ -87,6 +87,32 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
         }
 
         [TestMethod]
+        public void GetTags_HasIntersectingIssues_ReturnsIntersectingIssues()
+        {
+            var mockTextSnapshot = new Mock<ITextSnapshot>();
+            mockTextSnapshot.Setup(x => x.Length).Returns(100);
+
+            var span1 = new Span(0, 0);
+            var span2 = new Span(1, 1);
+
+            var snapshotSpan1 = new SnapshotSpan(mockTextSnapshot.Object, span1);
+            var snapshotSpan2 = new SnapshotSpan(mockTextSnapshot.Object, span2);
+
+            var marker1 = new IssueMarker(Mock.Of<IAnalysisIssue>(), snapshotSpan1);
+            var marker2 = new IssueMarker(Mock.Of<IAnalysisIssue>(), snapshotSpan2);
+
+            var markerList = new[] { marker1, marker2 };
+            var normalizedSpans = new NormalizedSnapshotSpanCollection(snapshotSpan2);
+
+            var testSubject = new IssueTagger(markerList, null);
+
+            var result = testSubject.GetTags(normalizedSpans);
+
+            result.Should().HaveCount(1);            
+            result.First().Span.Should().Be(snapshotSpan2);
+        }
+
+        [TestMethod]
         public void Dispose_CallsDelegateOnlyOnce()
         {
             var delegateCallCount = 0;

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Integration.Vsix;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
+{
+    [TestClass]
+    public class IssueTaggerTests
+    {
+        private readonly IEnumerable<IssueMarker> ValidMarkerList = new[] { CreateValidMarker() };
+
+        private readonly SnapshotSpan ValidSnapshotSpan = new SnapshotSpan();
+
+        [TestMethod]
+        public void UpdateMarkers_NoSpan_EventNotRaised()
+        {
+            var testSubject = new IssueTagger(null, null);
+
+            var eventRaised = false;
+            testSubject.TagsChanged += (sender, e) => eventRaised = true;
+
+            testSubject.UpdateMarkers(ValidMarkerList, null);
+
+            eventRaised.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void UpdateMarkers_NoIssues_EventRaised()
+        {
+            var testSubject = new IssueTagger(ValidMarkerList, null);
+
+            var eventRaised = false;
+            testSubject.TagsChanged += (sender, e) => eventRaised = true;
+
+            testSubject.UpdateMarkers(null, ValidSnapshotSpan);
+
+            eventRaised.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void UpdateMarkers_ValidIssuesAndSpan_EventRaised()
+        {
+            var testSubject = new IssueTagger(null, null);
+
+            var eventRaised = false;
+            testSubject.TagsChanged += (sender, e) => eventRaised = true;
+
+            testSubject.UpdateMarkers(ValidMarkerList, ValidSnapshotSpan);
+
+            eventRaised.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Dispose_CallsDelegateOnlyOnce()
+        {
+            var delegateCallCount = 0;
+            IssueTagger taggerArgument = null;
+            IssueTagger.OnTaggerDisposed onTaggerDisposed = x =>
+            {
+                delegateCallCount++;
+                taggerArgument = x;
+            };
+
+            var testSubject = new IssueTagger(Enumerable.Empty<IssueMarker>(), onTaggerDisposed);
+
+            // 1. Delegate not called before disposal
+            taggerArgument.Should().BeNull();
+
+            // 2. Called on disposal
+            testSubject.Dispose();
+            taggerArgument.Should().BeSameAs(testSubject);
+            delegateCallCount.Should().Be(1);
+
+            // 3. Not call on subsequent disposal
+            testSubject.Dispose();
+            delegateCallCount.Should().Be(1);
+        }
+
+        private static IssueMarker CreateValidMarker() =>
+            new IssueMarker(Mock.Of<IAnalysisIssue>(), new SnapshotSpan());
+    }
+}

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -153,7 +153,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Taggers should be different but tracker should be the same
             tagger1.Should().NotBeSameAs(tagger2);
-            tagger1.IssueTracker.Should().BeSameAs(tagger2.IssueTracker);
+            provider.ActiveTrackersForTesting.Count().Should().Be(1);
         }
 
         [TestMethod]
@@ -187,7 +187,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var tagger2 = CreateTaggerForDocument(doc2);
             tagger2.Should().NotBeNull();
 
-            tagger1.IssueTracker.Should().NotBeSameAs(tagger2.IssueTracker);
+            provider.ActiveTrackersForTesting.Count().Should().Be(2);
             tagger1.Should().NotBe(tagger2);
         }
 

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -71,13 +71,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         #region Triggering analysis tests
 
         [TestMethod]
-        public void WhenTaggerIsRegistered_AnalysisIsRequested()
+        public void WhenTaggerCreated_AnalysisIsRequested()
         {
             // 1. No tagger -> analysis not requested
             CheckAnalysisWasNotRequested();
 
             // 2. Add a tagger -> analysis requested
-            using (var tagger = new IssueTagger(testSubject))
+            using (testSubject.CreateTagger())
             {
                 mockAnalyzerController.Verify(x => x.ExecuteAnalysis("foo.js", "utf-8", new AnalysisLanguage[] { AnalysisLanguage.Javascript }, testSubject,
                     (IAnalyzerOptions)null /* no expecting any options when a new tagger is added */,
@@ -124,7 +124,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             CheckAnalysisWasNotRequested();
 
             // 2. Add a tagger and raise -> analysis requested
-            var tagger = new IssueTagger(testSubject);
+            var tagger = testSubject.CreateTagger();
             mockAnalyzerController.Invocations.Clear();
 
 
@@ -144,7 +144,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         [TestMethod]
         public void WhenFileIsLoaded_AnalysisIsNotRequested()
         {
-            using (var tagger = new IssueTagger(testSubject))
+            using (var tagger = testSubject.CreateTagger())
             {
                 mockAnalyzerController.Invocations.Clear();
 

--- a/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
@@ -24,8 +24,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 {
     internal interface IIssueTracker
     {
-        void AddTagger(IssueTagger tagger);
-        void RemoveTagger(IssueTagger tagger);
         IssuesSnapshot LastIssues { get; }
         string FilePath { get; }
         SnapshotFactory Factory { get; }

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -157,8 +157,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 var issueTracker = buffer.Properties.GetOrCreateSingletonProperty(typeof(IIssueTracker),
                     () => new TextBufferIssueTracker(dte, this, textDocument, detectedLanguages, logger, issuesFilter));
 
-                // Always create a new tagger for each request
-                return new IssueTagger(issueTracker) as ITagger<T>;
+                // Always create a new tagger for each request.
+                // Delegate the actual creation to the tracker for the file.
+                return issueTracker.CreateTagger() as ITagger<T>;
             }
 
             return null;

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -101,7 +101,15 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             document.FileActionOccurred += SafeOnFileActionOccurred;
         }
 
-        public void AddTagger(IssueTagger tagger)
+        public IssueTagger CreateTagger()
+        {
+            var tagger = new IssueTagger(this.Factory.CurrentSnapshot.IssueMarkers, RemoveTagger);
+            this.AddTagger(tagger);
+            
+            return tagger;
+        }
+
+        private void AddTagger(IssueTagger tagger)
         {
             Debug.Assert(!activeTaggers.Contains(tagger), "Not expecting the tagger to be already registered");
             activeTaggers.Add(tagger);
@@ -118,7 +126,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             }
         }
 
-        public void RemoveTagger(IssueTagger tagger)
+        private void RemoveTagger(IssueTagger tagger)
         {
             Debug.Assert(activeTaggers.Contains(tagger), "Not expecting RemoveTagger to be called for an unregistered tagger");
             activeTaggers.Remove(tagger);
@@ -211,7 +219,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             SnapshotSpan? affectedSpan = CalculateAffectedSpan(LastIssues, newIssues);
             foreach (var tagger in activeTaggers)
             {
-                tagger.UpdateMarkers(newIssues, affectedSpan);
+                tagger.UpdateMarkers(newIssues.IssueMarkers, affectedSpan);
             }
 
             this.LastIssues = newIssues;


### PR DESCRIPTION
* moved the responsibility for managing the taggers to the tracker
* removed dependency between the tagger and the tracker (dependency still exists the other way)
* added some tests for the tagger