### PR TITLE
Ensure taint tool window is initialized

### DIFF
--- a/src/Core/IToolWindowService.cs
+++ b/src/Core/IToolWindowService.cs
@@ -31,10 +31,17 @@ namespace SonarLint.VisualStudio.Core
         void Show(Guid toolWindowId);
 
         /// <summary>
-        /// Creates the window if it does not already exist
+        /// Creates the window and its content if it does not already exist
         /// </summary>
         /// <remarks>If a new tool window is created it will not be brought to the front or given focus.
-        /// If the tool window already exists its visibility and focus will not be affected.</remarks>
+        /// If the tool window already exists its visibility and focus will not be affected.
+        /// <para>
+        /// Note: VS will delay creating a window until it actually needs to render it. For example, if a
+        /// tool window is docked but not top-most then VS can create a tab that displays the tool window
+        /// caption without actually creating the tool window content (e.g. when showing a window based on
+        /// a UIContext). This method ensures the window content is created.
+        /// </para>
+        /// </remarks>
         void EnsureToolWindowExists(Guid toolWindowId);
     }
 }

--- a/src/IssueViz.Security/Taint/TaintIssuesSynchronizer.cs
+++ b/src/IssueViz.Security/Taint/TaintIssuesSynchronizer.cs
@@ -110,6 +110,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
                 UpdateTaintIssuesUIContext(hasTaintIssues);
                 if (hasTaintIssues)
                 {
+                    // We need the tool window content to exist so the issues are filtered and the
+                    // tool window caption is updated. See the "EnsureToolWindowExists" method comment
+                    // for more information.
                     toolWindowService.EnsureToolWindowExists(TaintToolWindow.ToolWindowId);
                 }
             }


### PR DESCRIPTION
Relates to #2059

Modifies the taint synchronizer to ensure the taint tool window has been created so the tool window caption can be set correctly.