### PR TITLE
Remove ?? from VSIX description

### DIFF
--- a/src/Integration.Vsix/Manifests/VS2017/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2017/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
     <Identity Id="SonarLint.36871a7b-4853-481f-bb52-1835a874e81b" Version="5.3.0.0" Language="en-US" Publisher="SonarSource" />
     <DisplayName>SonarLint for Visual Studio 2017</DisplayName>
-    <Description xml:space="preserve">​​SonarLint helps you detect and fix coding issues so that the code committed is clean and safe. It supports C#, VB.NET, C, C++, JS, and TS and provides real-time feedback and clear fix guidance.</Description>
+    <Description xml:space="preserve">SonarLint helps you detect and fix coding issues so that the code committed is clean and safe. It supports C#, VB.NET, C, C++, JS, and TS and provides real-time feedback and clear fix guidance.</Description>
     <MoreInfo>http://vs.sonarlint.org</MoreInfo>
     <License>LICENSE</License>
     <GettingStartedGuide>http://vs.sonarlint.org</GettingStartedGuide>

--- a/src/Integration.Vsix/Manifests/VS2019/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2019/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
         <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
         <Identity Id="SonarLint.b986f788-6a16-4a3a-a68b-c757f6b1b7d5" Version="5.3.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarLint for Visual Studio 2019</DisplayName>
-        <Description xml:space="preserve">​​SonarLint helps you detect and fix coding issues so that the code committed is clean and safe. It supports C#, VB.NET, C, C++, JS, and TS and provides real-time feedback and clear fix guidance.</Description>
+      <Description xml:space="preserve">​​SonarLint helps you detect and fix coding issues so that the code committed is clean and safe. It supports C#, VB.NET, C, C++, JS, and TS and provides real-time feedback and clear fix guidance.</Description>
         <MoreInfo>http://vs.sonarlint.org</MoreInfo>
         <License>LICENSE</License>
         <GettingStartedGuide>http://vs.sonarlint.org</GettingStartedGuide>

--- a/src/Integration.Vsix/Manifests/VS2022/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2022/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
         <Identity Id="SonarLint.0DE19254-1DCA-4479-8EAF-58E5D677FF4D" Version="5.3.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarLint for Visual Studio 2022</DisplayName>
         <Preview>false</Preview>
-        <Description xml:space="preserve">​​SonarLint helps you detect and fix coding issues so that the code committed is clean and safe. It supports C#, VB.NET, C, C++, JS, and TS and provides real-time feedback and clear fix guidance.</Description>
+      <Description xml:space="preserve">SonarLint helps you detect and fix coding issues so that the code committed is clean and safe. It supports C#, VB.NET, C, C++, JS, and TS and provides real-time feedback and clear fix guidance.</Description>
         <MoreInfo>http://vs.sonarlint.org</MoreInfo>
         <License>LICENSE</License>
         <GettingStartedGuide>http://vs.sonarlint.org</GettingStartedGuide>


### PR DESCRIPTION
No idea why it happened or why simply removing and readding the `>` fixed it...

Before:
![image](https://user-images.githubusercontent.com/60586879/145851933-596405e3-c383-479b-a7d6-7a189f22f03f.png)

After:
![image](https://user-images.githubusercontent.com/60586879/145851909-8bac13aa-2c9d-4ad7-98af-08cba1b3ab8d.png)
