### PR TITLE
Change EslintBridgeProcess log verbosity

### DIFF
--- a/src/TypeScript/EslintBridgeClient/EslintBridgeProcess.cs
+++ b/src/TypeScript/EslintBridgeClient/EslintBridgeProcess.cs
@@ -189,8 +189,6 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient
 
         private void TerminateRunningProcess()
         {
-            logger.LogDebug(Resources.INFO_TerminatingServer);
-
             try
             {
                 if (Process == null || Process.HasExited)
@@ -199,9 +197,11 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient
                 }
                 else
                 {
+                    var processId = Process.Id;
+                    logger.WriteLine(Resources.INFO_TerminatingServer, processId);
                     Process.Kill();
                     Process.Dispose();
-                    logger.LogDebug(Resources.INFO_ServerTerminated);
+                    logger.WriteLine(Resources.INFO_ServerTerminated, processId);
                 }
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))

--- a/src/TypeScript/EslintBridgeClient/Resources.Designer.cs
+++ b/src/TypeScript/EslintBridgeClient/Resources.Designer.cs
@@ -90,7 +90,7 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [eslint-bridge] EslintBridge process has already been terminated..
+        ///   Looks up a localized string similar to [eslint-bridge] Cannot terminate eslint-bridge process: no process is running..
         /// </summary>
         internal static string INFO_ServerAlreadyTerminated {
             get {
@@ -108,7 +108,7 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [eslint-bridge] Started eslint-bridge server. Process id: {0}.
+        ///   Looks up a localized string similar to [eslint-bridge] Started eslint-bridge process. Process id: {0}.
         /// </summary>
         internal static string INFO_ServerProcessId {
             get {
@@ -126,7 +126,7 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [eslint-bridge] EslintBridge process terminated..
+        ///   Looks up a localized string similar to [eslint-bridge] Terminated eslint-bridge process. Process id: {0}.
         /// </summary>
         internal static string INFO_ServerTerminated {
             get {
@@ -135,7 +135,7 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [eslint-bridge] Terminating EslintBridge process....
+        ///   Looks up a localized string similar to [eslint-bridge] Terminating eslint-bridge process... Process id: {0}.
         /// </summary>
         internal static string INFO_TerminatingServer {
             get {

--- a/src/TypeScript/EslintBridgeClient/Resources.resx
+++ b/src/TypeScript/EslintBridgeClient/Resources.resx
@@ -129,21 +129,21 @@
 {1}</value>
   </data>
   <data name="INFO_ServerAlreadyTerminated" xml:space="preserve">
-    <value>[eslint-bridge] EslintBridge process has already been terminated.</value>
+    <value>[eslint-bridge] Cannot terminate eslint-bridge process: no process is running.</value>
   </data>
   <data name="INFO_ServerHasExisted" xml:space="preserve">
     <value>[eslint-bridge] Server process HasExited: {0}</value>
   </data>
   <data name="INFO_ServerProcessId" xml:space="preserve">
-    <value>[eslint-bridge] Started eslint-bridge server. Process id: {0}</value>
+    <value>[eslint-bridge] Started eslint-bridge process. Process id: {0}</value>
   </data>
   <data name="INFO_ServerStarted" xml:space="preserve">
     <value>[eslint-bridge] Server running on port: {0}</value>
   </data>
   <data name="INFO_ServerTerminated" xml:space="preserve">
-    <value>[eslint-bridge] EslintBridge process terminated.</value>
+    <value>[eslint-bridge] Terminated eslint-bridge process. Process id: {0}</value>
   </data>
   <data name="INFO_TerminatingServer" xml:space="preserve">
-    <value>[eslint-bridge] Terminating EslintBridge process...</value>
+    <value>[eslint-bridge] Terminating eslint-bridge process... Process id: {0}</value>
   </data>
 </root>


### PR DESCRIPTION
Changing LogDebug to Writeline, so we could see the termination logs in non-debug mode.