### PR TITLE
Use WpfTableEntryBase instead of IWpfTableEntry

### DIFF
--- a/src/IssueViz.Security.UnitTests/HotspotsList/HotspotTableEntryTests.cs
+++ b/src/IssueViz.Security.UnitTests/HotspotsList/HotspotTableEntryTests.cs
@@ -20,7 +20,6 @@
 
 using System;
 using FluentAssertions;
-using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text;
@@ -180,91 +179,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.HotspotsL
             var result = testSubject.TryGetValue("dummy column", out var content);
             result.Should().BeFalse();
             content.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryCreateToolTip_Null()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.TryCreateToolTip(StandardTableColumnDefinitions.DocumentName, out var value);
-
-            result.Should().BeFalse();
-            value.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void CanSetValue_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.CanSetValue(StandardTableColumnDefinitions.DocumentName);
-            result.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TrySetValue_False()
-        {
-            var hotspot = new Mock<IHotspot>();
-            hotspot.SetupGet(x => x.FilePath).Returns("unchanged file path");
-
-            var testSubject = new HotspotTableEntry(CreateIssueViz(hotspot.Object));
-            var result = testSubject.TrySetValue(StandardTableColumnDefinitions.DocumentName, "test");
-            result.Should().BeFalse();
-
-            testSubject.TryGetValue(StandardTableColumnDefinitions.DocumentName, out var value);
-            value.Should().Be("unchanged file path");
-        }
-
-        [TestMethod]
-        public void CanCreateDetailsContent_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.CanCreateDetailsContent();
-            result.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TryCreateDetailsContent_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.TryCreateDetailsContent(out var value);
-            result.Should().BeFalse();
-            value.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryCreateDetailsStringContent_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.TryCreateDetailsStringContent(out var value);
-            result.Should().BeFalse();
-            value.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryCreateColumnContent_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.TryCreateColumnContent("column", true, out var value);
-            result.Should().BeFalse();
-            value.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryCreateImageContent_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.TryCreateImageContent("column", true, out var value);
-            result.Should().BeFalse();
-            value.Should().BeEquivalentTo(default(ImageMoniker));
-        }
-
-        [TestMethod]
-        public void TryCreateStringContent_False()
-        {
-            var testSubject = new HotspotTableEntry(CreateIssueViz());
-            var result = testSubject.TryCreateStringContent("column", true, true, out var value);
-            result.Should().BeFalse();
-            value.Should().BeNull();
         }
 
         private static object GetValue(IHotspot hotspot, string column)

--- a/src/IssueViz.Security/HotspotsList/TableDataSource/HotspotTableEntry.cs
+++ b/src/IssueViz.Security/HotspotsList/TableDataSource/HotspotTableEntry.cs
@@ -19,8 +19,6 @@
  */
 
 using System;
-using System.Windows;
-using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.HotspotsList.TableDataSource.CustomColumns;
@@ -28,7 +26,7 @@ using SonarLint.VisualStudio.IssueVisualization.Security.Models;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.HotspotsList.TableDataSource
 {
-    internal class HotspotTableEntry : IWpfTableEntry
+    internal class HotspotTableEntry : WpfTableEntryBase
     {
         private readonly IAnalysisIssueVisualization hotspotViz;
 
@@ -42,9 +40,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.HotspotsList.TableD
             }
         }
 
-        public object Identity => hotspotViz;
+        public override object Identity => hotspotViz;
 
-        public bool TryGetValue(string keyName, out object content)
+        public override bool TryGetValue(string keyName, out object content)
         {
             var hotspot = hotspotViz.Issue as IHotspot;
 
@@ -94,60 +92,5 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.HotspotsList.TableD
 
             return true;
         }
-
-        #region IWpfTableEntry unimplemented methods
-
-        public virtual bool TryCreateToolTip(string columnName, out object toolTip)
-        {
-            toolTip = null;
-            return false;
-        }
-
-        public virtual bool TrySetValue(string keyName, object content)
-        {
-            return false;
-        }
-
-        public virtual bool CanSetValue(string keyName)
-        {
-            return false;
-        }
-
-        public virtual bool TryCreateStringContent(string columnName, bool truncatedText, bool singleColumnView, out string content)
-        {
-            content = null;
-            return false;
-        }
-
-        public virtual bool TryCreateImageContent(string columnName, bool singleColumnView, out ImageMoniker content)
-        {
-            content = default;
-            return false;
-        }
-
-        public virtual bool TryCreateColumnContent(string columnName, bool singleColumnView, out FrameworkElement content)
-        {
-            content = null;
-            return false;
-        }
-
-        public virtual bool CanCreateDetailsContent()
-        {
-            return false;
-        }
-
-        public virtual bool TryCreateDetailsContent(out FrameworkElement expandedContent)
-        {
-            expandedContent = null;
-            return false;
-        }
-
-        public virtual bool TryCreateDetailsStringContent(out string content)
-        {
-            content = null;
-            return false;
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
Cosmetics: I've noticed in the docs that there is a base class that I can inherit from, instead of the interface, so all the empty methods can be removed.