### PR TITLE
Drop redundant GetSonarRuleKey method

### DIFF
--- a/src/TypeScript.UnitTests/Rules/RulesProviderTests.cs
+++ b/src/TypeScript.UnitTests/Rules/RulesProviderTests.cs
@@ -48,24 +48,5 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.Rules
 
             testSubject.GetDefinitions().Should().BeEquivalentTo(defns);
         }
-
-        [TestMethod]
-        [DataRow(null, null)]
-        [DataRow("unknown es lint key", null)]
-        [DataRow("eslint common", "typescript:common")]
-        [DataRow("eslint ts S1135", "typescript:S1135")]
-        [DataRow("ESLINT TS S1135", "typescript:S1135")] // case-insensitive
-        public void GetSonarRuleKey_ReturnsExpected(string eslintRuleKey, string expected)
-        {
-            var defns = new RuleDefinition[]
-            {
-                new RuleDefinition { EslintKey = "eslint common", RuleKey = "typescript:common"},
-                new RuleDefinition { EslintKey = "eslint ts S1135", RuleKey = "typescript:S1135"},
-                new RuleDefinition { EslintKey = "should be ignored", RuleKey = "foo"}
-            };
-
-            var testSubject = new RulesProvider(defns);
-            testSubject.GetSonarRuleKey(eslintRuleKey).Should().Be(expected);
-        }
     }
 }

--- a/src/TypeScript/Analyzer/EslintBridgeIssueConverter.cs
+++ b/src/TypeScript/Analyzer/EslintBridgeIssueConverter.cs
@@ -44,8 +44,8 @@ namespace SonarLint.VisualStudio.TypeScript.Analyzer
         public IAnalysisIssue Convert(string filePath, Issue issue)
         {
             var ruleDefinitions = rulesProvider.GetDefinitions();
-            var ruleDefinition = ruleDefinitions.SingleOrDefault(x => x.EslintKey == issue.RuleId);
-            var sonarRuleKey = rulesProvider.GetSonarRuleKey(issue.RuleId);
+            var ruleDefinition = ruleDefinitions.Single(x => x.EslintKey.Equals(issue.RuleId, StringComparison.OrdinalIgnoreCase));
+            var sonarRuleKey = ruleDefinition.RuleKey;
 
             return new AnalysisIssue(
                 sonarRuleKey,

--- a/src/TypeScript/Rules/RulesProviders.cs
+++ b/src/TypeScript/Rules/RulesProviders.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SonarLint.VisualStudio.TypeScript.Rules
 {
@@ -30,11 +29,6 @@ namespace SonarLint.VisualStudio.TypeScript.Rules
         /// Returns the metadata descriptions for all rules for a single language repository
         /// </summary>
         IEnumerable<RuleDefinition> GetDefinitions();
-
-        /// <summary>
-        /// Returns the rule key to display in VS for the specified ESLint rule
-        /// </summary>
-        string GetSonarRuleKey(string eslintRuleKey);
     }
 
     internal class RulesProvider : IRulesProvider
@@ -47,9 +41,5 @@ namespace SonarLint.VisualStudio.TypeScript.Rules
         }
 
         public IEnumerable<RuleDefinition> GetDefinitions() => ruleDefinitions;
-
-        public string GetSonarRuleKey(string eslintRuleKey) =>
-            ruleDefinitions.FirstOrDefault(x => x.EslintKey.Equals(eslintRuleKey, StringComparison.OrdinalIgnoreCase))
-                ?.RuleKey;
     }
 }


### PR DESCRIPTION
* it was only used by the issue converter, which had already fetched the appropriate rule definition