### PR TITLE
Show goldbar if server exclusions are different

### DIFF
--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
@@ -21,8 +21,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
-using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using FluentAssertions;
@@ -149,7 +149,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.SetBindingMode(SonarLintMode.LegacyConnected);
             SetSolutionExistsAndFullyLoadedContextState(isActive: true);
 
-            bindingRequiredIndicator.Setup(x => x.IsBindingUpdateRequired()).Returns(true);
+            bindingRequiredIndicator.Setup(x => x.IsBindingUpdateRequired(It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             var testSubject = CreateTestSubject();
 
@@ -170,7 +170,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.SetBindingMode(SonarLintMode.Connected);
             SetSolutionExistsAndFullyLoadedContextState(isActive: true);
 
-            bindingRequiredIndicator.Setup(x => x.IsBindingUpdateRequired()).Returns(true);
+            bindingRequiredIndicator.Setup(x => x.IsBindingUpdateRequired(It.IsAny<CancellationToken>())).ReturnsAsync(true);
             
             var testSubject = CreateTestSubject();
 
@@ -1001,7 +1001,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private void ConfigureLoadedSolution(bool hasUnboundProject = true)
         {
-            bindingRequiredIndicator.Setup(x => x.IsBindingUpdateRequired()).Returns(hasUnboundProject);
+            bindingRequiredIndicator.Setup(x => x.IsBindingUpdateRequired(It.IsAny<CancellationToken>())).ReturnsAsync(hasUnboundProject);
 
             SetSolutionExistsAndFullyLoadedContextState(isActive: true);
         }

--- a/src/Integration.UnitTests/LocalServices/UnboundSolutionCheckerTests.cs
+++ b/src/Integration.UnitTests/LocalServices/UnboundSolutionCheckerTests.cs
@@ -19,6 +19,8 @@
  */
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -32,14 +34,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         [TestMethod]
         [DataRow(true, false)]
         [DataRow(false, true)]
-        public void IsBindingUpdateRequired_ReturnsIfSettingsExist(bool settingsExist, bool expectedResult)
+        public async Task IsBindingUpdateRequired_ReturnsIfSettingsExist(bool settingsExist, bool expectedResult)
         {
             var exclusionsSettingStorage = new Mock<IExclusionSettingsStorage>();
             exclusionsSettingStorage.Setup(x => x.SettingsExist()).Returns(settingsExist);
 
             var testSubject = CreateTestSubject(exclusionsSettingStorage.Object);
 
-            var result = testSubject.IsBindingUpdateRequired();
+            var result = await testSubject.IsBindingUpdateRequired(CancellationToken.None);
 
             result.Should().Be(expectedResult);
             exclusionsSettingStorage.VerifyAll();
@@ -47,7 +49,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         }
 
         [TestMethod]
-        public void IsBindingUpdateRequired_FailedToFetchServerSettings_False()
+        public async Task IsBindingUpdateRequired_FailedToFetchServerSettings_False()
         {
             var exclusionsSettingStorage = new Mock<IExclusionSettingsStorage>();
             exclusionsSettingStorage
@@ -58,7 +60,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
 
             var testSubject = CreateTestSubject(exclusionsSettingStorage.Object, logger);
 
-            var result = testSubject.IsBindingUpdateRequired();
+            var result = await testSubject.IsBindingUpdateRequired(CancellationToken.None);
 
             result.Should().BeFalse();
             logger.AssertPartialOutputStringExists("this is a test");
@@ -74,7 +76,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
 
             var testSubject = CreateTestSubject(exclusionsSettingStorage.Object);
 
-            Action act = () => testSubject.IsBindingUpdateRequired();
+            Func<Task> act = async () => await testSubject.IsBindingUpdateRequired(CancellationToken.None);
 
             act.Should().Throw<StackOverflowException>();
         }

--- a/src/Integration.UnitTests/LocalServices/UnboundSolutionCheckerTests.cs
+++ b/src/Integration.UnitTests/LocalServices/UnboundSolutionCheckerTests.cs
@@ -25,27 +25,83 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Core.Binding;
+using SonarQube.Client;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
 {
     [TestClass]
     public class UnboundSolutionCheckerTests
     {
+        private const string ServerProjectKey = "my proj";
+
         [TestMethod]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        public async Task IsBindingUpdateRequired_ReturnsIfSettingsExist(bool settingsExist, bool expectedResult)
+        public async Task IsBindingUpdateRequired_SettingsDoNotExist_True()
         {
-            var exclusionsSettingStorage = new Mock<IExclusionSettingsStorage>();
-            exclusionsSettingStorage.Setup(x => x.SettingsExist()).Returns(settingsExist);
+            var exclusionsSettingStorage = SetupLocalExclusions(null);
 
             var testSubject = CreateTestSubject(exclusionsSettingStorage.Object);
 
             var result = await testSubject.IsBindingUpdateRequired(CancellationToken.None);
 
-            result.Should().Be(expectedResult);
+            result.Should().BeTrue();
             exclusionsSettingStorage.VerifyAll();
             exclusionsSettingStorage.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task IsBindingUpdateRequired_SettingsExist_ServerSettingsAreDifferent_True()
+        {
+            var localExclusions = new ServerExclusions(
+                exclusions: new[] { "1" },
+                globalExclusions: new[] { "2" },
+                inclusions: new[] { "3" });
+
+            var serverExclusions = new ServerExclusions(
+                exclusions: new[] { "4" },
+                globalExclusions: new[] { "5" },
+                inclusions: new[] { "6" });
+
+            var exclusionsSettingStorage = SetupLocalExclusions(localExclusions);
+            var sonarQubeServer = SetupServerExclusions(serverExclusions);
+
+            var testSubject = CreateTestSubject(exclusionsSettingStorage.Object, sonarQubeServer.Object);
+
+            var result = await testSubject.IsBindingUpdateRequired(CancellationToken.None);
+
+            result.Should().BeTrue();
+            exclusionsSettingStorage.VerifyAll();
+            exclusionsSettingStorage.VerifyNoOtherCalls();
+            sonarQubeServer.VerifyAll();
+            sonarQubeServer.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task IsBindingUpdateRequired_SettingsExist_ServerSettingsAreTheSame_False()
+        {
+            var localExclusions = new ServerExclusions(
+                exclusions: new[] { "1" },
+                globalExclusions: new[] { "2" },
+                inclusions: new[] { "3" });
+
+            var serverExclusions = new ServerExclusions(
+                exclusions: new[] { "1" },
+                globalExclusions: new[] { "2" },
+                inclusions: new[] { "3" });
+
+            var exclusionsSettingStorage = SetupLocalExclusions(localExclusions);
+            var sonarQubeServer = SetupServerExclusions(serverExclusions);
+
+            var testSubject = CreateTestSubject(exclusionsSettingStorage.Object, sonarQubeServer.Object);
+
+            var result = await testSubject.IsBindingUpdateRequired(CancellationToken.None);
+
+            result.Should().BeFalse();
+            exclusionsSettingStorage.VerifyAll();
+            exclusionsSettingStorage.VerifyNoOtherCalls();
+            sonarQubeServer.VerifyAll();
+            sonarQubeServer.VerifyNoOtherCalls();
         }
 
         [TestMethod]
@@ -53,12 +109,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         {
             var exclusionsSettingStorage = new Mock<IExclusionSettingsStorage>();
             exclusionsSettingStorage
-                .Setup(x => x.SettingsExist())
+                .Setup(x => x.GetSettings())
                 .Throws(new NotImplementedException("this is a test"));
 
             var logger = new TestLogger();
 
-            var testSubject = CreateTestSubject(exclusionsSettingStorage.Object, logger);
+            var testSubject = CreateTestSubject(exclusionsSettingStorage.Object, logger:logger);
 
             var result = await testSubject.IsBindingUpdateRequired(CancellationToken.None);
 
@@ -71,7 +127,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
         {
             var exclusionsSettingStorage = new Mock<IExclusionSettingsStorage>();
             exclusionsSettingStorage
-                .Setup(x => x.SettingsExist())
+                .Setup(x => x.GetSettings())
                 .Throws(new StackOverflowException());
 
             var testSubject = CreateTestSubject(exclusionsSettingStorage.Object);
@@ -81,11 +137,45 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.LocalServices
             act.Should().Throw<StackOverflowException>();
         }
 
-        private UnboundSolutionChecker CreateTestSubject(IExclusionSettingsStorage exclusionsSettingStorage, ILogger logger = null)
+        private UnboundSolutionChecker CreateTestSubject(IExclusionSettingsStorage exclusionsSettingStorage,
+            ISonarQubeService sonarQubeService = null,
+            ILogger logger = null)
         {
             logger ??= Mock.Of<ILogger>();
+            var bindingConfigurationProvider = SetupBindingConfiguration();
 
-            return new UnboundSolutionChecker(exclusionsSettingStorage, logger);
+            return new UnboundSolutionChecker(exclusionsSettingStorage, bindingConfigurationProvider.Object, sonarQubeService, logger);
+        }
+
+        private static Mock<IExclusionSettingsStorage> SetupLocalExclusions(ServerExclusions localExclusions)
+        {
+            var exclusionsSettingStorage = new Mock<IExclusionSettingsStorage>();
+            exclusionsSettingStorage.Setup(x => x.GetSettings()).Returns(localExclusions);
+            
+            return exclusionsSettingStorage;
+        }
+
+        private static Mock<ISonarQubeService> SetupServerExclusions(ServerExclusions serverExclusions)
+        {
+            var sonarQubeServer = new Mock<ISonarQubeService>();
+            sonarQubeServer.Setup(x => x.GetServerExclusions(ServerProjectKey, CancellationToken.None))
+                .ReturnsAsync(serverExclusions);
+           
+            return sonarQubeServer;
+        }
+
+        private Mock<IConfigurationProvider> SetupBindingConfiguration()
+        {
+            var bindingConfiguration =
+                new BindingConfiguration(
+                    new BoundSonarQubeProject(new Uri("http://localhost"), ServerProjectKey, null),
+                    SonarLintMode.Connected,
+                    null);
+
+            var bindingConfigProvider = new Mock<IConfigurationProvider>();
+            bindingConfigProvider.Setup(x => x.GetConfiguration()).Returns(bindingConfiguration);
+
+            return bindingConfigProvider;
         }
     }
 }

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -229,7 +229,7 @@ namespace SonarLint.VisualStudio.Integration
 
             this.OutputMessage(Strings.SonarLintCheckingForUnboundProjects);
 
-            var isBindingRequired = bindingChecker.IsBindingUpdateRequired();
+            var isBindingRequired = await bindingChecker.IsBindingUpdateRequired(CancellationToken.None);
 
             if (isBindingRequired)
             {

--- a/src/Integration/LocalServices/IBindingChecker.cs
+++ b/src/Integration/LocalServices/IBindingChecker.cs
@@ -19,6 +19,8 @@
  */
 
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using SonarLint.VisualStudio.Integration.Resources;
 
 namespace SonarLint.VisualStudio.Integration
@@ -28,7 +30,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// Returns true/false if the currently opened solution/folder and all the projects in it are properly bound
         /// </summary>
-        bool IsBindingUpdateRequired();
+        Task<bool> IsBindingUpdateRequired(CancellationToken token);
     }
 
     internal class BindingChecker : IBindingChecker
@@ -46,9 +48,11 @@ namespace SonarLint.VisualStudio.Integration
             this.logger = logger;
         }
 
-        public bool IsBindingUpdateRequired()
+        public async Task<bool> IsBindingUpdateRequired(CancellationToken token)
         {
-            if (unboundSolutionChecker.IsBindingUpdateRequired())
+            var solutionBindingRequired = await unboundSolutionChecker.IsBindingUpdateRequired(token);
+
+            if (solutionBindingRequired)
             {
                 logger.WriteLine(Strings.SonarLintFoundUnboundSolution);
                 return true;

--- a/src/Integration/LocalServices/IUnboundSolutionChecker.cs
+++ b/src/Integration/LocalServices/IUnboundSolutionChecker.cs
@@ -19,6 +19,8 @@
  */
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Helpers;
@@ -31,7 +33,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// Returns true/false if the currently opened solution/folder is bound and requires re-binding
         /// </summary>
-        bool IsBindingUpdateRequired();
+        Task<bool> IsBindingUpdateRequired(CancellationToken token);
     }
 
     internal class UnboundSolutionChecker : IUnboundSolutionChecker
@@ -45,7 +47,7 @@ namespace SonarLint.VisualStudio.Integration
             this.logger = logger;
         }
 
-        public bool IsBindingUpdateRequired()
+        public async Task<bool> IsBindingUpdateRequired(CancellationToken token)
         {
             try
             {

--- a/src/Integration/LocalServices/IUnboundSolutionChecker.cs
+++ b/src/Integration/LocalServices/IUnboundSolutionChecker.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using SonarLint.VisualStudio.Core;
@@ -68,6 +69,9 @@ namespace SonarLint.VisualStudio.Integration
                 }
 
                 var bindingConfiguration = bindingConfigProvider.GetConfiguration();
+
+                Debug.Assert(bindingConfiguration.Mode != SonarLintMode.Standalone, "Not expecting to be called in standalone mode.");
+
                 var serverExclusions = await sonarQubeService.GetServerExclusions(bindingConfiguration.Project.ProjectKey, token);
 
                 return !savedExclusions.Equals(serverExclusions);

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -334,6 +334,8 @@ namespace SonarLint.VisualStudio.Integration
                     new BindingChecker(
                         new UnboundSolutionChecker(
                             new ExclusionSettingsStorage(this.GetService<IConfigurationProviderService>(), Logger),
+                            this.GetService<IConfigurationProviderService>(),
+                            SonarQubeService,
                             Logger),
                         new UnboundProjectFinder(this, Logger), Logger),
                     Logger)));


### PR DESCRIPTION
Fixes [#3083](https://github.com/SonarSource/sonarlint-visualstudio/issues/3083)

Perhaps worth reviewing in separate commits: first commit changes the call to async, and second commit pulls exclusions from the server and compares.