### PR TITLE
Changed Request.EnvironmentVariables to IReadOnlyDictionary<>

### DIFF
--- a/src/Core/CFamily/IRequest.cs
+++ b/src/Core/CFamily/IRequest.cs
@@ -39,7 +39,7 @@ namespace SonarLint.VisualStudio.Core.CFamily
         /// <summary>
         /// Any environment variables that need to be passed to the subprocess. Can be null.
         /// </summary>
-        IDictionary<string, string> EnvironmentVariables { get; }
+        IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
 
         /// <summary>
         /// Serializes the request for diagnostic purposes

--- a/src/Integration.Vsix/CFamily/CMake/CompilationDatabaseRequest.cs
+++ b/src/Integration.Vsix/CFamily/CMake/CompilationDatabaseRequest.cs
@@ -61,7 +61,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.CMake
 
         public RequestContext Context { get; }
 
-        public IDictionary<string, string> EnvironmentVariables
+        public IReadOnlyDictionary<string, string> EnvironmentVariables
         {
             get
             {

--- a/src/Integration.Vsix/CFamily/ProcessRunner.cs
+++ b/src/Integration.Vsix/CFamily/ProcessRunner.cs
@@ -168,7 +168,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
             }
         }
 
-        private void SetEnvironmentVariables(ProcessStartInfo psi, IDictionary<string, string> envVariables)
+        private void SetEnvironmentVariables(ProcessStartInfo psi, IReadOnlyDictionary<string, string> envVariables)
         {
             if (envVariables == null)
             {

--- a/src/Integration.Vsix/CFamily/ProcessRunnerArguments.cs
+++ b/src/Integration.Vsix/CFamily/ProcessRunnerArguments.cs
@@ -72,7 +72,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
         /// <summary>
         /// Additional environments variables that should be set/overridden for the process. Can be null.
         /// </summary>
-        public IDictionary<string, string> EnvironmentVariables { get; set; }
+        public IReadOnlyDictionary<string, string> EnvironmentVariables { get; set; }
 
         public Action<StreamWriter> HandleInputStream { get; set; }
         public Action<StreamReader> HandleOutputStream { get; set; }

--- a/src/Integration.Vsix/CFamily/Request.cs
+++ b/src/Integration.Vsix/CFamily/Request.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily
         /// <summary>
         /// This protocol does not use environment variables
         /// </summary>
-        public IDictionary<string, string> EnvironmentVariables => null;
+        public IReadOnlyDictionary<string, string> EnvironmentVariables => null;
 
         // TODO - duplicate property - remove
         internal string CFamilyLanguage { get; set; }


### PR DESCRIPTION
There's no need for the settings to be writable, and the new VS environment variable provider returns 'IReadOnlyDictionary<>`, so I've switched to make everything read-only.