### PR TITLE
Refactoring to TextBufferIssueTracker

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -192,23 +192,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void TaggerAdded_SonarErrorDataSourceIsNotified()
-        {
-            CreateTagger(jsContentType);
-            var trackers = provider.ActiveTrackersForTesting.ToArray();
-            trackers.Count().Should().Be(1); // sanity check
-
-            mockSonarErrorDataSource.Verify(x => x.AddFactory(trackers[0].Factory), Times.Once);
-        }
-
-        [TestMethod]
         public void RequestAnalysis_Should_NotThrow_When_AnalysisFails()
         {
             mockAnalysisScheduler
                 .Setup(x => x.Schedule("doc1.js", It.IsAny<Action<CancellationToken>>(), It.IsAny<int>()))
                 .Throws<Exception>();
 
-            Action act = () => 
+            Action act = () =>
             provider.RequestAnalysis("doc1.js", "", new []{AnalysisLanguage.CFamily}, null, null);
 
             act.Should().NotThrow();
@@ -222,7 +212,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var trackers = CreateMockedIssueTrackers("any", "any2");
 
             var actual = TaggerProvider.FilterIssuesTrackersByPath(trackers, filePaths);
-            
+
             actual.Should().BeEquivalentTo(trackers);
         }
 
@@ -284,7 +274,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private IIssueTracker[] CreateMockedIssueTrackers(params string[] filePaths) =>
             filePaths.Select(x => CreateMockedIssueTracker(x)).ToArray();
 
-        private IIssueTracker CreateMockedIssueTracker(string filePath)
+        private static IIssueTracker CreateMockedIssueTracker(string filePath)
         {
             var mock = new Mock<IIssueTracker>();
             mock.Setup(x => x.FilePath).Returns(filePath);

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -253,7 +253,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             SetupIssuesFilter(out var _);
 
             // Sanity check
-            testSubject.LastIssues.Should().BeNull();
             testSubject.Factory.CurrentSnapshot.VersionNumber.Should().Be(0);
             testSubject.Factory.CurrentSnapshot.IssueMarkers.Count().Should().Be(0);
 
@@ -263,7 +262,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Assert
             CheckErrorListRefreshWasRequested(1);
 
-            testSubject.LastIssues.Should().NotBeNull();
             testSubject.Factory.CurrentSnapshot.VersionNumber.Should().Be(1);
             testSubject.Factory.CurrentSnapshot.IssueMarkers.Count().Should().Be(2);
 

--- a/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
@@ -24,7 +24,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 {
     internal interface IIssueTracker
     {
-        IssuesSnapshot LastIssues { get; }
         string FilePath { get; }
         void RequestAnalysis(IAnalyzerOptions options);
     }

--- a/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IIssueTracker.cs
@@ -26,7 +26,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     {
         IssuesSnapshot LastIssues { get; }
         string FilePath { get; }
-        SnapshotFactory Factory { get; }
         void RequestAnalysis(IAnalyzerOptions options);
     }
 }

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -156,7 +156,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             {
                 // Multiple views could have that buffer open simultaneously, so only create one instance of the tracker.
                 var issueTracker = buffer.Properties.GetOrCreateSingletonProperty(typeof(IIssueTracker),
-                    () => new TextBufferIssueTracker(dte, this, textDocument, detectedLanguages, logger, issuesFilter));
+                    () => new TextBufferIssueTracker(dte, this, textDocument, detectedLanguages, issuesFilter, sonarErrorDataSource, logger));
 
                 // Always create a new tagger for each request.
                 // Delegate the actual creation to the tracker for the file.
@@ -192,7 +192,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             lock (issueTrackers)
             {
                 issueTrackers.Add(issueTracker);
-                sonarErrorDataSource.AddFactory(issueTracker.Factory);
             }
         }
 
@@ -201,13 +200,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             lock (issueTrackers)
             {
                 issueTrackers.Remove(issueTracker);
-                sonarErrorDataSource.RemoveFactory(issueTracker.Factory);
             }
-        }
-
-        public void RefreshErrorList()
-        {
-            sonarErrorDataSource.RefreshErrorList();
         }
     }
 }

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -61,8 +61,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         public string FilePath { get; private set; }
         internal /* for testing */ SnapshotFactory Factory { get; }
 
-        public IssuesSnapshot LastIssues { get; private set; }
-
         private readonly ISet<IssueTagger> activeTaggers = new HashSet<IssueTagger>();
 
         public TextBufferIssueTracker(DTE dte, TaggerProvider provider, ITextDocument document,
@@ -214,6 +212,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         private void SnapToNewSnapshot(IssuesSnapshot newIssues)
         {
+            var oldIssues = Factory.CurrentSnapshot;
+
             // Tell our factory to snap to a new snapshot.
             this.Factory.UpdateSnapshot(newIssues);
 
@@ -221,13 +221,11 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
             // Work out which part of the document has been affected by the changes, and tell
             // the taggers about the changes
-            SnapshotSpan? affectedSpan = CalculateAffectedSpan(LastIssues, newIssues);
+            SnapshotSpan? affectedSpan = CalculateAffectedSpan(oldIssues, newIssues);
             foreach (var tagger in activeTaggers)
             {
                 tagger.UpdateMarkers(newIssues.IssueMarkers, affectedSpan);
             }
-
-            this.LastIssues = newIssues;
         }
 
         private SnapshotSpan? CalculateAffectedSpan(IssuesSnapshot oldIssues, IssuesSnapshot newIssues)


### PR DESCRIPTION
* moved responsibility for registering with the error list from the TaggerProvider to the TextBufferIssueTracker
* removed unnecessary members from `IIssueTracker`