### PR TITLE
Simplify command line builds

### DIFF
--- a/SonarLint.VsTargetVersion.props
+++ b/SonarLint.VsTargetVersion.props
@@ -11,7 +11,11 @@
 
        Building from the command line
        ==============================
-       When building from the command line you must specify the version of VS to target e.g.
+       When building from the VS developer command line, by default the targeted version of VS will
+       depend on the version of the developer command prompt
+       i.e. building from the VS2019 developer command prompt will build for VS2019 etc.
+
+       Alternatively, you can explicitly specify the version of VS to target e.g.
 
          msbuild.exe SonarLint.VisualStudio.Integration.sln /p:VsTargetVersion=2017   
 
@@ -24,11 +28,8 @@
     <VsTargetVersionPropsImported>true</VsTargetVersionPropsImported>
   </PropertyGroup>
   
-  <!-- ************************************************************* -->
-  <!-- Building inside Visual Studio -->
-  <!-- ************************************************************* -->
   <!-- Set the VsTargetVersion based on the version of VS -->
-  <PropertyGroup Condition=" $(BuildingInsideVisualStudio) == 'true' AND $(VsTargetVersion) == '' " >
+  <PropertyGroup Condition=" $(VsTargetVersion) == '' " >
     <VsTargetVersion Condition="$(VisualStudioVersion)=='15.0'">2017</VsTargetVersion>
     <VsTargetVersion Condition="$(VisualStudioVersion)=='16.0'">2019</VsTargetVersion>
     <VsTargetVersion Condition="$(VisualStudioVersion)=='17.0'">2022</VsTargetVersion>


### PR DESCRIPTION
- no need to explicitly set VsTargetVersion unless you want to target a specific VS version