### PR TITLE
Fix debug.assert failures

### DIFF
--- a/src/TypeScript.UnitTests/TsConfig/TsConfigProviderTests.cs
+++ b/src/TypeScript.UnitTests/TsConfig/TsConfigProviderTests.cs
@@ -67,24 +67,24 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_SourceFileIsNotInAnyTsConfig_Null()
         {
             const string testedFileName = "some file";
-            var tsConfigsInSolution = new[] { "config1", "config2", "config3" };
+            var tsConfigsInSolution = new[] { "c:\\config1", "c:\\config2", "c:\\config3" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config1", new TSConfigResponse()},
-                {"config2", new TSConfigResponse{Files = new List<string>{"some other file"}}},
-                {"config3", new TSConfigResponse{Files = new List<string>{"some file2"}}},
+                {"c:\\config1", new TSConfigResponse()},
+                {"c:\\config2", new TSConfigResponse{Files = new List<string>{"some other file"}}},
+                {"c:\\config3", new TSConfigResponse{Files = new List<string>{"some file2"}}},
             });
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object);
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
             result.Should().BeNull();
 
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config1", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config3", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config1", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config3", CancellationToken.None), Times.Once);
             eslintBridgeClient.VerifyNoOtherCalls();
         }
 
@@ -95,24 +95,24 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_SourceFileFoundInTsConfig_OtherTsConfigsNotChecked(string foundFileName)
         {
             const string testedFileName = "tested\\file";
-            var tsConfigsInSolution = new[] { "config1", "config2", "config3" };
+            var tsConfigsInSolution = new[] { "c:\\config1", "c:\\config2", "c:\\config3" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config1", new TSConfigResponse()},
-                {"config2", new TSConfigResponse{Files = new List<string>{foundFileName}}},
-                {"config3", new TSConfigResponse()},
+                {"c:\\config1", new TSConfigResponse()},
+                {"c:\\config2", new TSConfigResponse{Files = new List<string>{foundFileName}}},
+                {"c:\\config3", new TSConfigResponse()},
             });
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object);
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
-            result.Should().Be("config2");
+            result.Should().Be("c:\\config2");
 
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config1", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config3", CancellationToken.None), Times.Never);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config1", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config3", CancellationToken.None), Times.Never);
             eslintBridgeClient.VerifyNoOtherCalls();
         }
 
@@ -120,13 +120,13 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_TsConfigContainsFileWithIllegalCharacters_FileInTsConfigIsSkipped()
         {
             const string testedFileName = "tested\\file";
-            var tsConfigsInSolution = new[] { "config" };
+            var tsConfigsInSolution = new[] { "c:\\config" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config", new TSConfigResponse{Files = new List<string>
+                {"c:\\config", new TSConfigResponse{Files = new List<string>
                 {
                     "validPath",
                     "invalid\\*",
@@ -136,27 +136,27 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object);
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
-            result.Should().Be("config");
+            result.Should().Be("c:\\config");
         }
 
         [TestMethod]
         public async Task GetConfigForFile_FailedToProcessTsConfig_TsConfigIsSkipped()
         {
             const string testedFileName = "tested\\file";
-            var tsConfigsInSolution = new[] { "config1", "config2" };
+            var tsConfigsInSolution = new[] { "c:\\config1", "c:\\config2" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
                 {
-                    "config1", new TSConfigResponse
+                    "c:\\config1", new TSConfigResponse
                     {
                         Error = "some error",
                         Files = new[] {testedFileName} // should be ignored
                     }
                 },
-                {"config2", new TSConfigResponse()}
+                {"c:\\config2", new TSConfigResponse()}
             });
 
             var logger = new TestLogger();
@@ -164,8 +164,8 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
             result.Should().BeNull();
 
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config1", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config1", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
             eslintBridgeClient.VerifyNoOtherCalls();
 
             logger.AssertPartialOutputStringExists("some error");
@@ -175,7 +175,7 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_FailedToProcessTsConfig_ParsingError_TsConfigIsSkipped()
         {
             const string testedFileName = "tested\\file";
-            var tsConfigsInSolution = new[] { "config1", "config2" };
+            var tsConfigsInSolution = new[] { "c:\\config1", "c:\\config2" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
@@ -183,13 +183,13 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
                 {
-                    "config1", new TSConfigResponse
+                    "c:\\config1", new TSConfigResponse
                     {
                         ParsingError = parsingError,
                         Files = new[] {testedFileName} // should be ignored
                     }
                 },
-                {"config2", new TSConfigResponse()}
+                {"c:\\config2", new TSConfigResponse()}
             });
 
             var logger = new TestLogger();
@@ -197,8 +197,8 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
             result.Should().BeNull();
 
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config1", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config1", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
             eslintBridgeClient.VerifyNoOtherCalls();
 
             logger.AssertPartialOutputStringExists(parsingError.Message, parsingError.Code.ToString(), parsingError.Line.ToString());
@@ -208,30 +208,30 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_TsConfigHasProjectReferences_ProjectReferencesAreChecked()
         {
             const string testedFileName = "some file";
-            var tsConfigsInSolution = new[] { "config1", "config2" };
+            var tsConfigsInSolution = new[] { "c:\\config1", "c:\\config2" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
 
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config1", new TSConfigResponse()},
-                {"config2", new TSConfigResponse
+                {"c:\\config1", new TSConfigResponse()},
+                {"c:\\config2", new TSConfigResponse
                 {
                     Files = new List<string>{"some other file"},
-                    ProjectReferences = new List<string>{ "config3" }
+                    ProjectReferences = new List<string>{ "c:\\config3" }
 
                 }},
-                {"config3", new TSConfigResponse{Files = new List<string>{testedFileName}}}
+                {"c:\\config3", new TSConfigResponse{Files = new List<string>{testedFileName}}}
             });
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object);
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
-            result.Should().Be("config3");
+            result.Should().Be("c:\\config3");
 
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config1", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config3", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config1", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config3", CancellationToken.None), Times.Once);
             eslintBridgeClient.VerifyNoOtherCalls();
         }
 
@@ -239,19 +239,19 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_TsConfigHasProjectReferences_ProjectReferencesAreCheckedBeforeFiles()
         {
             const string testedFileName = "some file";
-            var tsConfigsInSolution = new[] { "config1" };
+            var tsConfigsInSolution = new[] { "c:\\config1" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
 
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config1", new TSConfigResponse
+                {"c:\\config1", new TSConfigResponse
                 {
                     Files = new List<string>{testedFileName},
-                    ProjectReferences = new List<string>{ "config2" }
+                    ProjectReferences = new List<string>{ "c:\\config2" }
                 }},
-                {"config2", new TSConfigResponse
+                {"c:\\config2", new TSConfigResponse
                 {
                     Files = new List<string>{testedFileName}
                 }}
@@ -259,40 +259,40 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object);
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
-            result.Should().Be("config2");
+            result.Should().Be("c:\\config2");
 
             // Veify that project references are checked before "TSConfigResponse.Files"
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
         }
 
         [TestMethod]
         public async Task GetConfigForFile_TsConfigHasProjectReferences_CircularReferencesAreIgnored()
         {
             const string testedFileName = "some file";
-            var tsConfigsInSolution = new[] { "config1", "config3" };
+            var tsConfigsInSolution = new[] { "c:\\config1", "c:\\config3" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
 
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config1", new TSConfigResponse{ProjectReferences = new List<string>{"config2"}}},
-                {"config2", new TSConfigResponse
+                {"c:\\config1", new TSConfigResponse{ProjectReferences = new List<string>{"c:\\config2"}}},
+                {"c:\\config2", new TSConfigResponse
                 {
                     Files = new List<string>{"some other file"},
-                    ProjectReferences = new List<string>{ "config1" } // circular loop
+                    ProjectReferences = new List<string>{ "c:\\config1" } // circular loop
 
                 }},
-                {"config3", new TSConfigResponse{Files = new List<string>{testedFileName}}}
+                {"c:\\config3", new TSConfigResponse{Files = new List<string>{testedFileName}}}
             });
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object);
             var result = await testSubject.GetConfigForFile(testedFileName, CancellationToken.None);
-            result.Should().Be("config3");
+            result.Should().Be("c:\\config3");
 
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config1", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config2", CancellationToken.None), Times.Once);
-            eslintBridgeClient.Verify(x => x.TsConfigFiles("config3", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config1", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config2", CancellationToken.None), Times.Once);
+            eslintBridgeClient.Verify(x => x.TsConfigFiles("c:\\config3", CancellationToken.None), Times.Once);
             eslintBridgeClient.VerifyNoOtherCalls();
         }
 
@@ -300,14 +300,14 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
         public async Task GetConfigForFile_TsConfigHasFolderProjectReference_ReferenceProcessedWithDefaultTsConfigName()
         {
             const string testedFileName = "some file";
-            var tsConfigsInSolution = new[] { "config1" };
+            var tsConfigsInSolution = new[] { "c:\\config1" };
             var tsConfigsLocator = SetupTsConfigsLocator(testedFileName, tsConfigsInSolution);
 
             var eslintBridgeClient = new Mock<ITypeScriptEslintBridgeClient>();
 
             SetupEslintBridgeResponse(eslintBridgeClient, new Dictionary<string, TSConfigResponse>
             {
-                {"config1", new TSConfigResponse
+                {"c:\\config1", new TSConfigResponse
                 {
                     ProjectReferences = new List<string>{"c:/a/b"}
                 }},
@@ -319,7 +319,7 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.TsConfig
             });
 
             var fileSystem = new Mock<IFileSystem>();
-            fileSystem.Setup(x => x.Directory.Exists("config1")).Returns(false);
+            fileSystem.Setup(x => x.Directory.Exists("c:\\config1")).Returns(false);
             fileSystem.Setup(x => x.Directory.Exists("c:/a/b")).Returns(true);
 
             var testSubject = CreateTestSubject(tsConfigsLocator.Object, eslintBridgeClient.Object, fileSystem.Object);


### PR DESCRIPTION
Minor nuisance fix: there is a debug.assert in the code that these tests are failing on.
https://github.com/SonarSource/sonarlint-visualstudio/blob/master/src/TypeScript/TsConfig/TsConfigProvider.cs#L94

No product changes.