### PR TITLE
Removed tagging functionality from TextBufferIssueTracker

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueTaggerTests.cs
@@ -88,32 +88,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger
         }
 
         [TestMethod]
-        public void GetTags_HasIntersectingIssues_ReturnsIntersectingIssues()
-        {
-            var mockTextSnapshot = new Mock<ITextSnapshot>();
-            mockTextSnapshot.Setup(x => x.Length).Returns(100);
-
-            var span1 = new Span(0, 0);
-            var span2 = new Span(1, 1);
-
-            var snapshotSpan1 = new SnapshotSpan(mockTextSnapshot.Object, span1);
-            var snapshotSpan2 = new SnapshotSpan(mockTextSnapshot.Object, span2);
-
-            var marker1 = new IssueMarker(CreateIssueViz(), snapshotSpan1);
-            var marker2 = new IssueMarker(CreateIssueViz(), snapshotSpan2);
-
-            var markerList = new[] { marker1, marker2 };
-            var normalizedSpans = new NormalizedSnapshotSpanCollection(snapshotSpan2);
-
-            var testSubject = new IssueTagger(markerList, null);
-
-            var result = testSubject.GetTags(normalizedSpans);
-
-            result.Should().HaveCount(1);
-            result.First().Span.Should().Be(snapshotSpan2);
-        }
-
-        [TestMethod]
         public void Dispose_CallsDelegateOnlyOnce()
         {
             var delegateCallCount = 0;

--- a/src/Integration.Vsix/SonarLintTagger/IssueTagger.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueTagger.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Tagging;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
@@ -76,14 +75,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         {
             Debug.Assert(!isDisposed, "Not expecting GetTags to be called after the tagger has been disposed");
 
-            if (issueMarkers == null)
-            {
-                return Enumerable.Empty<ITagSpan<IErrorTag>>();
-            }
-
-            return issueMarkers
-                .Where(marker => spans.IntersectsWith(marker.Span))
-                .Select(marker => new TagSpan<IErrorTag>(marker.Span, new ErrorTag(PredefinedErrorTypeNames.Warning, marker.Issue.Message)));
+            // TODO: remove this class completely
+            // Tagging will be handled by a different set of classes
+            return Enumerable.Empty<ITagSpan<IErrorTag>>();
         }
     }
 }


### PR DESCRIPTION
The TextBufferIssueTracker is now only responsible for triggering analysis (when the doc is opened, saved, or analysis requested because the user settings have changed).

TODO: more cleanup