### PR TITLE
Fix build-time plugin download error caused by long paths

### DIFF
--- a/build/DownloadSonarPlugin/Common.cs
+++ b/build/DownloadSonarPlugin/Common.cs
@@ -33,6 +33,26 @@ namespace DownloadCFamilyPlugin
 {
     internal static class Common
     {
+        /// <summary>
+        /// Returns the full path to the local directory in which the plugin will be cached at build time
+        /// </summary>
+        /// <param name="pluginFolderName">Per-plugin unique folder name</param>
+        /// <remarks>By default the plugins will be stored under the user's %LocalAppData% folder e.g. C:\Users\JoeBloggs\AppData\Local.
+        /// An alternative root directory can be specified by setting the environment variable SONARLINT_INTERNAL_PLUGIN_CACHE_DIR.
+        /// This might be necessary if the user name is long so the full paths of the files being unpacked under the root folder
+        /// are exceed the maximum path length.</remarks>
+        public static string GetLocalBuildTimePluginCacheDir(string pluginFolderName)
+        {
+            var baseFolder = Environment.GetEnvironmentVariable("SONARLINT_INTERNAL_PLUGIN_CACHE_DIR");
+            if (string.IsNullOrEmpty(baseFolder))
+            {
+                baseFolder = Environment.GetEnvironmentVariable("LocalAppData");
+            }
+
+            var fullPath = Path.Combine(baseFolder, pluginFolderName);
+            return fullPath;
+        }
+
         public static void EnsureWorkingDirectoryExist(string localWorkingFolder, TaskLoggingHelper logger)
         {
             if (!Directory.Exists(localWorkingFolder))

--- a/build/DownloadSonarPlugin/Common.cs
+++ b/build/DownloadSonarPlugin/Common.cs
@@ -40,7 +40,7 @@ namespace DownloadCFamilyPlugin
         /// <remarks>By default the plugins will be stored under the user's %LocalAppData% folder e.g. C:\Users\JoeBloggs\AppData\Local.
         /// An alternative root directory can be specified by setting the environment variable SONARLINT_INTERNAL_PLUGIN_CACHE_DIR.
         /// This might be necessary if the user name is long so the full paths of the files being unpacked under the root folder
-        /// are exceed the maximum path length.</remarks>
+        /// exceed the maximum path length.</remarks>
         public static string GetLocalBuildTimePluginCacheDir(string pluginFolderName)
         {
             var baseFolder = Environment.GetEnvironmentVariable("SONARLINT_INTERNAL_PLUGIN_CACHE_DIR");

--- a/build/DownloadSonarPlugin/DownloadAndExtractCFamily.cs
+++ b/build/DownloadSonarPlugin/DownloadAndExtractCFamily.cs
@@ -82,7 +82,7 @@ namespace DownloadCFamilyPlugin
             var pluginFileName = Common.ExtractPluginFileNameFromUrl(DownloadUrl, Log);
 
             // Ensure working directories exists
-            var localWorkingFolder = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "SLVS_CFamily_Build");
+            var localWorkingFolder = Common.GetLocalBuildTimePluginCacheDir("SLVS_CFamily_Build");
             var perVersionPluginFolder = Path.Combine(localWorkingFolder, Path.GetFileNameWithoutExtension(pluginFileName));
             Common.EnsureWorkingDirectoryExist(perVersionPluginFolder, this.Log);
 

--- a/build/DownloadSonarPlugin/DownloadAndExtractSonarJS.cs
+++ b/build/DownloadSonarPlugin/DownloadAndExtractSonarJS.cs
@@ -85,7 +85,7 @@ namespace DownloadCFamilyPlugin
             var pluginFileName = Common.ExtractPluginFileNameFromUrl(DownloadUrl, Log);
 
             // Ensure working directories exists
-            var localWorkingFolder = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "SLVS_TypeScript_Build");
+            var localWorkingFolder = Common.GetLocalBuildTimePluginCacheDir("SLVS_TypeScript_Build");
             var perVersionPluginFolder = Path.Combine(localWorkingFolder, Path.GetFileNameWithoutExtension(pluginFileName));
             Common.EnsureWorkingDirectoryExist(perVersionPluginFolder, this.Log);
 


### PR DESCRIPTION
This is a change to a build-time helper project - no changes to product code.

Parts of the CFamily and JS/TS plugins are embedded in the VSIX we ship. At build time, we download and unpack the required plugins if they are not already on the machine.

Previously, the plugins were always cached under %LOCALAPPDATA%. However, a recent security change by the IT Ops teams meant they had to recreate my user account on my local dev machine. One effect of this is that the name of my local app data folder is now much longer, which is causing SLVS builds to fail on my machine because the paths created when unzipping the plugins are now too long.

The default behaviour hasn't changed. However, there is now a local environment variable that can be set to change the root download folder if necessary.