### PR TITLE
Don't show verbose log output when node was not located

### DIFF
--- a/src/TypeScript.UnitTests/Analyzer/TypeScriptAnalyzerTests.cs
+++ b/src/TypeScript.UnitTests/Analyzer/TypeScriptAnalyzerTests.cs
@@ -183,6 +183,21 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.Analyzer
             eslintBridgeAnalyzer.Verify(x => x.Dispose(), Times.Once);
         }
 
+        [TestMethod, Description("Regression test for #2452")]
+        public async Task ExecuteAnalysis_EslintBridgeProcessLaunchException_NotifiesThatAnalysisFailedWithoutStackTrace()
+        {
+            var statusNotifier = new Mock<IAnalysisStatusNotifier>();
+            var exception = new EslintBridgeProcessLaunchException("this is a test");
+            var eslintBridgeAnalyzer = SetupEslintBridgeAnalyzer(exceptionToThrow: exception);
+
+            var testSubject = CreateTestSubject(eslintBridgeAnalyzer.Object, statusNotifier: statusNotifier.Object);
+            await testSubject.ExecuteAnalysis("some path", Mock.Of<IIssueConsumer>(), CancellationToken.None);
+
+            statusNotifier.Verify(x => x.AnalysisStarted("some path"), Times.Once);
+            statusNotifier.Verify(x => x.AnalysisFailed("some path", "this is a test"), Times.Once);
+            statusNotifier.VerifyNoOtherCalls();
+        }
+
         [TestMethod]
         public async Task ExecuteAnalysis_AnalysisFailed_NotifiesThatAnalysisFailed()
         {

--- a/src/TypeScript.UnitTests/EslintBridgeClient/EslintBridgeProcessTests.cs
+++ b/src/TypeScript.UnitTests/EslintBridgeClient/EslintBridgeProcessTests.cs
@@ -37,14 +37,14 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.EslintBridgeClient
     public class EslintBridgeProcessTests
     {
         [TestMethod]
-        public void Start_FailsToFindNode_FileNotFoundException()
+        public void Start_FailsToFindNode_EslintBridgeProcessLaunchException()
         {
             var nodeLocator = SetupNodeLocator(null);
 
             var testSubject = CreateTestSubject(nodeLocator: nodeLocator.Object);
             Func<Task> act = async () => await testSubject.Start();
 
-            act.Should().ThrowExactly<FileNotFoundException>().And.Message.Should().Contain("node.exe");
+            act.Should().ThrowExactly<EslintBridgeProcessLaunchException>().And.Message.Should().Contain("node.exe");
         }
 
         [TestMethod] // Regression test for #2370
@@ -139,7 +139,7 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.EslintBridgeClient
         }
 
         [TestMethod]
-        public void Start_FailsToFindStartupScript_FileNotFoundException()
+        public void Start_FailsToFindStartupScript_EslintBridgeProcessLaunchException()
         {
             const string filePath = "somefile.txt";
 
@@ -147,7 +147,7 @@ namespace SonarLint.VisualStudio.TypeScript.UnitTests.EslintBridgeClient
             var testSubject = CreateTestSubject(filePath, fileSystem: fileSystem.Object);
             Func<Task> act = async () => await testSubject.Start();
 
-            act.Should().ThrowExactly<FileNotFoundException>().And.Message.Should().Contain(filePath);
+            act.Should().ThrowExactly<EslintBridgeProcessLaunchException>().And.Message.Should().Contain(filePath);
         }
 
         [TestMethod]

--- a/src/TypeScript/Analyzer/JavaScriptAnalyzer.cs
+++ b/src/TypeScript/Analyzer/JavaScriptAnalyzer.cs
@@ -96,6 +96,10 @@ namespace SonarLint.VisualStudio.TypeScript.Analyzer
             {
                 analysisStatusNotifier.AnalysisCancelled(filePath);
             }
+            catch (EslintBridgeProcessLaunchException ex)
+            {
+                analysisStatusNotifier.AnalysisFailed(filePath, ex.Message);
+            }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
                 analysisStatusNotifier.AnalysisFailed(filePath, ex);

--- a/src/TypeScript/Analyzer/TypeScriptAnalyzer.cs
+++ b/src/TypeScript/Analyzer/TypeScriptAnalyzer.cs
@@ -99,6 +99,7 @@ namespace SonarLint.VisualStudio.TypeScript.Analyzer
                     analysisStatusNotifier.AnalysisFailed(filePath, Resources.ERR_NoTsConfig);
                     return;
                 }
+
                 logger.WriteLine("[TypescriptAnalyzer] time to find ts config: " + stopwatch.ElapsedMilliseconds);
 
                 stopwatch.Restart();
@@ -113,6 +114,10 @@ namespace SonarLint.VisualStudio.TypeScript.Analyzer
             catch (TaskCanceledException)
             {
                 analysisStatusNotifier.AnalysisCancelled(filePath);
+            }
+            catch (EslintBridgeProcessLaunchException ex)
+            {
+                analysisStatusNotifier.AnalysisFailed(filePath, ex.Message);
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {

--- a/src/TypeScript/EslintBridgeClient/EslintBridgeProcess.cs
+++ b/src/TypeScript/EslintBridgeClient/EslintBridgeProcess.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -47,6 +46,16 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient
         /// Returns true/false if the process is running.
         /// </summary>
         bool IsRunning { get; }
+    }
+
+    [Serializable]
+    internal class EslintBridgeProcessLaunchException : Exception
+    {
+        public EslintBridgeProcessLaunchException(string message) : base(message) { }
+        public EslintBridgeProcessLaunchException(string message, Exception inner) : base(message, inner) { }
+        protected EslintBridgeProcessLaunchException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 
     internal sealed class EslintBridgeProcess : IEslintBridgeProcess
@@ -235,7 +244,7 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient
 
             if (string.IsNullOrEmpty(nodePath))
             {
-                throw new FileNotFoundException("Could not find node.exe");
+                throw new EslintBridgeProcessLaunchException("Could not find node.exe");
             }
 
             return nodePath;
@@ -245,7 +254,7 @@ namespace SonarLint.VisualStudio.TypeScript.EslintBridgeClient
         {
             if (!fileSystem.File.Exists(eslintBridgeStartupScriptPath))
             {
-                throw new FileNotFoundException($"Could not find eslint-bridge startup script file: {eslintBridgeStartupScriptPath}");
+                throw new EslintBridgeProcessLaunchException($"Could not find eslint-bridge startup script file: {eslintBridgeStartupScriptPath}");
             }
 
             return GetQuotedScriptPath(eslintBridgeStartupScriptPath);


### PR DESCRIPTION
Fixes #2452