### PR TITLE
Automatically update the asmref baseline when building in the IDE

### DIFF
--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -409,6 +409,9 @@
        to update the baseline file, then check in the updated baseline with the rest of your changes.
   -->
   <PropertyGroup>
+    <!-- By default update the baseline when building in the IDE (simplifies development when working on new code) -->
+    <AsmRefUpdateBaseline Condition="$(AsmRefUpdateBaseline)=='' AND $(BuildingInsideVisualStudio)=='true'">true</AsmRefUpdateBaseline>
+    
     <!-- Only check the VS2019 build -->
     <AsmRefDisableBaselining Condition=" $(VersionSpecificSuffix) != '2019' ">true</AsmRefDisableBaselining>
     


### PR DESCRIPTION
I'm in two minds about whether auto-updating the baseline during development defeats the point of having the AsmRef checking. On balance I think it's ok since we should notice that the baseline has been updated and decide whether or not to commit the changes.