### PR TITLE
Update embedded CFamily analyzer to v6.26.0.36731

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -6,7 +6,7 @@
     <!-- Note: don't forget to upload the new packages to the package feed when changing 
          the SonarAnalyzer version -->
     <EmbeddedSonarAnalyzerVersion>8.26.0.34506</EmbeddedSonarAnalyzerVersion>
-    <EmbeddedSonarCFamilyAnalyzerVersion>6.23.0.34138</EmbeddedSonarCFamilyAnalyzerVersion>
+    <EmbeddedSonarCFamilyAnalyzerVersion>6.25.0.35661</EmbeddedSonarCFamilyAnalyzerVersion>
     <EmbeddedSonarJSAnalyzerVersion>8.1.0.15788</EmbeddedSonarJSAnalyzerVersion>
   </PropertyGroup>
  

--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -6,7 +6,7 @@
     <!-- Note: don't forget to upload the new packages to the package feed when changing 
          the SonarAnalyzer version -->
     <EmbeddedSonarAnalyzerVersion>8.26.0.34506</EmbeddedSonarAnalyzerVersion>
-    <EmbeddedSonarCFamilyAnalyzerVersion>6.25.0.35661</EmbeddedSonarCFamilyAnalyzerVersion>
+    <EmbeddedSonarCFamilyAnalyzerVersion>6.26.0.36731</EmbeddedSonarCFamilyAnalyzerVersion>
     <EmbeddedSonarJSAnalyzerVersion>8.1.0.15788</EmbeddedSonarJSAnalyzerVersion>
   </PropertyGroup>
  

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
@@ -40,12 +40,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
         // The QP filter has "active/inactive" tabs. The number of rules is shown in the top-right of the screen.
         // 5. Repeat for C++.
 
-        // Rule data for C-Family plugin v6.23 (build 34138)
+        // Rule data for C-Family plugin v6.25 (build 35661)
         private const int Active_C_Rules = 205;
         private const int Inactive_C_Rules = 103;
 
-        private const int Active_CPP_Rules = 388;
-        private const int Inactive_CPP_Rules = 161;
+        private const int Active_CPP_Rules = 391;
+        private const int Inactive_CPP_Rules = 162;
 
         private readonly CFamilySonarWayRulesConfigProvider rulesMetadataCache = new CFamilySonarWayRulesConfigProvider(CFamilyShared.CFamilyFilesDirectory);
 

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
@@ -40,11 +40,11 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
         // The QP filter has "active/inactive" tabs. The number of rules is shown in the top-right of the screen.
         // 5. Repeat for C++.
 
-        // Rule data for C-Family plugin v6.25 (build 35661)
+        // Rule data for C-Family plugin v6.26 (build 36731)
         private const int Active_C_Rules = 205;
         private const int Inactive_C_Rules = 103;
 
-        private const int Active_CPP_Rules = 391;
+        private const int Active_CPP_Rules = 395;
         private const int Inactive_CPP_Rules = 162;
 
         private readonly CFamilySonarWayRulesConfigProvider rulesMetadataCache = new CFamilySonarWayRulesConfigProvider(CFamilyShared.CFamilyFilesDirectory);

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
@@ -44,8 +44,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
         private const int Active_C_Rules = 205;
         private const int Inactive_C_Rules = 103;
 
-        private const int Active_CPP_Rules = 395;
-        private const int Inactive_CPP_Rules = 162;
+        private const int Active_CPP_Rules = 396;
+        private const int Inactive_CPP_Rules = 161;
 
         private readonly CFamilySonarWayRulesConfigProvider rulesMetadataCache = new CFamilySonarWayRulesConfigProvider(CFamilyShared.CFamilyFilesDirectory);
 


### PR DESCRIPTION
Release notes:
* `6.22` - https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10090&version=16806
* `6.23` - https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10090&version=16855
* `6.24` - https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10090&version=16866
* `6.25` - https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10090&version=16938
* `6.26` - https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10090&version=16932