### PR TITLE
Set projectGuid to empty if there is no project file

### DIFF
--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -191,7 +191,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         {
             var project = GetProject();
 
-            if (project == null)
+            if (project == null || string.IsNullOrEmpty(project.FileName))
             {
                 return Guid.Empty;
             }


### PR DESCRIPTION
Fixes #2193

Seems that there is no concept of Current Project in the Error List for CMake projects.
For example, compiler errors are showed for all projects in the "solution" even when Current Project filter is selected:
![image](https://user-images.githubusercontent.com/60586879/125159475-dcff2a80-e177-11eb-8b0c-59cfecdf5134.png)

Hence, if we just return Guid.Empty for CMake projects, we will get the default VS's behavior.