### PR TITLE
moved result of GetContentTypeForExtension to a variable

### DIFF
--- a/src/Infrastructure.VS/LanguageDetection/SonarLanguageRecognizer.cs
+++ b/src/Infrastructure.VS/LanguageDetection/SonarLanguageRecognizer.cs
@@ -124,12 +124,13 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LanguageDetection
         {
             var extension = GetNormalizedExtention(fileName);
 
+            var contentTypeName = fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName;
+
             // ContentType for "js" is typescript we do manual check to be consistent with Detect method
             if (JavascriptSupportedExtensions.Contains(extension)) { return AnalysisLanguage.Javascript; }
-            if (fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName == TypeScriptTypeName) { return AnalysisLanguage.TypeScript; }
-            if (fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName == CFamilyTypeName) { return AnalysisLanguage.CFamily; }
-            if (fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName == CSharpTypeName 
-                || fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName == BasicTypeName) { return AnalysisLanguage.RoslynFamily; }
+            if (contentTypeName == TypeScriptTypeName) { return AnalysisLanguage.TypeScript; }
+            if (contentTypeName == CFamilyTypeName) { return AnalysisLanguage.CFamily; }
+            if (contentTypeName == CSharpTypeName || contentTypeName == BasicTypeName) { return AnalysisLanguage.RoslynFamily; }
 
             return null;
         }

--- a/src/Infrastructure.VS/LanguageDetection/SonarLanguageRecognizer.cs
+++ b/src/Infrastructure.VS/LanguageDetection/SonarLanguageRecognizer.cs
@@ -123,16 +123,23 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LanguageDetection
         public AnalysisLanguage? GetAnalysisLanguageFromExtension(string fileName)
         {
             var extension = GetNormalizedExtention(fileName);
-
-            var contentTypeName = fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName;
-
+            
             // ContentType for "js" is typescript we do manual check to be consistent with Detect method
             if (JavascriptSupportedExtensions.Contains(extension)) { return AnalysisLanguage.Javascript; }
-            if (contentTypeName == TypeScriptTypeName) { return AnalysisLanguage.TypeScript; }
-            if (contentTypeName == CFamilyTypeName) { return AnalysisLanguage.CFamily; }
-            if (contentTypeName == CSharpTypeName || contentTypeName == BasicTypeName) { return AnalysisLanguage.RoslynFamily; }
 
-            return null;
+            var contentTypeName = fileExtensionRegistryService.GetContentTypeForExtension(extension).TypeName;
+            switch (contentTypeName)
+            {
+                case TypeScriptTypeName:
+                    return AnalysisLanguage.TypeScript;
+                case CFamilyTypeName:
+                    return AnalysisLanguage.CFamily;
+                case CSharpTypeName:
+                case BasicTypeName:
+                    return AnalysisLanguage.RoslynFamily;
+                default:
+                    return null;                   
+            }
         }
 
         private string GetNormalizedExtention(string fileName)


### PR DESCRIPTION
Rita suggested this change after the merge of the branch. With using of GetContentTypeForExtension the result will not be different for each language anymore so no need to run the method multiple times. 