### PR TITLE
Initialize taint sync monitor in a separate package

### DIFF
--- a/src/Core/Binding/IActiveSolutionBoundTracker.cs
+++ b/src/Core/Binding/IActiveSolutionBoundTracker.cs
@@ -38,6 +38,8 @@ namespace SonarLint.VisualStudio.Core.Binding
         /// <summary>
         /// Event to notify subscribers when the binding status of a solution have changed.
         /// This occurs when a new solution is opened, or the SonarQube binding status of the solution changes.
+        /// The event is raised after the <see cref="ISonarQubeService"/> connection has finished
+        /// opening/closing.
         /// </summary>
         event EventHandler<ActiveSolutionBindingEventArgs> SolutionBindingChanged;
 

--- a/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
@@ -31,6 +31,14 @@ using SonarQube.Client;
 
 namespace SonarLint.VisualStudio.Integration
 {
+    /// <summary>
+    /// Raises an event after the bound solution state has finished changing
+    /// i.e. the server connection has been opened/closed as appropriate.
+    /// </summary>
+    /// <remarks>
+    /// In addition to raising an event, this class will also set/clear the <see cref="BoundSolutionUIContext"/>
+    /// UIContext.
+    /// </remarks>
     [Export(typeof(IActiveSolutionBoundTracker))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal sealed class ActiveSolutionBoundTracker : IActiveSolutionBoundTracker, IDisposable, IPartImportsSatisfiedNotification

--- a/src/IssueViz.Security/IssueVizSecurityPackage.cs
+++ b/src/IssueViz.Security/IssueVizSecurityPackage.cs
@@ -39,7 +39,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security
         and tool windows.
 
         It doesn't provide any other services, and doesn't need to be auto-loadable. It will be loaded
-        by VS only when needed i.e. when it has received a reqeust to to invoke a command or display a
+        by VS only when needed i.e. when it has received a request to to invoke a command or display a
         tool window.
     */
 

--- a/src/IssueViz.Security/Taint/TaintResources.Designer.cs
+++ b/src/IssueViz.Security/Taint/TaintResources.Designer.cs
@@ -95,5 +95,23 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint {
                 return ResourceManager.GetString("Synchronizer_ServerNotConnected", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Taint] Finished initializing taint issues synchronization package..
+        /// </summary>
+        internal static string SyncPackage_Initialized {
+            get {
+                return ResourceManager.GetString("SyncPackage_Initialized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Taint] Initializing taint issues synchronization package....
+        /// </summary>
+        internal static string SyncPackage_Initializing {
+            get {
+                return ResourceManager.GetString("SyncPackage_Initializing", resourceCulture);
+            }
+        }
     }
 }

--- a/src/IssueViz.Security/Taint/TaintResources.resx
+++ b/src/IssueViz.Security/Taint/TaintResources.resx
@@ -129,4 +129,10 @@
   <data name="Synchronizer_NumberOfServerIssues" xml:space="preserve">
     <value>[Taint] Fetched {0} taint vulnerabilities.</value>
   </data>
+  <data name="SyncPackage_Initialized" xml:space="preserve">
+    <value>[Taint] Finished initializing taint issues synchronization package.</value>
+  </data>
+  <data name="SyncPackage_Initializing" xml:space="preserve">
+    <value>[Taint] Initializing taint issues synchronization package...</value>
+  </data>
 </root>

--- a/src/IssueViz.Security/Taint/TaintSyncPackage.cs
+++ b/src/IssueViz.Security/Taint/TaintSyncPackage.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Integration;
+using Task = System.Threading.Tasks.Task;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
+{
+
+    /*
+        This package will auto-load when a bound solution is opened and the server connection
+        has been established.
+
+        Currently, the only job of this package is to start the taint sync process running.
+        This is being done in a different package to the one that provides the taint tool window
+        to avoid threading issues on package initialization (if the sync process and taint window
+        are provisioned in the same package, the sync process can trigger a call back to the package
+        to display the tool window before the package has finished initialising, causing VS to lock up).
+    */
+
+    [ExcludeFromCodeCoverage]
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [ProvideAutoLoad(BoundSolutionUIContext.GuidString, PackageAutoLoadFlags.BackgroundLoad)]
+    [Guid("EEEB81FA-D6C3-438D-B29E-9FAAC91471CC")]
+    public sealed class TaintSyncPackage : AsyncPackage
+    {
+        private ITaintIssuesBindingMonitor bindingMonitor;
+
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            var componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
+            var logger = componentModel.GetService<ILogger>();
+            logger.WriteLine(TaintResources.SyncPackage_Initializing);
+
+            bindingMonitor = componentModel.GetService<ITaintIssuesBindingMonitor>();
+            await componentModel.GetService<ITaintIssuesSynchronizer>().SynchronizeWithServer();
+            logger.WriteLine(TaintResources.SyncPackage_Initialized);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                bindingMonitor.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
* avoids reentrant calls on UI thread causing VS to lock up

Relates to #2059