### PR TITLE
Taint issues: output user-friendly message for unsupported SQ version

### DIFF
--- a/src/IssueViz.Security/Taint/TaintResources.Designer.cs
+++ b/src/IssueViz.Security/Taint/TaintResources.Designer.cs
@@ -97,6 +97,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [Taint] Cannot fetch taint vulnerabilities: requires SonarQube v8.6 or later, or SonarCloud. Connected SonarQube version: v{0}
+        ///    Visit https://github.com/SonarSource/sonarlint-visualstudio/wiki to find out more about this and other SonarLint features..
+        /// </summary>
+        internal static string Synchronizer_UnsupportedSQVersion {
+            get {
+                return ResourceManager.GetString("Synchronizer_UnsupportedSQVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Taint] Finished initializing taint issues synchronization package..
         /// </summary>
         internal static string SyncPackage_Initialized {

--- a/src/IssueViz.Security/Taint/TaintResources.Designer.cs
+++ b/src/IssueViz.Security/Taint/TaintResources.Designer.cs
@@ -70,7 +70,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Taint] Cannot fetch taint vulnerabilities: not in connected mode..
+        ///   Looks up a localized string similar to [Taint] Unable to fetch taint vulnerabilities: not in connected mode..
         /// </summary>
         internal static string Synchronizer_NotInConnectedMode {
             get {
@@ -88,7 +88,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Taint] Cannot fetch taint vulnerabilities: a connection to the server is not yet established..
+        ///   Looks up a localized string similar to [Taint] Unable to fetch taint vulnerabilities: a connection to the server is not yet established..
         /// </summary>
         internal static string Synchronizer_ServerNotConnected {
             get {
@@ -97,7 +97,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [Taint] Cannot fetch taint vulnerabilities: requires SonarQube v8.6 or later, or SonarCloud. Connected SonarQube version: v{0}
+        ///   Looks up a localized string similar to [Taint] Displaying taint vulnerabilities in the IDE requires SonarQube v8.6 or later, or SonarCloud. Connected SonarQube version: v{0}
         ///    Visit https://github.com/SonarSource/sonarlint-visualstudio/wiki to find out more about this and other SonarLint features..
         /// </summary>
         internal static string Synchronizer_UnsupportedSQVersion {

--- a/src/IssueViz.Security/Taint/TaintResources.resx
+++ b/src/IssueViz.Security/Taint/TaintResources.resx
@@ -135,4 +135,8 @@
   <data name="SyncPackage_Initializing" xml:space="preserve">
     <value>[Taint] Initializing taint issues synchronization package...</value>
   </data>
+  <data name="Synchronizer_UnsupportedSQVersion" xml:space="preserve">
+    <value>[Taint] Cannot fetch taint vulnerabilities: requires SonarQube v8.6 or later, or SonarCloud. Connected SonarQube version: v{0}
+    Visit https://github.com/SonarSource/sonarlint-visualstudio/wiki to find out more about this and other SonarLint features.</value>
+  </data>
 </root>

--- a/src/IssueViz.Security/Taint/TaintResources.resx
+++ b/src/IssueViz.Security/Taint/TaintResources.resx
@@ -121,10 +121,10 @@
     <value>[Taint] Failed to synchronize taint vulnerabilities with the connected server: {0}.</value>
   </data>
   <data name="Synchronizer_NotInConnectedMode" xml:space="preserve">
-    <value>[Taint] Cannot fetch taint vulnerabilities: not in connected mode.</value>
+    <value>[Taint] Unable to fetch taint vulnerabilities: not in connected mode.</value>
   </data>
   <data name="Synchronizer_ServerNotConnected" xml:space="preserve">
-    <value>[Taint] Cannot fetch taint vulnerabilities: a connection to the server is not yet established.</value>
+    <value>[Taint] Unable to fetch taint vulnerabilities: a connection to the server is not yet established.</value>
   </data>
   <data name="Synchronizer_NumberOfServerIssues" xml:space="preserve">
     <value>[Taint] Fetched {0} taint vulnerabilities.</value>
@@ -136,7 +136,7 @@
     <value>[Taint] Initializing taint issues synchronization package...</value>
   </data>
   <data name="Synchronizer_UnsupportedSQVersion" xml:space="preserve">
-    <value>[Taint] Cannot fetch taint vulnerabilities: requires SonarQube v8.6 or later, or SonarCloud. Connected SonarQube version: v{0}
+    <value>[Taint] Displaying taint vulnerabilities in the IDE requires SonarQube v8.6 or later, or SonarCloud. Connected SonarQube version: v{0}
     Visit https://github.com/SonarSource/sonarlint-visualstudio/wiki to find out more about this and other SonarLint features.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #2179

Example of new output:

![image](https://user-images.githubusercontent.com/10757559/109329022-0450fd00-7852-11eb-9e8f-d628087701cb.png)
