### PR TITLE
Fix debug test failures

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CLangAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CLangAnalyzerTests.cs
@@ -99,7 +99,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
         [TestMethod]
         public void TriggerAnalysisAsync_StreamsIssuesFromSubProcessToConsumer()
         {
-            const string fileName = "c:\\data\\aaa\\bbb\file.txt";
+            const string fileName = "c:\\data\\aaa\\bbb\\file.txt";
             var rulesConfig = new DummyCFamilyRulesConfig("c")
                 .AddRule("rule1", isActive: true)
                 .AddRule("rule2", isActive: true);
@@ -173,7 +173,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
         [TestMethod]
         public void TriggerAnalysisAsync_IssuesForInactiveRulesAreNotStreamed()
         {
-            const string fileName = "c:\\data\\aaa\\bbb\file.txt";
+            const string fileName = "c:\\data\\aaa\\bbb\\file.txt";
             var rulesConfig = new DummyCFamilyRulesConfig("c")
                 .AddRule("inactiveRule", isActive: false)
                 .AddRule("activeRule", isActive: true);


### PR DESCRIPTION
Mea culpa - I didn't run all of the tests in debug after fixing the assertion to use `PathHelper`. Two of the tests failed in debug due to invalid paths, but of course this wasn't picked up by the CI.