### PR TITLE
Change IsNavigable to rely on SnapshotSpan

### DIFF
--- a/src/Core/WPF/AggregatorValueConverter.cs
+++ b/src/Core/WPF/AggregatorValueConverter.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Data;
+
+namespace SonarLint.VisualStudio.Core.WPF
+{
+    /// <summary>
+    /// https://riptutorial.com/wpf/example/16146/group-multiple-converters--ivalueconverter-
+    /// </summary>
+    public class AggregatorValueConverter : List<IValueConverter>, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueToIssueMarkerConverterTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/IssueToIssueMarkerConverterTests.cs
@@ -57,13 +57,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void Convert_NullSpan_Null()
+        public void Convert_EmptySpan_Null()
         {
             var mockIssue = Mock.Of<IAnalysisIssue>();
             var mockSnapshot = Mock.Of<ITextSnapshot>();
 
             var spanCalculator = new Mock<IIssueSpanCalculator>();
-            spanCalculator.Setup(x => x.CalculateSpan(mockIssue, mockSnapshot)).Returns((SnapshotSpan?) null);
+            spanCalculator.Setup(x => x.CalculateSpan(mockIssue, mockSnapshot)).Returns(new SnapshotSpan());
             
             var testSubject = new IssueToIssueMarkerConverter(Mock.Of<IAnalysisIssueVisualizationConverter>(), spanCalculator.Object);
             var issueMarker = testSubject.Convert(mockIssue, mockSnapshot);
@@ -72,18 +72,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void Convert_SpanIsNotNull_ReturnsMarkerWithSpan()
+        public void Convert_SpanIsNotEmpty_ReturnsMarkerWithSpan()
         {
             var mockIssue = Mock.Of<IAnalysisIssue>();
-            var mockSnapshot = Mock.Of<ITextSnapshot>();
-            var mockSpan = new SnapshotSpan();
+            var mockSnapshot = new Mock<ITextSnapshot>();
+            mockSnapshot.SetupGet(x => x.Length).Returns(20);
+            var mockSpan = new SnapshotSpan(mockSnapshot.Object, 0, 10);
 
             var spanCalculator = new Mock<IIssueSpanCalculator>();
-            spanCalculator.Setup(x => x.CalculateSpan(mockIssue, mockSnapshot)).Returns(mockSpan);
+            spanCalculator.Setup(x => x.CalculateSpan(mockIssue, mockSnapshot.Object)).Returns(mockSpan);
             var passThroughConverter = CreatePassthroughConverter();
 
             var testSubject = new IssueToIssueMarkerConverter(passThroughConverter, spanCalculator.Object);
-            var issueMarker = testSubject.Convert(mockIssue, mockSnapshot);
+            var issueMarker = testSubject.Convert(mockIssue, mockSnapshot.Object);
 
             issueMarker.Should().NotBeNull();
             issueMarker.Issue.Should().Be(mockIssue);

--- a/src/Integration.Vsix/SonarLintTagger/IssueToIssueMarkerConverter.cs
+++ b/src/Integration.Vsix/SonarLintTagger/IssueToIssueMarkerConverter.cs
@@ -62,8 +62,14 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
             var span = issueSpanCalculator.CalculateSpan(issue, textSnapshot);
 
+            if (span.IsEmpty)
+            {
+                return null;
+            }
+
             var issueViz = issueVizConverter.Convert(issue);
-            return span == null ? null : new IssueMarker(issueViz, span.Value);
+
+            return new IssueMarker(issueViz, span);
         }
     }
 }

--- a/src/IssueViz.UnitTests/Editor/IssueSpanCalculatorTests.cs
+++ b/src/IssueViz.UnitTests/Editor/IssueSpanCalculatorTests.cs
@@ -55,7 +55,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
         [DataTestMethod]
         [DataRow(100, 1)]
         [DataRow(101, 100)]
-        public void CalculateSpan_IssueStartLineIsOutsideOfSnapshot_ReturnsNull(int issueStartLine, int bufferLineCount)
+        public void CalculateSpan_IssueStartLineIsOutsideOfSnapshot_ReturnsEmptySpan(int issueStartLine, int bufferLineCount)
         {
             // Arrange
             var issue = new DummyAnalysisIssue { StartLine = issueStartLine };
@@ -63,13 +63,13 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
 
             // Act and assert
             var result = testSubject.CalculateSpan(issue, mockSnapshot.Object);
-            result.Should().BeNull();
+            result.IsEmpty.Should().BeTrue();
 
             checksumCalculatorMock.VerifyNoOtherCalls();
         }
 
         [TestMethod]
-        public void CalculateSpan_IssueLineHashIsDifferent_ReturnsNull()
+        public void CalculateSpan_IssueLineHashIsDifferent_ReturnsEmptySpan()
         {
             var issue = new DummyAnalysisIssue { StartLine = 10, LineHash = "some hash" };
 
@@ -86,7 +86,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             checksumCalculatorMock.Setup(x => x.Calculate(startLine.Text)).Returns("some other hash");
 
             var result = testSubject.CalculateSpan(issue, mockSnapshot.Object);
-            result.Should().BeNull();
+            result.IsEmpty.Should().BeTrue();
 
             checksumCalculatorMock.VerifyAll();
         }
@@ -127,9 +127,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             var result = testSubject.CalculateSpan(issue, textSnapshotMock.Object);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Value.Start.Position.Should().Be(45); // firstLine.LineStartPosition + issue.StartLineOffset
-            result.Value.End.Position.Should().Be(67); // secondLine.LineStartPosition + issue.EndLineOffset
+            result.IsEmpty.Should().BeFalse();
+            result.Start.Position.Should().Be(45); // firstLine.LineStartPosition + issue.StartLineOffset
+            result.End.Position.Should().Be(67); // secondLine.LineStartPosition + issue.EndLineOffset
         }
 
         [TestMethod]
@@ -171,9 +171,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             var result = testSubject.CalculateSpan(issue, textSnapshotMock.Object);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Value.Start.Position.Should().Be(103); // firstLine.LineStartPosition. Ignore issue.StartLineOffset in this case
-            result.Value.End.Position.Should().Be(137); // firstLine.LineStartPosition +  firstLine.LineLength
+            result.IsEmpty.Should().BeFalse();
+            result.Start.Position.Should().Be(103); // firstLine.LineStartPosition. Ignore issue.StartLineOffset in this case
+            result.End.Position.Should().Be(137); // firstLine.LineStartPosition +  firstLine.LineLength
         }
 
         [TestMethod]
@@ -216,9 +216,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             var result = testSubject.CalculateSpan(issue, textSnapshotMock.Object);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Value.Start.Position.Should().Be(1599); // firstLine.LineStartPosition. Ignore offset because that will take us beyond the end of file
-            result.Value.End.Position.Should().Be(1600); // snapshot length
+            result.IsEmpty.Should().BeFalse();
+            result.Start.Position.Should().Be(1599); // firstLine.LineStartPosition. Ignore offset because that will take us beyond the end of file
+            result.End.Position.Should().Be(1600); // snapshot length
         }
 
         [TestMethod]
@@ -255,9 +255,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             var result = testSubject.CalculateSpan(issue, textSnapshotMock.Object);
 
             // Assert
-            result.Should().NotBeNull();
-            result.Value.Start.Position.Should().Be(1601); // vsLine.LineStartPosition + issue.StartLineOffset
-            result.Value.End.Position.Should().Be(1602); // snapshot length
+            result.IsEmpty.Should().BeFalse();
+            result.Start.Position.Should().Be(1601); // vsLine.LineStartPosition + issue.StartLineOffset
+            result.End.Position.Should().Be(1602); // snapshot length
         }
 
         [TestMethod]
@@ -287,7 +287,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             // Act
             var result = testSubject.CalculateSpan(issue, textSnapshotMock.Object);
 
-            result.Should().NotBeNull();
+            result.IsEmpty.Should().BeFalse();
 
             checksumCalculatorMock.VerifyNoOtherCalls();
         }

--- a/src/IssueViz.UnitTests/IssueVisualizationControl/IssueVisualizationViewModelTests.cs
+++ b/src/IssueViz.UnitTests/IssueVisualizationControl/IssueVisualizationViewModelTests.cs
@@ -574,21 +574,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.IssueVisualization
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
-        public void SelectionService_OnLocationChanged_NewLocationIsNotNull_NavigabilityUpdated(bool navigationSucceeded)
+        public void SelectionService_OnLocationChanged_NewLocationIsNotNull_NavigationToLocation()
         {
             var locationViz = CreateMockLocation("c:\\test\\c1.c");
-            locationViz.IsNavigable = !navigationSucceeded;
-
-            locationNavigatorMock.Setup(x => x.TryNavigate(locationViz.Location)).Returns(navigationSucceeded);
 
             var selectedFlow = new Mock<IAnalysisIssueFlowVisualization>();
             selectedFlow.Setup(x => x.Locations).Returns(new[] {locationViz});
 
             RaiseSelectionChangedEvent(SelectionChangeLevel.Flow, null, selectedFlow.Object, locationViz);
 
-            locationViz.IsNavigable.Should().Be(navigationSucceeded);
+            locationNavigatorMock.Verify(x => x.TryNavigate(locationViz), Times.Once);
         }
 
         #endregion
@@ -644,7 +639,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.IssueVisualization
             var locationViz = new Mock<IAnalysisIssueLocationVisualization>();
             locationViz.Setup(x => x.Location).Returns(Mock.Of<IAnalysisIssueLocation>());
             locationViz.Setup(x => x.CurrentFilePath).Returns(filePath);
-            locationViz.SetupProperty(x => x.IsNavigable);
 
             return locationViz.Object;
         }

--- a/src/IssueViz.UnitTests/IssueVisualizationControl/SpanToNavigabilityConverterTests.cs
+++ b/src/IssueViz.UnitTests/IssueVisualizationControl/SpanToNavigabilityConverterTests.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl;
+
+namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.IssueVisualizationControl
+{
+    [TestClass]
+    public class SpanToNavigabilityConverterTests
+    {
+        [TestMethod]
+        public void ConvertBack_NotImplementedException()
+        {
+            Action act = () => new SpanToNavigabilityConverter().ConvertBack(null, null, null, null);
+
+            act.Should().Throw<NotImplementedException>("ConvertBack is not required");
+        }
+
+        [TestMethod]
+        public void Convert_NullSpan_True()
+        {
+            var testSubject = new SpanToNavigabilityConverter();
+            var result = testSubject.Convert(null, null, null, null);
+
+            result.Should().Be(true);
+        }
+
+        [TestMethod]
+        public void Convert_EmptySpan_False()
+        {
+            var testSubject = new SpanToNavigabilityConverter();
+            var result = testSubject.Convert(new SnapshotSpan(), null, null, null);
+
+            result.Should().Be(false);
+        }
+
+        [TestMethod]
+        public void Convert_NonEmptySpan_True()
+        {
+            var textSnapshotMock = new Mock<ITextSnapshot>();
+            textSnapshotMock.SetupGet(x => x.Length).Returns(20);
+            var span = new SnapshotSpan(textSnapshotMock.Object, new Span(0, 10));
+
+            var testSubject = new SpanToNavigabilityConverter();
+            var result = testSubject.Convert(span, null, null, null);
+
+            result.Should().Be(true);
+        }
+    }
+}

--- a/src/IssueViz.UnitTests/Models/AnalysisIssueLocationVisualizationExtensionsTests.cs
+++ b/src/IssueViz.UnitTests/Models/AnalysisIssueLocationVisualizationExtensionsTests.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+
+namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Models
+{
+    [TestClass]
+    public class AnalysisIssueLocationVisualizationExtensionsTests
+    {
+        [TestMethod]
+        public void IsNavigable_NoSpan_True()
+        {
+            var locationViz = new Mock<IAnalysisIssueLocationVisualization>();
+            locationViz.SetupGet(x => x.Span).Returns((SnapshotSpan?) null);
+
+            var result = locationViz.Object.IsNavigable();
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsNavigable_EmptySpan_False()
+        {
+            var locationViz = new Mock<IAnalysisIssueLocationVisualization>();
+            locationViz.SetupGet(x => x.Span).Returns(new SnapshotSpan());
+
+            var result = locationViz.Object.IsNavigable();
+            result.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsNavigable_NonEmptySpan_True()
+        {
+            var mockTextSnapshot = new Mock<ITextSnapshot>();
+            mockTextSnapshot.SetupGet(x => x.Length).Returns(20);
+            var nonEmptySpan = new SnapshotSpan(mockTextSnapshot.Object, new Span(0, 10));
+
+            var locationViz = new Mock<IAnalysisIssueLocationVisualization>();
+            locationViz.SetupGet(x => x.Span).Returns(nonEmptySpan);
+
+            var result = locationViz.Object.IsNavigable();
+            result.Should().BeTrue();
+        }
+    }
+}

--- a/src/IssueViz.UnitTests/Models/AnalysisIssueLocationVisualizationTests.cs
+++ b/src/IssueViz.UnitTests/Models/AnalysisIssueLocationVisualizationTests.cs
@@ -1,0 +1,137 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.ComponentModel;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+
+namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Models
+{
+    [TestClass]
+    public class AnalysisIssueLocationVisualizationTests
+    {
+        [TestMethod]
+        public void Ctor_StepNumberIsSet()
+        {
+            var testSubject = CreateTestSubject(stepNumber: 20);
+
+            testSubject.StepNumber.Should().Be(20);
+        }
+
+        [TestMethod]
+        public void Ctor_InitialFilePathIsTakenFromIssueLocation()
+        {
+            var testSubject = CreateTestSubject(filePath: "test path");
+
+            testSubject.CurrentFilePath.Should().Be("test path");
+        }
+
+        [TestMethod]
+        public void Ctor_InitialSpanIsNull()
+        {
+            var testSubject = CreateTestSubject();
+
+            testSubject.Span.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void SetCurrentFilePath_NoSubscribers_NoException()
+        {
+            var testSubject = CreateTestSubject();
+
+            Action act = () => testSubject.CurrentFilePath = "new path";
+            act.Should().NotThrow();
+
+            testSubject.CurrentFilePath.Should().Be("new path");
+        }
+
+        [TestMethod]
+        public void SetCurrentFilePath_HasSubscribers_NotifiesSubscribers()
+        {
+            var propertyChangedEventHandler = new Mock<PropertyChangedEventHandler>();
+
+            var testSubject = CreateTestSubject();
+            testSubject.PropertyChanged += propertyChangedEventHandler.Object;
+
+            testSubject.CurrentFilePath = "new path";
+
+            propertyChangedEventHandler.Verify(x =>
+                    x(It.IsAny<object>(), It.Is((PropertyChangedEventArgs e) => e.PropertyName == nameof(IAnalysisIssueLocationVisualization.CurrentFilePath))),
+                Times.Once);
+
+            propertyChangedEventHandler.VerifyNoOtherCalls();
+
+            testSubject.CurrentFilePath.Should().Be("new path");
+        }
+
+        [TestMethod]
+        public void SetSpan_NoSubscribers_NoException()
+        {
+            var newSpan = CreateSpan();
+            var testSubject = CreateTestSubject();
+
+            Action act = () => testSubject.Span = newSpan;
+            act.Should().NotThrow();
+
+            testSubject.Span.Should().Be(newSpan);
+        }
+
+        [TestMethod]
+        public void SetSpan_HasSubscribers_NotifiesSubscribers()
+        {
+            var newSpan = CreateSpan();
+            var propertyChangedEventHandler = new Mock<PropertyChangedEventHandler>();
+
+            var testSubject = CreateTestSubject();
+            testSubject.PropertyChanged += propertyChangedEventHandler.Object;
+
+            testSubject.Span = newSpan;
+
+            propertyChangedEventHandler.Verify(x =>
+                    x(It.IsAny<object>(), It.Is((PropertyChangedEventArgs e) => e.PropertyName == nameof(IAnalysisIssueLocationVisualization.Span))),
+                Times.Once);
+
+            propertyChangedEventHandler.VerifyNoOtherCalls();
+
+            testSubject.Span.Should().Be(newSpan);
+        }
+
+        private SnapshotSpan CreateSpan()
+        {
+            var mockTextSnapshot = new Mock<ITextSnapshot>();
+            mockTextSnapshot.SetupGet(x => x.Length).Returns(20);
+
+            return new SnapshotSpan(mockTextSnapshot.Object, new Span(0, 10));
+        }
+
+        private AnalysisIssueLocationVisualization CreateTestSubject(int stepNumber = 1, string filePath = null)
+        {
+            var issueLocation = new Mock<IAnalysisIssueLocation>();
+            issueLocation.SetupGet(x => x.FilePath).Returns(filePath);
+
+            return new AnalysisIssueLocationVisualization(stepNumber, issueLocation.Object);
+        }
+    }
+}

--- a/src/IssueViz.UnitTests/Models/AnalysisIssueVisualizationTests.cs
+++ b/src/IssueViz.UnitTests/Models/AnalysisIssueVisualizationTests.cs
@@ -1,0 +1,137 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.ComponentModel;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+
+namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Models
+{
+    [TestClass]
+    public class AnalysisIssueVisualizationTests
+    {
+        [TestMethod]
+        public void Ctor_StepNumberIsZero()
+        {
+            var testSubject = CreateTestSubject();
+
+            testSubject.StepNumber.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void Ctor_InitialFilePathIsTakenFromIssue()
+        {
+            var testSubject = CreateTestSubject(filePath: "test path");
+
+            testSubject.CurrentFilePath.Should().Be("test path");
+        }
+
+        [TestMethod]
+        public void Ctor_InitialSpanIsNull()
+        {
+            var testSubject = CreateTestSubject();
+
+            testSubject.Span.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void SetCurrentFilePath_NoSubscribers_NoException()
+        {
+            var testSubject = CreateTestSubject();
+
+            Action act = () => testSubject.CurrentFilePath = "new path";
+            act.Should().NotThrow();
+
+            testSubject.CurrentFilePath.Should().Be("new path");
+        }
+
+        [TestMethod]
+        public void SetCurrentFilePath_HasSubscribers_NotifiesSubscribers()
+        {
+            var propertyChangedEventHandler = new Mock<PropertyChangedEventHandler>();
+
+            var testSubject = CreateTestSubject();
+            testSubject.PropertyChanged += propertyChangedEventHandler.Object;
+
+            testSubject.CurrentFilePath = "new path";
+
+            propertyChangedEventHandler.Verify(x =>
+                    x(It.IsAny<object>(), It.Is((PropertyChangedEventArgs e) => e.PropertyName == nameof(IAnalysisIssueVisualization.CurrentFilePath))),
+                Times.Once);
+
+            propertyChangedEventHandler.VerifyNoOtherCalls();
+
+            testSubject.CurrentFilePath.Should().Be("new path");
+        }
+
+        [TestMethod]
+        public void SetSpan_NoSubscribers_NoException()
+        {
+            var newSpan = CreateSpan();
+            var testSubject = CreateTestSubject();
+
+            Action act = () => testSubject.Span = newSpan;
+            act.Should().NotThrow();
+
+            testSubject.Span.Should().Be(newSpan);
+        }
+
+        [TestMethod]
+        public void SetSpan_HasSubscribers_NotifiesSubscribers()
+        {
+            var newSpan = CreateSpan();
+            var propertyChangedEventHandler = new Mock<PropertyChangedEventHandler>();
+
+            var testSubject = CreateTestSubject();
+            testSubject.PropertyChanged += propertyChangedEventHandler.Object;
+
+            testSubject.Span = newSpan;
+
+            propertyChangedEventHandler.Verify(x =>
+                    x(It.IsAny<object>(), It.Is((PropertyChangedEventArgs e) => e.PropertyName == nameof(IAnalysisIssueVisualization.Span))),
+                Times.Once);
+
+            propertyChangedEventHandler.VerifyNoOtherCalls();
+
+            testSubject.Span.Should().Be(newSpan);
+        }
+
+        private SnapshotSpan CreateSpan()
+        {
+            var mockTextSnapshot = new Mock<ITextSnapshot>();
+            mockTextSnapshot.SetupGet(x => x.Length).Returns(20);
+
+            return new SnapshotSpan(mockTextSnapshot.Object, new Span(0, 10));
+        }
+
+        private AnalysisIssueVisualization CreateTestSubject(string filePath = null)
+        {
+            var issue = new Mock<IAnalysisIssue>();
+            issue.SetupGet(x => x.FilePath).Returns(filePath);
+
+            return new AnalysisIssueVisualization(null, issue.Object);
+        }
+    }
+}

--- a/src/IssueViz/Editor/LocationNavigator.cs
+++ b/src/IssueViz/Editor/LocationNavigator.cs
@@ -59,7 +59,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor
             try
             {
                 var textView = documentNavigator.Open(locationVisualization.CurrentFilePath);
-                var locationSpan = GetLocationSpan(locationVisualization, textView);
+                var locationSpan = GetOrCalculateLocationSpan(locationVisualization, textView);
 
                 if (!locationSpan.IsEmpty)
                 {
@@ -71,14 +71,15 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
                 logger.WriteLine(Resources.ERR_OpenDocumentException, locationVisualization.CurrentFilePath, ex.Message);
+                locationVisualization.InvalidateSpan();
             }
 
             return false;
         }
 
-        private SnapshotSpan GetLocationSpan(IAnalysisIssueLocationVisualization locationVisualization, ITextView textView)
+        private SnapshotSpan GetOrCalculateLocationSpan(IAnalysisIssueLocationVisualization locationVisualization, ITextView textView)
         {
-            var shouldCalculateSpan = !locationVisualization.Span.HasValue || locationVisualization.Span.Value.IsEmpty;
+            var shouldCalculateSpan = !locationVisualization.Span.HasValue;
 
             if (shouldCalculateSpan)
             {

--- a/src/IssueViz/Editor/LocationNavigator.cs
+++ b/src/IssueViz/Editor/LocationNavigator.cs
@@ -20,15 +20,17 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration;
+using SonarLint.VisualStudio.IssueVisualization.Models;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Editor
 {
     internal interface ILocationNavigator
     {
-        bool TryNavigate(IAnalysisIssueLocation location);
+        bool TryNavigate(IAnalysisIssueLocationVisualization locationVisualization);
     }
 
     [Export(typeof(ILocationNavigator))]
@@ -47,33 +49,43 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor
             this.logger = logger;
         }
 
-        public bool TryNavigate(IAnalysisIssueLocation location)
+        public bool TryNavigate(IAnalysisIssueLocationVisualization locationVisualization)
         {
-            var locationFilePath = location?.FilePath;
-
-            if (string.IsNullOrEmpty(locationFilePath))
+            if (locationVisualization == null)
             {
-                return false;
+                throw new ArgumentNullException(nameof(locationVisualization));
             }
 
             try
             {
-                var textView = documentNavigator.Open(locationFilePath);
-                var locationSpan = spanCalculator.CalculateSpan(location, textView.TextBuffer.CurrentSnapshot);
+                var textView = documentNavigator.Open(locationVisualization.CurrentFilePath);
+                var locationSpan = GetLocationSpan(locationVisualization, textView);
 
-                if (locationSpan.HasValue)
+                if (!locationSpan.IsEmpty)
                 {
-                    documentNavigator.Navigate(textView, locationSpan.Value);
+                    documentNavigator.Navigate(textView, locationSpan);
 
                     return true;
                 }
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
-                logger.WriteLine(Resources.ERR_OpenDocumentException, locationFilePath, ex.Message);
+                logger.WriteLine(Resources.ERR_OpenDocumentException, locationVisualization.CurrentFilePath, ex.Message);
             }
 
             return false;
+        }
+
+        private SnapshotSpan GetLocationSpan(IAnalysisIssueLocationVisualization locationVisualization, ITextView textView)
+        {
+            var shouldCalculateSpan = !locationVisualization.Span.HasValue || locationVisualization.Span.Value.IsEmpty;
+
+            if (shouldCalculateSpan)
+            {
+                locationVisualization.Span = spanCalculator.CalculateSpan(locationVisualization.Location, textView.TextBuffer.CurrentSnapshot);
+            }
+
+            return locationVisualization.Span.Value;
         }
     }
 }

--- a/src/IssueViz/IssueVisualizationControl/IssueVisualizationControl.xaml
+++ b/src/IssueViz/IssueVisualizationControl/IssueVisualizationControl.xaml
@@ -12,8 +12,13 @@
              DataContext="{Binding ViewModel, RelativeSource={RelativeSource Mode=Self}}" x:ClassModifier="internal">
     <UserControl.Resources>
         <vsUtilities:BrushToColorConverter x:Key="BrushToColorConverter"/>
-        <core:BoolToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
         <visualization:SeverityToMonikerConverter x:Key="SeverityToMonikerConverter" />
+        <visualization:SpanToNavigabilityConverter x:Key="SpanToNavigabilityConverter"/>
+
+        <core:AggregatorValueConverter x:Key="SpanToInvertedVisibilityConverter">
+            <visualization:SpanToNavigabilityConverter />
+            <core:BoolToVisibilityConverter TrueValue="Collapsed" FalseValue="Visible" />
+        </core:AggregatorValueConverter>
 
         <!-- Base styles -->
 
@@ -128,14 +133,14 @@
                 <MultiDataTrigger>
                     <MultiDataTrigger.Conditions>
                         <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Mode=Self}}" Value="True"/>
-                        <Condition Binding="{Binding Location.IsNavigable}" Value="True"/>
+                        <Condition Binding="{Binding Location.Span, Converter={StaticResource SpanToNavigabilityConverter}}" Value="True"/>
                     </MultiDataTrigger.Conditions>
                     <MultiDataTrigger.Setters>
                         <Setter Property="Background" Value="{DynamicResource {x:Static vsShell:VsBrushes.StartPageSelectedItemBackgroundKey}}"/>
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsShell:VsBrushes.StartPageSelectedItemBackgroundKey}}" />
                     </MultiDataTrigger.Setters>
                 </MultiDataTrigger>
-                <DataTrigger Binding="{Binding Location.IsNavigable}" Value="False">
+                <DataTrigger Binding="{Binding Location.Span, Converter={StaticResource SpanToNavigabilityConverter}}" Value="False">
                     <Setter Property="IsSelected" Value="False"/>
                     <Setter Property="IsEnabled" Value="False"/>
                     <Setter Property="Focusable" Value="false"/>
@@ -152,7 +157,7 @@
             <Setter Property="Margin" Value="5,0,0,0"/>
             <Setter Property="Padding" Value="1"/>
             <Style.Triggers>
-                <DataTrigger Binding="{Binding Location.IsNavigable}" Value="False">
+                <DataTrigger Binding="{Binding Location.Span, Converter={StaticResource SpanToNavigabilityConverter}}" Value="False">
                     <Setter Property="FontStyle" Value="Italic" />
                     <Setter Property="FontWeight" Value="Regular" />
                     <Setter Property="Foreground" Value="{DynamicResource {x:Static vsShell:VsBrushes.CommandBarTextInactiveKey}}"/>
@@ -160,7 +165,7 @@
                 <MultiDataTrigger>
                     <MultiDataTrigger.Conditions>
                         <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ListViewItem}}}" Value="True"/>
-                        <Condition Binding="{Binding Location.IsNavigable}" Value="True"/>
+                        <Condition Binding="{Binding Location.Span, Converter={StaticResource SpanToNavigabilityConverter}}" Value="True"/>
                     </MultiDataTrigger.Conditions>
                     <MultiDataTrigger.Setters>
                         <Setter Property="Foreground" Value="{DynamicResource {x:Static vsShell:VsBrushes.StartPageSelectedItemStrokeKey}}"/>
@@ -257,7 +262,7 @@
                             <vsImaging:CrispImage Grid.Column="2"
                                                 Height="16" Width="16"
                                                 Moniker="{x:Static vsCatalog:KnownMonikers.DocumentWarning}" 
-                                                Visibility="{Binding Location.IsNavigable, Converter={StaticResource InvertedBooleanToVisibilityConverter}, Mode=OneWay}"/>
+                                                Visibility="{Binding Location.Span, Converter={StaticResource SpanToInvertedVisibilityConverter}, Mode=OneWay}"/>
                         </Grid>
                     </DataTemplate>
                 </ListBox.Resources>

--- a/src/IssueViz/IssueVisualizationControl/SpanToNavigabilityConverter.cs
+++ b/src/IssueViz/IssueVisualizationControl/SpanToNavigabilityConverter.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Microsoft.VisualStudio.Text;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+
+namespace SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl
+{
+    [ValueConversion(typeof(SnapshotSpan?), typeof(bool))]
+    public class SpanToNavigabilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var span = (SnapshotSpan?)value;
+
+            return span.IsNavigable();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/IssueViz/IssueVisualizationControl/ViewModels/IssueVisualizationViewModel.cs
+++ b/src/IssueViz/IssueVisualizationControl/ViewModels/IssueVisualizationViewModel.cs
@@ -168,7 +168,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.Vi
                 return;
             }
 
-            locationVisualization.IsNavigable = locationNavigator.TryNavigate(locationVisualization.Location);
+            locationNavigator.TryNavigate(locationVisualization);
         }
 
         private void UpdateLocationsList()

--- a/src/IssueViz/Models/AnalysisIssueLocationVisualization.cs
+++ b/src/IssueViz/Models/AnalysisIssueLocationVisualization.cs
@@ -29,7 +29,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
     {
         int StepNumber { get; }
 
-        bool IsNavigable { get; set; }
+        IAnalysisIssueLocation Location { get; }
 
         /// <summary>
         /// Up-to-date file path associated with the issue location
@@ -38,8 +38,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
         /// If the file was renamed after the analysis, this property will contain the new value and will be different from the underlying <see cref="IAnalysisIssueLocation.FilePath"/>.
         /// </remarks>
         string CurrentFilePath { get; set; }
-
-        IAnalysisIssueLocation Location { get; }
 
         /// <summary>
         /// Editor span associated with the issue location
@@ -55,21 +53,29 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
 
     public class AnalysisIssueLocationVisualization : IAnalysisIssueLocationVisualization
     {
-        private bool isNavigable;
         private string filePath;
+        private SnapshotSpan? span;
 
         public AnalysisIssueLocationVisualization(int stepNumber, IAnalysisIssueLocation location)
         {
             StepNumber = stepNumber;
             Location = location;
-            IsNavigable = true;
             CurrentFilePath = location.FilePath;
         }
 
         public int StepNumber { get; }
 
         public IAnalysisIssueLocation Location { get; }
-        public SnapshotSpan? Span { get; set; }
+
+        public SnapshotSpan? Span
+        {
+            get => span;
+            set 
+            {
+                span = value;
+                NotifyPropertyChanged();
+            }
+        }
 
         public string CurrentFilePath
         {
@@ -81,21 +87,28 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
             }
         }
 
-        public bool IsNavigable
-        {
-            get => isNavigable;
-            set
-            {
-                isNavigable = value;
-                NotifyPropertyChanged();
-            }
-        }
-
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected virtual void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public static class AnalysisIssueLocationVisualizationExtensions
+    {
+        /// <summary>
+        /// Returns true/false if we can navigate to <see cref="Span"/>.
+        /// Returns true if <see cref="Span"/> is null.
+        /// </summary>
+        public static bool IsNavigable(this IAnalysisIssueLocationVisualization locationVisualization)
+        {
+            return locationVisualization.Span.IsNavigable();
+        }
+
+        public static bool IsNavigable(this SnapshotSpan? span)
+        {
+            return !span.HasValue || !span.Value.IsEmpty;
         }
     }
 }

--- a/src/IssueViz/Models/AnalysisIssueLocationVisualization.cs
+++ b/src/IssueViz/Models/AnalysisIssueLocationVisualization.cs
@@ -98,12 +98,20 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
     public static class AnalysisIssueLocationVisualizationExtensions
     {
         /// <summary>
-        /// Returns true/false if we can navigate to <see cref="Span"/>.
-        /// Returns true if <see cref="Span"/> is null.
+        /// Returns true/false if we can navigate to <see cref="IAnalysisIssueLocationVisualization.Span"/>.
+        /// Returns true if <see cref="IAnalysisIssueLocationVisualization.Span"/> is null.
         /// </summary>
         public static bool IsNavigable(this IAnalysisIssueLocationVisualization locationVisualization)
         {
             return locationVisualization.Span.IsNavigable();
+        }
+
+        /// <summary>
+        /// Sets <see cref="IAnalysisIssueLocationVisualization.Span"/> to an empty span.
+        /// </summary>
+        public static void InvalidateSpan(this IAnalysisIssueLocationVisualization locationVisualization)
+        {
+            locationVisualization.Span = new SnapshotSpan();
         }
 
         public static bool IsNavigable(this SnapshotSpan? span)

--- a/src/IssueViz/Models/AnalysisIssueVisualization.cs
+++ b/src/IssueViz/Models/AnalysisIssueVisualization.cs
@@ -36,13 +36,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
     internal class AnalysisIssueVisualization : IAnalysisIssueVisualization
     {
         private string currentFilePath;
-        private bool isNavigable;
+        private SnapshotSpan? span;
 
         public AnalysisIssueVisualization(IReadOnlyList<IAnalysisIssueFlowVisualization> flows, IAnalysisIssue issue)
         {
             Flows = flows;
             Issue = issue;
-            IsNavigable = true;
             CurrentFilePath = issue.FilePath;
         }
 
@@ -50,7 +49,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
         public IAnalysisIssue Issue { get; }
         public int StepNumber => 0;
         public IAnalysisIssueLocation Location => Issue;
-        public SnapshotSpan? Span { get; set; }
+
+        public SnapshotSpan? Span
+        {
+            get => span;
+            set
+            {
+                span = value;
+                NotifyPropertyChanged();
+            }
+        }
 
         public string CurrentFilePath
         {
@@ -58,16 +66,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
             set
             {
                 currentFilePath = value;
-                NotifyPropertyChanged();
-            }
-        }
-
-        public bool IsNavigable
-        {
-            get => isNavigable;
-            set
-            {
-                isNavigable = value;
                 NotifyPropertyChanged();
             }
         }

--- a/src/IssueViz/Selection/IssueFlowStepNavigator.cs
+++ b/src/IssueViz/Selection/IssueFlowStepNavigator.cs
@@ -79,14 +79,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Selection
 
             var navigableLocations = order(currentFlow.Locations)
                 .Where(x =>
-                    x.IsNavigable &&
+                    x.IsNavigable() &&
                     match(x, currentLocation));
 
             foreach (var locationViz in navigableLocations)
             {
-                locationViz.IsNavigable = locationNavigator.TryNavigate(locationViz.Location);
-
-                if (locationViz.IsNavigable)
+                if (locationNavigator.TryNavigate(locationViz))
                 {
                     selectionService.SelectedLocation = locationViz;
                     break;


### PR DESCRIPTION
The main changes are in 
1. `IAnalysisIssueLocationVisualization` - removing IsNavigable property and adding extension methods that rely on Span.
2. `LocationNavigator` - now uses the existing `IAnalysisIssueLocationVisualization.Span`, and is responsible to update it if it's null.
The rest of the files were changed as a result.  