### PR TITLE
Separated rule metadata from IHotspot

### DIFF
--- a/src/IssueViz.Security.UnitTests/Models/HotspotRuleTests.cs
+++ b/src/IssueViz.Security.UnitTests/Models/HotspotRuleTests.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.IssueVisualization.Security.Models;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Models
+{
+    [TestClass]
+    public class HotspotRuleTests
+    {
+        public void Ctor_PropertiesSet()
+        {
+            IHotspotRule rule = new HotspotRule("key", "name", "sec cat", HotspotPriority.Medium, "risk", "vuln", "fix");
+
+            rule.RuleKey.Should().Be("key");
+            rule.RuleName.Should().Be("name");
+            rule.SecurityCategory.Should().Be("sec cat");
+            rule.Priority.Should().Be(HotspotPriority.Medium);
+            rule.RiskDescription.Should().Be("risk");
+            rule.VulnerabilityDescription.Should().Be("vuln");
+            rule.FixRecommendations.Should().Be("fix");
+        }
+    }
+}

--- a/src/IssueViz.Security.UnitTests/Models/HotspotTests.cs
+++ b/src/IssueViz.Security.UnitTests/Models/HotspotTests.cs
@@ -30,10 +30,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Models
     [TestClass]
     public class HotspotTests
     {
+        private static readonly IHotspotRule ValidRule = CreateRule("x123");
+
         [TestMethod]
         public void Ctor_PropertiesSet()
         {
-            var hotspot = new Hotspot("hotspot key", "local-path.cpp", "server-path", "message", 1, 2, 3, 4, "hash", "rule", HotspotPriority.Medium, null);
+            var hotspot = new Hotspot("hotspot key", "local-path.cpp", "server-path", "message", 1, 2, 3, 4, "hash", ValidRule, null);
 
             hotspot.HotspotKey.Should().Be("hotspot key");
             hotspot.FilePath.Should().Be("local-path.cpp");
@@ -44,15 +46,15 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Models
             hotspot.StartLineOffset.Should().Be(3);
             hotspot.EndLineOffset.Should().Be(4);
             hotspot.LineHash.Should().Be("hash");
-            hotspot.RuleKey.Should().Be("rule");
-            hotspot.Priority.Should().Be(HotspotPriority.Medium);
+            hotspot.RuleKey.Should().Be(ValidRule.RuleKey);
+            hotspot.Rule.Should().BeSameAs(ValidRule);
         }
 
         [TestMethod]
         public void Ctor_NoFlows_EmptyFlows()
         {
             IReadOnlyList<IAnalysisIssueFlow> flows = null;
-            var hotspot = new Hotspot("hotspot key", "local-path.cpp", "server-path", "message", 1, 2, 3, 4, "hash", "rule", HotspotPriority.Medium, flows);
+            var hotspot = new Hotspot("hotspot key", "local-path.cpp", "server-path", "message", 1, 2, 3, 4, "hash", ValidRule, flows);
 
             hotspot.Flows.Should().BeEmpty();
         }
@@ -61,9 +63,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Models
         public void Ctor_HasFlows_CorrectFlows()
         {
             var flows = new[] { Mock.Of<IAnalysisIssueFlow>(), Mock.Of<IAnalysisIssueFlow>() };
-            var hotspot = new Hotspot("hotspot key", "local-path.cpp", "server-path", "message", 1, 2, 3, 4, "hash", "rule", HotspotPriority.Medium, flows);
+            var hotspot = new Hotspot("hotspot key", "local-path.cpp", "server-path", "message", 1, 2, 3, 4, "hash", ValidRule, flows);
 
             hotspot.Flows.Should().BeEquivalentTo(flows);
+        }
+
+        private static IHotspotRule CreateRule(string ruleKey)
+        {
+            var ruleMock = new Mock<IHotspotRule>();
+            ruleMock.Setup(x => x.RuleKey).Returns(ruleKey);
+            return ruleMock.Object;
         }
     }
 }

--- a/src/IssueViz.Security.UnitTests/OpenInIDE/Api/HotspotToIssueVisualizationConverterTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE/Api/HotspotToIssueVisualizationConverterTests.cs
@@ -59,11 +59,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE
             issueVizConverter.Verify(x => x.Convert(
                     It.Is((IHotspot hotspot) =>
                         hotspot.HotspotKey == "some key" &&
-                        hotspot.Priority == HotspotPriority.High &&
+                        hotspot.Rule.Priority == HotspotPriority.High &&
                         hotspot.LineHash == "hash-xxx" &&
                         hotspot.Flows.IsEmpty() &&
                         hotspot.Message == "message" &&
                         hotspot.RuleKey == "rule key" &&
+                        hotspot.Rule.RuleKey == "rule key" &&
                         hotspot.FilePath== "some absolute path" &&
                         hotspot.ServerFilePath== "some path" &&
                         hotspot.StartLine == 5 &&
@@ -136,7 +137,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE
             testSubject.Convert(sonarQubeHotspot);
 
             issueVizConverter.Verify(x => x.Convert(
-                    It.Is((IHotspot hotspot) => hotspot.Priority == expectedPriority),
+                    It.Is((IHotspot hotspot) => hotspot.Rule.Priority == expectedPriority),
                     It.IsAny<ITextSnapshot>()),
                 Times.Once);
         }

--- a/src/IssueViz.Security/HotspotsList/HotspotsControl.xaml
+++ b/src/IssueViz.Security/HotspotsList/HotspotsControl.xaml
@@ -213,7 +213,7 @@
             <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="TextAlignment" Value="Center"/>
             <Setter Property="Margin" Value="1"/>
-            <Setter Property="Background" Value="{Binding Path=DataContext.Hotspot.Issue.Priority, RelativeSource={RelativeSource Self}, Converter={StaticResource PriorityToBackgroundConverter}}"/>
+            <Setter Property="Background" Value="{Binding Path=DataContext.Hotspot.Issue.Rule.Priority, RelativeSource={RelativeSource Self}, Converter={StaticResource PriorityToBackgroundConverter}}"/>
         </Style>
     </UserControl.Resources>
     <Grid UseLayoutRounding="True">
@@ -267,10 +267,10 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Hotspot.Issue.Priority" Header="Priority" Width="100">
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Hotspot.Issue.Rule.Priority" Header="Priority" Width="100">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding Hotspot.Issue.Priority}" 
+                            <TextBlock Text="{Binding Hotspot.Issue.Rule.Priority}" 
                                        Style="{StaticResource PriorityColumnCellTextBlockStyle}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>

--- a/src/IssueViz.Security/Models/IHotspot.cs
+++ b/src/IssueViz.Security/Models/IHotspot.cs
@@ -28,19 +28,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Models
     {
         string HotspotKey { get; }
 
-        HotspotPriority Priority { get; }
+        IHotspotRule Rule { get; }
 
         /// <summary>
         /// File path as received from SQ server
         /// </summary>
         string ServerFilePath { get; }
-    }
-
-    public enum HotspotPriority
-    {
-        High,
-        Medium,
-        Low
     }
 
     internal class Hotspot : IHotspot
@@ -56,8 +49,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Models
             int startLineOffset,
             int endLineOffset,
             string lineHash,
-            string ruleKey,
-            HotspotPriority priority,
+            IHotspotRule rule,
             IReadOnlyList<IAnalysisIssueFlow> flows)
         {
             HotspotKey = hotspotKey;
@@ -69,8 +61,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Models
             StartLineOffset = startLineOffset;
             EndLineOffset = endLineOffset;
             LineHash = lineHash;
-            RuleKey = ruleKey;
-            Priority = priority;
+            Rule = rule;
             Flows = flows ?? EmptyFlows;
         }
 
@@ -82,9 +73,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Models
         public int StartLineOffset { get; }
         public int EndLineOffset { get; }
         public string LineHash { get; }
-        public string RuleKey { get; }
+        public string RuleKey => Rule.RuleKey;
+        public IHotspotRule Rule { get; }
         public IReadOnlyList<IAnalysisIssueFlow> Flows { get; }
-        public HotspotPriority Priority { get; }
         public string ServerFilePath { get;  }
     }
 }

--- a/src/IssueViz.Security/Models/IHotspotRule.cs
+++ b/src/IssueViz.Security/Models/IHotspotRule.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.Models
+{
+    public enum HotspotPriority
+    {
+        High,
+        Medium,
+        Low
+    }
+
+    internal interface IHotspotRule
+    {
+        string RuleKey { get; }
+        string RuleName { get; }
+        string SecurityCategory { get; }
+        HotspotPriority Priority { get; }
+        string RiskDescription { get; }
+        string VulnerabilityDescription { get; }
+        string FixRecommendations { get; }
+    }
+
+    internal class HotspotRule : IHotspotRule
+    {
+        public HotspotRule(string ruleKey, string ruleName,
+            string securityCategory, HotspotPriority priority,
+            string riskDescription, string vulnDescription, string fixRecommendations)
+        {
+            RuleKey = ruleKey;
+            RuleName = ruleName;
+            SecurityCategory = securityCategory;
+            Priority = priority;
+            RiskDescription = riskDescription;
+            VulnerabilityDescription = vulnDescription;
+            FixRecommendations = fixRecommendations;
+        }
+
+        public string RuleKey { get; }
+        public string RuleName { get; }
+        public string SecurityCategory { get; }
+        public HotspotPriority Priority { get; }
+        public string RiskDescription { get; }
+        public string VulnerabilityDescription { get; }
+        public string FixRecommendations { get; }
+    }
+}

--- a/src/IssueViz.Security/OpenInIDE/Api/IHotspotToIssueVisualizationConverter.cs
+++ b/src/IssueViz.Security/OpenInIDE/Api/IHotspotToIssueVisualizationConverter.cs
@@ -65,6 +65,17 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE.Api
             var localFilePath = absoluteFilePathLocator.Locate(sonarQubeHotspot.FilePath);
             var priority = GetPriority(sonarQubeHotspot.Rule.VulnerabilityProbability);
 
+            var sqRule = sonarQubeHotspot.Rule;
+            var rule = new HotspotRule(
+                sqRule.RuleKey,
+                sqRule.RuleName,
+                sqRule.SecurityCategory,
+                priority,
+                sqRule.RiskDescription,
+                sqRule.VulnerabilityDescription,
+                sqRule.FixRecommendations
+                );
+
             var hotspot = new Hotspot(
                 hotspotKey: sonarQubeHotspot.HotspotKey,
                 filePath: localFilePath,
@@ -75,8 +86,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE.Api
                 startLineOffset: sonarQubeHotspot.TextRange.StartOffset,
                 endLineOffset: sonarQubeHotspot.TextRange.EndOffset,
                 lineHash: sonarQubeHotspot.LineHash,
-                ruleKey: sonarQubeHotspot.Rule.RuleKey,
-                priority,
+                rule: rule,
                 flows: null);
 
             return hotspot;


### PR DESCRIPTION
Added data fields for rule help

The web API returns additional information such as the "help" fields that we currently don't handle but will need later.
This commit changes the SLVS data structure to more closely match the data structure returned by the API i.e. a separate interface to contain the rule metadata.
 