### PR TITLE
Internal tooling: add targets to download and extract SonarJS plugin

### DIFF
--- a/build/DownloadCFamilyPlugin/DownloadAndExtractSonarJS.cs
+++ b/build/DownloadCFamilyPlugin/DownloadAndExtractSonarJS.cs
@@ -1,0 +1,119 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace DownloadCFamilyPlugin
+{
+    /// <summary>
+    /// Downloads the Sonar JavaScript/TypeScript jar and extracts the files that need to be
+    /// embedded in the SLVS vsix
+    /// </summary>
+    /// <remarks>
+    /// Assumptions:
+    /// * we are downloading the sonar-js plugin jar e.g. https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-6.2.0.12043.jar
+    /// * the jar contains a .tgz archive containing ESLintBridge (a NodeJS app)
+    /// * the jar contains various .json files, some with well-known names.
+    /// 
+    /// We want the task to fail if it cannot locate all of the expected files (otherwise we'll build an invalid VSIX).
+    /// 
+    /// Downloading and extracting the files can be slow so we want to skip those steps if possible.
+    /// </remarks>
+    public class DownloadAndExtractSonarJS: Task
+    {
+        // Structure of the archive file:
+        // 
+        //      eslint-bridge-1.0.0.tgz -> eslint-bridge-1.0.0.tar ->
+        //          package\bin\
+        //          package\lib\
+        //          package\node_modules\
+        //          package\package.json
+
+        // The archive containing the eslintbridge
+        private const string SourceEsLintBridgeFilePattern = "eslint-bridge-*.tgz";
+
+        // Sub-folder into which the tar file should be unzipped
+        public const string TargetEslintBridgeFolderName = "eslint-bridge";
+
+        // List of patterns to match single files in the uncompressed output
+        private readonly string[] SourceSingleFilePatterns = new string[]
+        {
+                "Sonar_way_profile.json",
+                "Sonar_way_recommended_profile.json"
+        };
+
+        private readonly string SourceRelativePackageDirectory = TargetEslintBridgeFolderName + @"\package";
+
+        #region MSBuild input / output properties (set/read in the project file)
+
+        // Download url example: https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-6.2.0.12043.jar
+        [Required]
+        public string DownloadUrl { get; set; }
+
+        [Output]
+        public string[] FilesToEmbed { get; private set; }
+
+        [Output]
+        public string PackageDirectoryToEmbed { get; private set; }
+
+        #endregion
+
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, $"Download url: {DownloadUrl}");
+
+            var pluginFileName = Common.ExtractPluginFileNameFromUrl(DownloadUrl, Log);
+
+            // Ensure working directories exists
+            var localWorkingFolder = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "SLVS_TypeScript_Build");
+            var perVersionPluginFolder = Path.Combine(localWorkingFolder, Path.GetFileNameWithoutExtension(pluginFileName));
+            Common.EnsureWorkingDirectoryExist(perVersionPluginFolder, this.Log);
+
+            // Download and unzip the jar
+            var jarFilePath = Path.Combine(perVersionPluginFolder, pluginFileName);
+            Common.DownloadJarFile(DownloadUrl, jarFilePath, Log);
+            Common.UnzipJar(jarFilePath, perVersionPluginFolder, Log);
+
+            // Uncompress and extract the windows tar archive to get the eslint-bridge folder
+            var tarFilePath = Common.FindSingleFile(perVersionPluginFolder, SourceEsLintBridgeFilePattern, Log);
+            var tarSubFolder = Path.Combine(perVersionPluginFolder, TargetEslintBridgeFolderName);
+            Common.UncompressAndUnzipTgz(tarFilePath, tarSubFolder, Log);
+
+            // Locate the required files from the uncompressed jar and tar
+            var fileList = FindFiles(perVersionPluginFolder);
+            FilesToEmbed = fileList.ToArray();
+
+            PackageDirectoryToEmbed =   Path.Combine(perVersionPluginFolder, SourceRelativePackageDirectory);
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private List<string> FindFiles(string searchRoot)
+        {
+            var files = new List<string>();
+            files.AddRange(Common.FindSingleFiles(searchRoot, SourceSingleFilePatterns, Log));
+            return files;
+        }
+    }
+}

--- a/build/DownloadCFamilyPlugin/DownloadCFamilyPlugin.csproj
+++ b/build/DownloadCFamilyPlugin/DownloadCFamilyPlugin.csproj
@@ -1,32 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <!-- This target exists to help test manually testing and debugging this targets file and the tasks in this project.
-       Just build from the command line specifying the target e.g.
-          
-          msbuild.exe /t:ManualTest
-        
-        Optionally, pass in the OutputDir and PluginUrl values to use.
-        To debug, add a call to "System.Diagnostics.Debugger.Launch();" in the code.
-  -->
-  <Target Name="ManualTest">
-
-    <!-- Example URLs:
-      https://binaries.sonarsource.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-6.17.0.27551.jar
-    
-    -->
-    
-    <PropertyGroup>
-      <OutputDir Condition=" $(OutputDir) == ''">$(MSBuildThisFileDirectory)ManualTestOutput</OutputDir>
-      <PluginUrl Condition=" $(PluginUrl)=='' ">https://binaries.sonarsource.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-6.17.0.27551.jar</PluginUrl>
-    </PropertyGroup>
-
-    <MSBuild Targets="Restore;Build;CopyEmbeddedFiles"
-             Projects ="$(MSBuildProjectFullPath)"
-             Properties="PluginUrl=$(PluginUrl);TargetDirectory=$(OutputDir)"
-             />
-  </Target>
-
-
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
     
@@ -47,14 +20,14 @@
 
   <!-- Building the project creates an assembly that contains this custom task.   
        We then need to execute the CopyEmbeddedFiles task to execute the task and copy the files. -->
-  <UsingTask TaskName="DownloadAndExtract" AssemblyFile="$(OutputPath)DownloadCFamilyPlugin.dll" />
-  
-  <Target Name="CopyEmbeddedFiles" >
-    <Message Importance="high" Text="Fetching CFamily files..." />
 
-    <!-- Parameter validation -->
-    <Error Condition="$(PluginUrl)==''" Text="PluginUrl property must be specified (url from which the CFamily jar can be downloaded)" />
-    <Error Condition="$(TargetDirectory)==''" Text="TargetDirectory property must be specified (i.e. destination to copy the CFamily files to)" />
+  <!-- ******************************************** -->
+  <!-- CFamily jar handling -->
+  <!-- ******************************************** -->
+  <UsingTask TaskName="DownloadAndExtract" AssemblyFile="$(OutputPath)DownloadCFamilyPlugin.dll" />  
+
+  <Target Name="CopyEmbeddedFiles" DependsOnTargets="ValidateInputs" >
+    <Message Importance="high" Text="Fetching CFamily files..." />
 
     <DownloadAndExtract DownloadUrl="$(PluginUrl)">
       <Output TaskParameter="FilesToEmbed" ItemName="FilesToEmbed" />
@@ -67,6 +40,98 @@
     <MakeDir Directories="$(TargetDirectory)" />
     <Copy DestinationFolder="$(TargetDirectory)" SkipUnchangedFiles="true" SourceFiles="@(FilesToEmbed)" />
     
+  </Target>
+
+
+  <!-- ******************************************** -->
+  <!-- TypeScript jar handling -->
+  <!-- ******************************************** -->
+  <UsingTask TaskName="DownloadAndExtractSonarJS" AssemblyFile="$(OutputPath)DownloadCFamilyPlugin.dll" />
+
+  <Target Name="EmbedTypeScriptFiles" DependsOnTargets="ValidateInputs" >
+    <Message Importance="high" Text="Fetching TypeScript files..." />
+
+    <DownloadAndExtractSonarJS DownloadUrl="$(PluginUrl)">
+      <Output TaskParameter="FilesToEmbed" ItemName="FilesToEmbed" />
+      <Output TaskParameter="PackageDirectoryToEmbed" PropertyName="PackageDirectoryToEmbed" />
+    </DownloadAndExtractSonarJS>
+
+    <Message Importance="high" Text="List of TypeScript files to be embedded in the VSIX:" />
+    <Message Importance="high" Text="  %(FilesToEmbed.Identity)" />
+
+    <Message Importance="high" Text="Copying files to $(TargetDirectory)..." />
+    <MakeDir Directories="$(TargetDirectory)" />
+    <Copy DestinationFolder="$(TargetDirectory)" SkipUnchangedFiles="true" SourceFiles="@(FilesToEmbed)" />
+
+    
+    <!-- We want to preserve the directory structure of the package directory
+         See https://docs.microsoft.com/en-us/visualstudio/msbuild/copy-task?view=vs-2019#example-2
+    -->
+    <Message Importance="high" Text="Package directory: $(PackageDirectoryToEmbed)" />
+
+    <ItemGroup>
+      <PackageSourceFiles Include="$(PackageDirectoryToEmbed)\**\*.*" />
+    </ItemGroup>
+    
+    <Message Importance="high" Text="List of packaged files to be embedded in the VSIX:" />
+    <Message Importance="high" Text="  %(PackageDirectoryToEmbed.Identity)" />
+    
+    <Copy SkipUnchangedFiles="true"
+          SourceFiles="@(PackageSourceFiles)"
+          DestinationFiles="@(PackageSourceFiles->'$(TargetDirectory)\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+
+  </Target>
+
+  <!-- ******************************************** -->
+  <!-- Common -->
+  <!-- ******************************************** -->
+
+  <Target Name="ValidateInputs">
+    <!-- Parameter validation -->
+    <Error Condition="$(PluginUrl)==''" Text="PluginUrl property must be specified (url from which the TypeScript jar can be downloaded)" />
+    <Error Condition="$(TargetDirectory)==''" Text="TargetDirectory property must be specified (i.e. destination to copy the TypeScript files to)" />
+  </Target>
+  
+  
+  <!-- ******************************************** -->
+  <!-- Targets to help with manual testing -->
+  <!-- ******************************************** -->
+  <!-- These targets exists to help test manually testing and debugging this targets file and the tasks in this project.
+       Just build from the command line specifying the target e.g.
+          
+          msbuild.exe /t:ManualTestCFamily
+          
+          or
+          
+          msbuild.exe /t:ManualTestTypeScript
+
+        Optionally, pass in the OutputDir and PluginUrl values to use.
+        To debug, add a call to "System.Diagnostics.Debugger.Launch();" in the code.
+  -->
+  
+  <Target Name="ManualTestCFamily">
+    
+    <PropertyGroup>
+      <OutputDir Condition=" $(OutputDir) == ''">$(MSBuildThisFileDirectory)ManualTestOutput</OutputDir>
+      <PluginUrl Condition=" $(PluginUrl)=='' ">https://binaries.sonarsource.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-6.17.0.27551.jar</PluginUrl>
+    </PropertyGroup>
+
+    <MSBuild Targets="Restore;Build;CopyEmbeddedFiles"
+             Projects ="$(MSBuildProjectFullPath)"
+             Properties="PluginUrl=$(PluginUrl);TargetDirectory=$(OutputDir)" />
+  </Target>
+
+  <Target Name="ManualTestTypeScript">
+    
+    <PropertyGroup>
+      <OutputDir Condition=" $(OutputDir) == ''">$(MSBuildThisFileDirectory)ManualTestOutput</OutputDir>
+      <PluginUrl Condition=" $(PluginUrl)=='' ">https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-6.2.0.12043.jar</PluginUrl>
+    </PropertyGroup>
+
+    <MSBuild Targets="Restore;Build;EmbedTypeScriptFiles"
+             Projects ="$(MSBuildProjectFullPath)"
+             Properties="PluginUrl=$(PluginUrl);TargetDirectory=$(OutputDir)" />
   </Target>
 
 </Project>

--- a/build/DownloadCFamilyPlugin/DownloadCFamilyPlugin.sln
+++ b/build/DownloadCFamilyPlugin/DownloadCFamilyPlugin.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DownloadCFamilyPlugin", "DownloadCFamilyPlugin.csproj", "{37E4D27F-FDAB-4D1D-8269-362ADC06D777}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{37E4D27F-FDAB-4D1D-8269-362ADC06D777}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37E4D27F-FDAB-4D1D-8269-362ADC06D777}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37E4D27F-FDAB-4D1D-8269-362ADC06D777}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37E4D27F-FDAB-4D1D-8269-362ADC06D777}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {12B97225-FE66-4177-8E41-2D51616C13DB}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Part of #2246

First part: add a new target and tasks to download the required files from the SonarJS plugin.