### PR TITLE
Refactor issue consumer to separate class

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/AccumulatingIssueConsumerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/AccumulatingIssueConsumerTests.cs
@@ -1,0 +1,182 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Integration.Vsix;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
+{
+    [TestClass]
+    public class AccumulatingIssueConsumerTests
+    {
+        private static readonly IAnalysisIssue ValidIssue = CreateIssue(startLine: 1, endline: 1);
+        private static readonly ITextSnapshot ValidTextSnapshot = CreateSnapshot(lineCount: 10);
+        private const string ValidFilePath = "c:\\myfile.txt";
+
+        [TestMethod]
+        public void Ctor_InvalidArgs_Throws()
+        {
+            AccumulatingIssueConsumer.OnIssuesChanged validCallback = _ => { };
+
+            Action act = () => new AccumulatingIssueConsumer(null, ValidFilePath, validCallback);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("analysisSnapshot");
+
+            act = () => new AccumulatingIssueConsumer(ValidTextSnapshot, null, validCallback);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("analysisFilePath");
+
+            act = () => new AccumulatingIssueConsumer(ValidTextSnapshot, ValidFilePath, null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("onIssuesChangedCallback");
+        }
+
+        [TestMethod]
+        public void Accept_WrongFile_CallbackIsNotCalled()
+        {
+            var callbackSpy = new OnIssuesChangedCallbackSpy();
+            var issues = new IAnalysisIssue[] { ValidIssue };
+
+            var testSubject = new AccumulatingIssueConsumer(ValidTextSnapshot, "c:\\file1.txt", callbackSpy.Callback);
+
+            using (new AssertIgnoreScope())
+            {
+                testSubject.Accept("wrong file", issues);
+            }
+
+            callbackSpy.CallCount.Should().Be(0);
+        }
+
+        [TestMethod]
+        [DataRow(-1, 10, false)] // start line < 1
+        [DataRow(0, 0, false)] // file-level issue, can't be mapped to snapshot
+        [DataRow(1, 1, true)] // starts in first line of snapshot
+        [DataRow(9, 10, true)] // in snapshot
+        [DataRow(10, 10, true)] // end is in last line of snapshot
+        [DataRow(10, 11, false)] // end is outside snapshot
+        [DataRow(11, 11, false)] // ditto
+        [DataRow(99, 99, false)] // ditto
+        public void Accept_IssuesNotInSnapshotAreIgnored_CallbackIsCalledWithExpectedIssues(int oneBasedIssueStartLine, int oneBasedIssueEndLine, bool isMappableToSnapshot)
+        {
+            const int LinesInSnapshot = 10;
+            var snapshot = CreateSnapshot(LinesInSnapshot);
+            var issues = new[] { CreateIssue(oneBasedIssueStartLine, oneBasedIssueEndLine) };
+
+            var callbackSpy = new OnIssuesChangedCallbackSpy();
+            var converter = CreateWrapAllConverter();
+
+            var testSubject = new AccumulatingIssueConsumer(snapshot, ValidFilePath, callbackSpy.Callback, converter);
+
+            using (new AssertIgnoreScope())
+            {
+                testSubject.Accept(ValidFilePath, issues);
+            }
+
+            callbackSpy.CallCount.Should().Be(1);
+            if (isMappableToSnapshot)
+            {
+                callbackSpy.LastSuppliedIssues.Should().BeEquivalentTo(issues);
+            }
+            else
+            {
+                callbackSpy.LastSuppliedMarkers.Should().BeEmpty();
+            }
+        }
+
+        [TestMethod]
+        public void Accept_MultipleCallsToAccept_IssuesAreAccumulated()
+        {
+            var callbackSpy = new OnIssuesChangedCallbackSpy();
+            var firstSetOfIssues = new[]
+            {
+                CreateIssue(1, 1), CreateIssue(2, 2)
+            };
+
+            var secondSetOfIssues = new[]
+            {
+                CreateIssue(3,3), CreateIssue(4,4)
+            };
+
+            var snapshot = CreateSnapshot(lineCount: 10);
+            var converter = CreateWrapAllConverter();
+
+            var testSubject = new AccumulatingIssueConsumer(snapshot, ValidFilePath, callbackSpy.Callback, converter);
+
+            // 1. First call
+            testSubject.Accept(ValidFilePath, firstSetOfIssues);
+
+            callbackSpy.CallCount.Should().Be(1);
+            callbackSpy.LastSuppliedIssues.Should().BeEquivalentTo(firstSetOfIssues);
+
+            // 2. Second call
+            testSubject.Accept(ValidFilePath, secondSetOfIssues);
+
+            callbackSpy.CallCount.Should().Be(2);
+            callbackSpy.LastSuppliedIssues.Should().BeEquivalentTo(firstSetOfIssues.Union(secondSetOfIssues));
+        }
+
+        private class OnIssuesChangedCallbackSpy
+        {
+            public int CallCount { get; private set; }
+            public IList<IssueMarker> LastSuppliedMarkers { get; private set; }
+            public IList<IAnalysisIssue> LastSuppliedIssues
+            {
+                get
+                {
+                    return LastSuppliedMarkers?.Select(x => x.Issue).ToList();
+                }
+            }
+
+            public void Callback(IEnumerable<IssueMarker> issueMarkers)
+            {
+                CallCount++;
+                LastSuppliedMarkers = issueMarkers?.ToList();
+            }
+        }
+
+        private static ITextSnapshot CreateSnapshot(int lineCount)
+        {
+            var mockSnapshot = new Mock<ITextSnapshot>();
+            mockSnapshot.Setup(x => x.LineCount).Returns(lineCount);
+            return mockSnapshot.Object;
+        }
+
+        private static IAnalysisIssue CreateIssue(int startLine, int endline) =>
+            new DummyAnalysisIssue
+            {
+                StartLine = startLine,
+                EndLine = endline,
+                Message = "any message"
+            };
+
+        private static IIssueToIssueMarkerConverter CreateWrapAllConverter()
+        {
+            // Set up an issue converter that just wraps and returns the supplied issues as IssueMarkers
+            var mockIssueConverter = new Mock<IIssueToIssueMarkerConverter>();
+            mockIssueConverter.Setup(x => x.Convert(It.IsAny<IAnalysisIssue>(), It.IsAny<ITextSnapshot>()))
+                .Returns<IAnalysisIssue, ITextSnapshot>((issue, snapshot) => new IssueMarker(issue, new SnapshotSpan(), null, null));
+            return mockIssueConverter.Object;
+        }
+    }
+}

--- a/src/Integration.Vsix/SonarLintTagger/AccumulatingIssueConsumer.cs
+++ b/src/Integration.Vsix/SonarLintTagger/AccumulatingIssueConsumer.cs
@@ -32,7 +32,7 @@ using SonarLint.VisualStudio.Core.Analysis;
  * at the point the analysis was triggered ("the analysis snaphost").
  * 
  * Each time IIssueConsumer.Accept is called, the new issues will be mapped back to the
- * analysis snapshot and decorated with the additional data required for filtering and tagging.s
+ * analysis snapshot and decorated with the additional data required for filtering and tagging.
  * Then, all of the issues that have been received that habe been received so far will be
  * passed to the OnIssuesChanged delegate.
  * 

--- a/src/Integration.Vsix/SonarLintTagger/AccumulatingIssueConsumer.cs
+++ b/src/Integration.Vsix/SonarLintTagger/AccumulatingIssueConsumer.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using SonarLint.VisualStudio.Core.Analysis;
+
+/* 
+ * Instancing: a new instance of this class should be created for each analysis request.
+ * 
+ * The class is initialized with the text snapshot representing the state of the text buffer
+ * at the point the analysis was triggered ("the analysis snaphost").
+ * 
+ * Each time IIssueConsumer.Accept is called, the new issues will be mapped back to the
+ * analysis snapshot and decorated with the additional data required for filtering and tagging.s
+ * Then, all of the issues that have been received that habe been received so far will be
+ * passed to the OnIssuesChanged delegate.
+ * 
+ * However, it's possible that the text buffer could have been edited since the analysis
+ * was triggered. It is the responsibity of the callback to translate to supplied IssueMarkers
+ * to the current snapshot, if necessary.
+ * 
+ * 
+ * Mapping from reported issue line/char positions to the analysis snapshot
+ * ------------------------------------------------------------------------
+ * Currently, the JS/CFamily analyzers run against the file on disc, not the content of 
+ * the snapshot. We're making a couple of assumptions:
+ * 1) we're triggering analysis on save, so the state of the text buffer matches the file on disc, and
+ * 2) the file won't have had time to change again before the analyzer reads it so we expect always to
+ *    be able to map back from the reported issue to the snapshot.
+ * However, we code defensively and strip out any issues that can't be mapped to the analysis snapshot.
+ * 
+ */
+
+namespace SonarLint.VisualStudio.Integration.Vsix
+{
+    /// <summary>
+    /// Handles processing the issues for a single analysis request
+    /// </summary>
+    internal class AccumulatingIssueConsumer : IIssueConsumer
+    {
+        // See bug #1487: this text snapshot should match the content of the file being analysed
+        private readonly ITextSnapshot analysisSnapshot;
+        private readonly IIssueToIssueMarkerConverter issueMarkerConverter;
+        private readonly List<IssueMarker> allIssueMarkers;
+        private readonly string analysisFilePath;
+        private readonly OnIssuesChanged onIssuesChanged;
+
+        public delegate void OnIssuesChanged(IEnumerable<IssueMarker> issueMarkers);
+
+        public AccumulatingIssueConsumer(ITextSnapshot analysisSnapshot, string analysisFilePath, OnIssuesChanged onIssuesChangedCallback)
+            : this(analysisSnapshot, analysisFilePath, onIssuesChangedCallback, new IssueToIssueMarkerConverter())
+        {
+        }
+
+        internal /* for testing */ AccumulatingIssueConsumer(ITextSnapshot analysisSnapshot, string analysisFilePath, OnIssuesChanged onIssuesChangedCallback,
+            IIssueToIssueMarkerConverter issueMarkerConverter)
+        {
+            this.analysisSnapshot = analysisSnapshot ?? throw new ArgumentNullException(nameof(analysisSnapshot));
+            this.analysisFilePath = analysisFilePath ?? throw new ArgumentNullException(nameof(analysisFilePath));
+            this.onIssuesChanged = onIssuesChangedCallback ?? throw new ArgumentNullException(nameof(onIssuesChangedCallback));
+
+            this.issueMarkerConverter = issueMarkerConverter ?? throw new ArgumentNullException(nameof(analysisSnapshot));
+
+            allIssueMarkers = new List<IssueMarker>();
+        }
+
+        public void Accept(string path, IEnumerable<IAnalysisIssue> issues)
+        {
+            // Callback from the daemon when new results are available
+            if (path != analysisFilePath)
+            {
+                Debug.Fail("Issues returned for an unexpected file path");
+                return;
+            }
+
+            Debug.Assert(issues.All(IsIssueInAnalysisSnapshot), "Not all reported issues could be mapped to the analysis snapshot");
+
+            var newMarkers = issues
+                .Where(IsIssueInAnalysisSnapshot)
+                .Select(x => issueMarkerConverter.Convert(x, analysisSnapshot))
+                .ToArray();
+
+            allIssueMarkers.AddRange(newMarkers);
+
+            onIssuesChanged.Invoke(allIssueMarkers);
+        }
+
+        /// <summary>
+        /// Checks that the analysis issue can be mapped to location in the text snapshot.
+        /// </summary>
+        private bool IsIssueInAnalysisSnapshot(IAnalysisIssue issue) =>
+            // Sonar issues line numbers are 1-based; 0 = file-level issue
+            // Spans lines are 0-based
+            1 <= issue.StartLine && issue.EndLine <= analysisSnapshot.LineCount;
+    }
+}

--- a/src/Integration.Vsix/SonarLintTagger/AccumulatingIssueConsumer.cs
+++ b/src/Integration.Vsix/SonarLintTagger/AccumulatingIssueConsumer.cs
@@ -29,26 +29,28 @@ using SonarLint.VisualStudio.Core.Analysis;
  * Instancing: a new instance of this class should be created for each analysis request.
  * 
  * The class is initialized with the text snapshot representing the state of the text buffer
- * at the point the analysis was triggered ("the analysis snaphost").
+ * at the point the analysis was triggered.
+ * 
+ * The job of the class is to:
+ * 1) map the issue start/end positions supplied by the analyzer to spans in the supplied text snapshot, and 
+ * 2) accumulate the list of issues that have return by the analyzer so far
  * 
  * Each time IIssueConsumer.Accept is called, the new issues will be mapped back to the
- * analysis snapshot and decorated with the additional data required for filtering and tagging.
- * Then, all of the issues that have been received that habe been received so far will be
- * passed to the OnIssuesChanged delegate.
+ * supplied snapshot and decorated with the additional data required for filtering and tagging.
+ * Then, all of the issues that have been received so far will be passed to the OnIssuesChanged delegate.
  * 
  * However, it's possible that the text buffer could have been edited since the analysis
- * was triggered. It is the responsibity of the callback to translate to supplied IssueMarkers
- * to the current snapshot, if necessary.
+ * was triggered. It is the responsibity of the callback to translate the supplied IssueMarkers
+ * to the current text buffer snapshot, if necessary.
  * 
  * 
  * Mapping from reported issue line/char positions to the analysis snapshot
  * ------------------------------------------------------------------------
  * Currently, the JS/CFamily analyzers run against the file on disc, not the content of 
- * the snapshot. We're making a couple of assumptions:
- * 1) we're triggering analysis on save, so the state of the text buffer matches the file on disc, and
- * 2) the file won't have had time to change again before the analyzer reads it so we expect always to
- *    be able to map back from the reported issue to the snapshot.
- * However, we code defensively and strip out any issues that can't be mapped to the analysis snapshot.
+ * the snapshot. We're assuming that analysis is triggered on save so the state of the
+ * text snapshot matches the file on disc which is being analyzed.
+ * We expect always to be able to map back from the reported issue to the snapshot.
+ * However, we code defensively and strip out any issues that can't be mapped.
  * 
  */
 

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -244,6 +244,11 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         public void RequestAnalysis(IAnalyzerOptions options)
         {
             var issueConsumer = new AccumulatingIssueConsumer(currentSnapshot, FilePath, HandleNewIssues);
+
+            // Call the consumer with no analysis issues to immediately clear issies for this file
+            // from the error list
+            issueConsumer.Accept(FilePath, Enumerable.Empty<IAnalysisIssue>());
+
             Provider.RequestAnalysis(FilePath, charset, detectedLanguages, issueConsumer, options);
         }
 


### PR DESCRIPTION
Relates to #1471
Fixes #1487

* separate issue consumer into separate class
* translate spans from the analysis snapshot to the current snapshot
* minor refactoring of buffer handling code
* added unit test for buffer handling code

TODO: change the CLangAnalyzer to actually stream the issues...