### PR TITLE
Fix2694: don't show "hide issue visualisation" menu for issues without secondary locations

### DIFF
--- a/src/IssueViz.UnitTests/Editor/QuickActions/IssueLocationActionsSourceTests.cs
+++ b/src/IssueViz.UnitTests/Editor/QuickActions/IssueLocationActionsSourceTests.cs
@@ -150,7 +150,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_NoSelectionTags_NoIssueTags_NoActions()
+        public void Get_Has_SuggestedActions_NoSelectionTags_NoIssueTags_NoActions()
         {
             var actionSets = GetSuggestedActions(
                 primaryIssues:Enumerable.Empty<IAnalysisIssueVisualization>(),
@@ -162,7 +162,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_NoSelectionTags_NoIssueTagsWithSecondaryLocations_NoActions()
+        public void Get_Has_SuggestedActions_NoSelectionTags_NoIssueTagsWithSecondaryLocations_NoActions()
         {
             var issuesWithoutSecondaryLocations = new[]
             {
@@ -180,7 +180,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_NoSelectionTags_HasIssueTagsWithSecondaryLocations_SelectIssueActions()
+        public void Get_Has_SuggestedActions_NoSelectionTags_HasIssueTagsWithSecondaryLocations_SelectIssueActions()
         {
             var issues = new[]
             {
@@ -204,7 +204,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_NoSelectionTags_HasSelectedIssueTag_SelectAndDeselectIssueAction()
+        public void Get_Has_SuggestedActions_NoSelectionTags_HasSelectedIssueTag_SelectAndDeselectIssueAction()
         {
             var issues = new[]
             {
@@ -226,7 +226,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_HasSelectionTags_NoIssueTags_DeselectIssueAction()
+        public void Get_Has_SuggestedActions_HasSelectionTags_NoIssueTags_DeselectIssueAction()
         {
             var secondaryLocations = new[]
             {
@@ -247,7 +247,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_HasSelectionTags_HasIssueTagsWithSecondaryLocations_SelectAndDeselectIssueActions()
+        public void Get_Has_SuggestedActions_HasSelectionTags_HasIssueTagsWithSecondaryLocations_SelectAndDeselectIssueActions()
         {
             var secondaryLocations = new[]
             {
@@ -278,7 +278,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void GetSuggestedActions_HasSelecttionTags_NoIssueTagsWithSecondaryLocations_NoActions()
+        public void Get_Has_SuggestedActions_HasSelecttionTags_NoIssueTagsWithSecondaryLocations_NoActions()
         {
             var issuesWithoutSecondaryLocations = new[]
             {
@@ -351,8 +351,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
             selectionService.Setup(x => x.SelectedIssue).Returns(selectedIssue);
 
             var testSubject = CreateTestSubject(selectedIssueLocationsTagAggregator.Object, issueLocationsTagAggregator.Object, selectionService.Object);
+            
+            //We are testing these two methods together because their logic is coupled. These methods should not act indepedently of each other. 
             var actualActionsSet = testSubject.GetSuggestedActions(null, mockSpan, CancellationToken.None);
-
             var hasActions = testSubject.HasSuggestedActionsAsync(null, mockSpan, CancellationToken.None).Result;
 
             return (actualActionsSet.ToList(), hasActions);

--- a/src/IssueViz.UnitTests/Editor/QuickActions/IssueLocationActionsSourceTests.cs
+++ b/src/IssueViz.UnitTests/Editor/QuickActions/IssueLocationActionsSourceTests.cs
@@ -269,6 +269,24 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
             (suggestedActions[1] as SelectIssueVisualizationAction).Issue.Should().Be(issues[1]);
         }
 
+        [TestMethod]
+        public void GetSuggestedActions_HasSelecttionTags_NoIssueTagsWithSecondaryLocations_NoActions()
+        {
+            var issuesWithoutSecondaryLocations = new[]
+            {
+                CreateIssueViz(),
+                CreateIssueViz()
+            };
+
+            var actionSets = GetSuggestedActions(
+                primaryIssues: issuesWithoutSecondaryLocations,
+                secondaryLocations: Enumerable.Empty<IAnalysisIssueLocationVisualization>(),
+                selectedIssue: issuesWithoutSecondaryLocations[0]);
+
+            actionSets.Should().BeEmpty();
+
+        }
+
         private static IAnalysisIssueVisualization CreateIssueViz(params IAnalysisIssueFlowVisualization[] flows)
         {
             var issueViz = new Mock<IAnalysisIssueVisualization>();

--- a/src/IssueViz/Editor/QuickActions/IssueLocationActionsSource.cs
+++ b/src/IssueViz/Editor/QuickActions/IssueLocationActionsSource.cs
@@ -79,7 +79,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
                 allActions.AddRange(actions);
             } 
 
-            if (IsOnSelectedVisualization(range))
+            if (IsOnSelectedVisualizationWithSecondaries(range))
             {
                 allActions.Add(new DeselectIssueVisualizationAction(selectionService));
             }
@@ -94,7 +94,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
 
         public Task<bool> HasSuggestedActionsAsync(ISuggestedActionCategorySet requestedActionCategories, SnapshotSpan range, CancellationToken cancellationToken)
         {
-            return Task.Factory.StartNew(() => IsOnIssueWithSecondaryLocations(range, out _) || IsOnSelectedVisualization(range),
+            return Task.Factory.StartNew(() => IsOnIssueWithSecondaryLocations(range, out _) || IsOnSelectedVisualizationWithSecondaries(range),
                 cancellationToken);
         }
 
@@ -110,12 +110,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
             return issuesWithSecondaryLocations.Any();
         }
 
-        private bool IsOnSelectedVisualization(SnapshotSpan range)
+        private bool IsOnSelectedVisualizationWithSecondaries(SnapshotSpan range)
         {
             var primaryLocationsTagSpans = issueLocationsTagAggregator.GetTags(range);
             var isOnSelectedPrimaryLocation = primaryLocationsTagSpans.Select(x => x.Tag.Location)
                 .OfType<IAnalysisIssueVisualization>()
-                .Any(x => x == selectionService.SelectedIssue);
+                .Any(x => x == selectionService.SelectedIssue && x.GetSecondaryLocations().Any());
 
             var selectedLocationsTagSpans = selectedIssueLocationsTagAggregator.GetTags(range);
             var isOnSelectedSecondaryLocation = selectedLocationsTagSpans.Any();


### PR DESCRIPTION
2694 Added existence of secondary location control for selected primary items