### PR TITLE
Updated SonarJS jar to internal version 7.4.0.15161

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <EmbeddedSonarAnalyzerVersion>8.19.0.28253</EmbeddedSonarAnalyzerVersion>
     <EmbeddedSonarCFamilyAnalyzerVersion>6.17.0.27551</EmbeddedSonarCFamilyAnalyzerVersion>
-    <EmbeddedSonarJSAnalyzerVersion>7.4.0.15103</EmbeddedSonarJSAnalyzerVersion>
+    <EmbeddedSonarJSAnalyzerVersion>7.4.0.15161</EmbeddedSonarJSAnalyzerVersion>
   </PropertyGroup>
  
 </Project>

--- a/src/EmbeddedVsix/EmbeddedVsix.csproj
+++ b/src/EmbeddedVsix/EmbeddedVsix.csproj
@@ -88,8 +88,7 @@
     <TypeScriptFolderName>ts</TypeScriptFolderName>
 	
 	<!-- TODO - delete the following property once the new version of the SonarJS plugin has been released. See #2270 -->
-	<PluginUrl>https://repox.jfrog.io/artifactory/sonarsource-public-dev/org/sonarsource/javascript/sonar-javascript-plugin/7.4.0.15103/sonar-javascript-plugin-$(EmbeddedSonarJSAnalyzerVersion).jar</PluginUrl>
-	
+	<PluginUrl>https://repox.jfrog.io/repox/sonarsource/org/sonarsource/javascript/sonar-javascript-plugin/$(EmbeddedSonarJSAnalyzerVersion)/sonar-javascript-plugin-$(EmbeddedSonarJSAnalyzerVersion).jar</PluginUrl>
 	
     <!-- Folder the embedded files should be copied to. This folder should be excluded from source code control. -->
     <TypeScriptTargetDirectory>$(MSBuildThisFileDirectory)$(TypeScriptFolderName)</TypeScriptTargetDirectory>


### PR DESCRIPTION
* unreleased, but the metadata file now contains JS rule definitions

Fixes #2282