### PR TITLE
MSVC Driver: add support for "/arch:AVX512" compiler option

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelper_CaptureTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyHelper_CaptureTests.cs
@@ -317,6 +317,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
                 .Be("/arch:AVX");
             CFamilyHelper.Capture.ConvertEnableEnhancedInstructionSet("AdvancedVectorExtensions2").Should()
                 .Be("/arch:AVX2");
+            CFamilyHelper.Capture.ConvertEnableEnhancedInstructionSet("AdvancedVectorExtensions512").Should()
+                .Be("/arch:AVX512");
             CFamilyHelper.Capture.ConvertEnableEnhancedInstructionSet("StreamingSIMDExtensions").Should()
                 .Be("/arch:SSE");
             CFamilyHelper.Capture.ConvertEnableEnhancedInstructionSet("StreamingSIMDExtensions2").Should()

--- a/src/Integration.Vsix.UnitTests/CFamily/MsvcDriverTest.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/MsvcDriverTest.cs
@@ -441,6 +441,30 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
                     Env = new List<string>(),
                     Cmd = new List<string>() {
                       "cl.exe",
+                      "/arch:AVX512",
+                      "c:\\file.cpp"
+                    },
+                }
+            });
+            req.Predefines.Should().ContainAll(
+                "#define __AVX512BW__ 1\n",
+                "#define __AVX512CD__ 1\n",
+                "#define __AVX512DQ__ 1\n",
+                "#define __AVX512F__ 1\n",
+                "#define __AVX512VL__ 1\n",
+                "#define _M_IX86_FP 2\n",
+                "#define __AVX__ 1\n",
+                "#define __AVX2__ 1\n");
+
+            req = MsvcDriver.ToRequest(new CFamilyHelper.Capture[] {
+                compiler,
+                new CFamilyHelper.Capture()
+                {
+                    Executable = "",
+                    Cwd = "basePath",
+                    Env = new List<string>(),
+                    Cmd = new List<string>() {
+                      "cl.exe",
                       "/arch:AVX2",
                       "c:\\file.cpp"
                     },

--- a/src/Integration.Vsix/CFamily/CFamilyHelper_Capture.cs
+++ b/src/Integration.Vsix/CFamily/CFamilyHelper_Capture.cs
@@ -206,6 +206,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
                         return "/arch:AVX";
                     case "AdvancedVectorExtensions2":
                         return "/arch:AVX2";
+                    case "AdvancedVectorExtensions512":
+                        return "/arch:AVX512";
                     case "StreamingSIMDExtensions":
                         return "/arch:SSE";
                     case "StreamingSIMDExtensions2":

--- a/src/Integration.Vsix/CFamily/PortedFromJava/MsvcDriver.cs
+++ b/src/Integration.Vsix/CFamily/PortedFromJava/MsvcDriver.cs
@@ -334,6 +334,14 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
                     case "SSE":
                         predefines.Append("#define _M_IX86_FP 1\n");
                         break;
+                    case "AVX512":
+                        predefines.Append("#define __AVX512BW__ 1\n");
+                        predefines.Append("#define __AVX512CD__ 1\n");
+                        predefines.Append("#define __AVX512DQ__ 1\n");
+                        predefines.Append("#define __AVX512F__ 1\n");
+                        predefines.Append("#define __AVX512VL__ 1\n");
+                        // fallthrough
+                        goto case "AVX2";
                     case "AVX2":
                         predefines.Append("#define __AVX2__ 1\n");
                         // fallthrough


### PR DESCRIPTION
Fixes #1780 