### PR TITLE
Update change version script to handle embedded VSIX

### DIFF
--- a/build/ChangeVersion.proj
+++ b/build/ChangeVersion.proj
@@ -28,11 +28,19 @@
       <ExpectedMatchCount>1</ExpectedMatchCount>
     </AssemblyInformationalVersion>
 
-    <VsixVersion Include="$(SolutionRoot)\src\Integration.Vsix\Manifests\VS201*\source.extension.vsixmanifest">
+    <!-- Set VSIX version in all VSIXes, including the embedded vsix -->
+    <VsixVersion Include="$(SolutionRoot)\src\Integration.Vsix\Manifests\VS201*\source.extension.vsixmanifest;$(SolutionRoot)\src\EmbeddedVsix\source.extension.vsixmanifest">
       <Find>(?&lt;=Identity.*Version=")([^"]*)</Find>
       <ReplaceWith>$(VsixVersion)</ReplaceWith>
       <ExpectedMatchCount>1</ExpectedMatchCount>
     </VsixVersion>
+
+    <RefToEmbeddedVsix Include="$(SolutionRoot)\src\Integration.Vsix\Manifests\VS201*\source.extension.vsixmanifest">
+      <Find>(?&lt;=Dependency.*="EmbeddedVsix".*Version=")([^"]*)</Find>
+      <!-- Note square brackets i.e. "only this exact version" --> 
+      <ReplaceWith>[$(VsixVersion)]</ReplaceWith>
+      <ExpectedMatchCount>1</ExpectedMatchCount>
+    </RefToEmbeddedVsix>
 
     <VsPackageVersion Include="$(SolutionRoot)\src\Integration.Vsix\SonarLintIntegrationPackage.cs">
       <Find>(?&lt;=\[InstalledProductRegistration\("#110", "#112", ")([^"]*)</Find>
@@ -46,6 +54,7 @@
     <RegexTransform Items="@(AssemblyFileVersion)" />
     <RegexTransform Items="@(AssemblyInformationalVersion)" />
     <RegexTransform Items="@(VsixVersion)" />
+    <RegexTransform Items="@(RefToEmbeddedVsix)" />
     <RegexTransform Items="@(VsPackageVersion)" />
   </Target>
 </Project>

--- a/src/EmbeddedVsix/source.extension.vsixmanifest
+++ b/src/EmbeddedVsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="SonarLint.AdditionalFiles.95521f6c-c3e6-460d-b0e6-aa64acd2fdb1" Version="1.0" Language="en-US" Publisher="SonarSource" />
+        <Identity Id="SonarLint.AdditionalFiles.95521f6c-c3e6-460d-b0e6-aa64acd2fdb1" Version="4.34.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarLint.AdditionalFiles</DisplayName>
         <Description xml:space="preserve">VSIX to package additional files required by non-Roslyn analyzers</Description>
     </Metadata>

--- a/src/Integration.Vsix/Manifests/VS2015/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2015/source.extension.vsixmanifest
@@ -21,7 +21,7 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
-    <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[1.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
+    <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[4.34.0.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Integration" Path="|Integration|" />

--- a/src/Integration.Vsix/Manifests/VS2015_v3Manifest/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2015_v3Manifest/source.extension.vsixmanifest
@@ -22,7 +22,7 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
-    <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[1.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
+    <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[4.34.0.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Integration" Path="|Integration|" />

--- a/src/Integration.Vsix/Manifests/VS2017/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2017/source.extension.vsixmanifest
@@ -17,7 +17,7 @@
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
-    <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[1.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
+    <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[4.34.0.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Integration" Path="|Integration|" />

--- a/src/Integration.Vsix/Manifests/VS2019/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2019/source.extension.vsixmanifest
@@ -17,7 +17,7 @@
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
-        <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[1.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
+        <Dependency d:Source="Project" d:ProjectName="EmbeddedVsix" Version="[4.34.0.0]" d:InstallSource="Embed" d:VsixSubPath="EmbeddedVsix" Location="|EmbeddedVsix;VSIXContainerProjectOutputGroup|" DisplayName="|EmbeddedVsix;VSIXNameProjectOutputGroup|" Id="|EmbeddedVsix;VSIXIdentifierProjectOutputGroup|" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Integration" Path="|Integration|" />


### PR DESCRIPTION
* the embedded VSIX version number is set to be the same as the main VSIX
* the main VSIX manifests are changed to reference an specific embeded VSIX version

Manually tested: auto-upgrade correctly updates both embedded and main VSIXes, and removes the old versions.