### PR TITLE
Move browser service interface to Core

### DIFF
--- a/src/Core/IVsBrowserService.cs
+++ b/src/Core/IVsBrowserService.cs
@@ -18,26 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.Shell;
-
 namespace SonarLint.VisualStudio.Infrastructure.VS
 {
     /// <summary>
-    /// Testable wrapper for <see cref="VsShellUtilities.OpenBrowser(string)"/>
+    /// Handles showing a page in a browser
     /// </summary>
     public interface IVsBrowserService
     {
         void Navigate(string url);
-    }
-
-    [Export(typeof(IVsBrowserService))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
-    internal class VsBrowserService : IVsBrowserService
-    {
-        public void Navigate(string url)
-        {
-            VsShellUtilities.OpenSystemBrowser(url);
-        }
     }
 }

--- a/src/Core/IVsBrowserService.cs
+++ b/src/Core/IVsBrowserService.cs
@@ -23,7 +23,7 @@ namespace SonarLint.VisualStudio.Core
     /// <summary>
     /// Handles showing a page in a browser
     /// </summary>
-    public interface IVsBrowserService
+    public interface IBrowserService
     {
         void Navigate(string url);
     }

--- a/src/Core/IVsBrowserService.cs
+++ b/src/Core/IVsBrowserService.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.Infrastructure.VS
+namespace SonarLint.VisualStudio.Core
 {
     /// <summary>
     /// Handles showing a page in a browser

--- a/src/Infrastructure.VS/VsBrowserService.cs
+++ b/src/Infrastructure.VS/VsBrowserService.cs
@@ -20,6 +20,7 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.Infrastructure.VS
 {

--- a/src/Infrastructure.VS/VsBrowserService.cs
+++ b/src/Infrastructure.VS/VsBrowserService.cs
@@ -24,9 +24,9 @@ using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.Infrastructure.VS
 {
-    [Export(typeof(IVsBrowserService))]
+    [Export(typeof(IBrowserService))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    internal class VsBrowserService : IVsBrowserService
+    internal class VsBrowserService : IBrowserService
     {
         public void Navigate(string url)
         {

--- a/src/Infrastructure.VS/VsBrowserService.cs
+++ b/src/Infrastructure.VS/VsBrowserService.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace SonarLint.VisualStudio.Infrastructure.VS
+{
+    [Export(typeof(IVsBrowserService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class VsBrowserService : IVsBrowserService
+    {
+        public void Navigate(string url)
+        {
+            VsShellUtilities.OpenSystemBrowser(url);
+        }
+    }
+}

--- a/src/Integration.UnitTests/Notifications/NotificationIndicatorViewModelTests.cs
+++ b/src/Integration.UnitTests/Notifications/NotificationIndicatorViewModelTests.cs
@@ -219,7 +219,7 @@ namespace SonarLint.VisualStudio.Integration.Notifications.UnitTests
         [TestMethod]
         public void NavigateToNotification_NotificationNavigated()
         {
-            var vsBrowserService = new Mock<IVsBrowserService>();
+            var vsBrowserService = new Mock<IBrowserService>();
             var testSubject = CreateTestSubject(vsBrowserService: vsBrowserService.Object);
 
             var notification = CreateNotification("test", "http://localhost:2000");
@@ -282,11 +282,11 @@ namespace SonarLint.VisualStudio.Integration.Notifications.UnitTests
 
         private NotificationIndicatorViewModel CreateTestSubject(ITimer timer = null, 
             IServerNotificationsTelemetryManager telemetryManager = null,
-            IVsBrowserService vsBrowserService = null)
+            IBrowserService vsBrowserService = null)
         {
             timer ??= Mock.Of<ITimer>();
             telemetryManager ??= Mock.Of<IServerNotificationsTelemetryManager>();
-            vsBrowserService ??= Mock.Of<IVsBrowserService>();
+            vsBrowserService ??= Mock.Of<IBrowserService>();
 
             return new NotificationIndicatorViewModel(telemetryManager, vsBrowserService, a => a(), timer);
         }

--- a/src/Integration.UnitTests/Notifications/NotificationIndicatorViewModelTests.cs
+++ b/src/Integration.UnitTests/Notifications/NotificationIndicatorViewModelTests.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarLint.VisualStudio.Infrastructure.VS;
 using SonarLint.VisualStudio.Integration.Telemetry;

--- a/src/Integration.Vsix.UnitTests/Settings/GeneralOptionsDialogPageTests.cs
+++ b/src/Integration.Vsix.UnitTests/Settings/GeneralOptionsDialogPageTests.cs
@@ -127,7 +127,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Settings
         [TestMethod]
         public void ClickHyperlink_ShowWikiCommandIsCalled()
         {
-            var browserService = new Mock<IVsBrowserService>();
+            var browserService = new Mock<IBrowserService>();
 
             GeneralOptionsDialogPageTestable page = new GeneralOptionsDialogPageTestable();
             ConfigureSiteMock(page, vsBrowserService: browserService.Object);
@@ -143,16 +143,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Settings
 
         private static void ConfigureSiteMock(GeneralOptionsDialogPage testSubject,
             ISonarLintSettings settings = null,
-            IVsBrowserService vsBrowserService = null)
+            IBrowserService vsBrowserService = null)
         {
             settings ??= new ConfigurableSonarLintSettings();
-            vsBrowserService ??= new Mock<IVsBrowserService>().Object;
+            vsBrowserService ??= new Mock<IBrowserService>().Object;
 
             var mefHostMock = new Mock<IComponentModel>();
             mefHostMock.Setup(m => m.GetExtensions<ISonarLintSettings>()).Returns(() => new[] { settings });
             mefHostMock.Setup(m => m.GetExtensions<ILogger>()).Returns(() => new[] { new TestLogger() });
             mefHostMock.Setup(m => m.GetExtensions<IUserSettingsProvider>()).Returns(() => new[] { new Mock<IUserSettingsProvider>().Object });
-            mefHostMock.Setup(m => m.GetExtensions<IVsBrowserService>()).Returns(() => new[] { vsBrowserService });
+            mefHostMock.Setup(m => m.GetExtensions<IBrowserService>()).Returns(() => new[] { vsBrowserService });
 
             var siteMock = new Mock<ISite>();
             siteMock.As<IServiceProvider>().Setup(m => m.GetService(It.Is<Type>(t => t == typeof(SComponentModel)))).Returns(mefHostMock.Object);

--- a/src/Integration.Vsix/Settings/GeneralOptionsDialogPage.cs
+++ b/src/Integration.Vsix/Settings/GeneralOptionsDialogPage.cs
@@ -46,7 +46,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 {
                     Debug.Assert(this.Site != null, "Expecting the page to be sited");
                     var userSettingsProvider = this.Site.GetMefService<IUserSettingsProvider>();
-                    var browserService = this.Site.GetMefService<IVsBrowserService>();
+                    var browserService = this.Site.GetMefService<IBrowserService>();
                     var logger = this.Site.GetMefService<ILogger>();
 
                     var openSettingsFileCmd = new OpenSettingsFileWpfCommand(this.Site, userSettingsProvider, this, logger);

--- a/src/Integration.Vsix/SonarLintNotificationsPackage.cs
+++ b/src/Integration.Vsix/SonarLintNotificationsPackage.cs
@@ -78,7 +78,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             AddOptionKey(NotificationDataKey);
 
             var telemetryManager = await this.GetMefServiceAsync<IServerNotificationsTelemetryManager>();
-            var vsBrowserService = await this.GetMefServiceAsync<Core.IVsBrowserService>();
+            var vsBrowserService = await this.GetMefServiceAsync<Core.IBrowserService>();
 
             notifications = new SonarQubeNotificationService(sonarqubeService,
                 new NotificationIndicatorViewModel(telemetryManager, vsBrowserService), new TimerWrapper { Interval = 60000 }, logger);

--- a/src/Integration.Vsix/SonarLintNotificationsPackage.cs
+++ b/src/Integration.Vsix/SonarLintNotificationsPackage.cs
@@ -78,7 +78,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             AddOptionKey(NotificationDataKey);
 
             var telemetryManager = await this.GetMefServiceAsync<IServerNotificationsTelemetryManager>();
-            var vsBrowserService = await this.GetMefServiceAsync<IVsBrowserService>();
+            var vsBrowserService = await this.GetMefServiceAsync<Core.IVsBrowserService>();
 
             notifications = new SonarQubeNotificationService(sonarqubeService,
                 new NotificationIndicatorViewModel(telemetryManager, vsBrowserService), new TimerWrapper { Interval = 60000 }, logger);

--- a/src/Integration/Notifications/NotificationIndicatorViewModel.cs
+++ b/src/Integration/Notifications/NotificationIndicatorViewModel.cs
@@ -50,7 +50,7 @@ namespace SonarLint.VisualStudio.Integration.Notifications
 
         public ICommand NavigateToNotification { get; }
 
-        public NotificationIndicatorViewModel(IServerNotificationsTelemetryManager telemetryManager, IVsBrowserService vsBrowserService)
+        public NotificationIndicatorViewModel(IServerNotificationsTelemetryManager telemetryManager, IBrowserService vsBrowserService)
             : this(telemetryManager, vsBrowserService, ThreadHelper.Generic.Invoke,
                   new TimerWrapper { AutoReset = false, Interval = 3000 /* 3 sec */})
         {
@@ -58,7 +58,7 @@ namespace SonarLint.VisualStudio.Integration.Notifications
 
         // For testing
         internal NotificationIndicatorViewModel(IServerNotificationsTelemetryManager telemetryManager, 
-            IVsBrowserService vsBrowserService,
+            IBrowserService vsBrowserService,
             Action<Action> uiThreadInvoker, 
             ITimer autocloseTimer)
         {

--- a/src/Integration/Notifications/NotificationIndicatorViewModel.cs
+++ b/src/Integration/Notifications/NotificationIndicatorViewModel.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Windows.Input;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
 using SonarLint.VisualStudio.Infrastructure.VS;
 using SonarLint.VisualStudio.Integration.Telemetry;

--- a/src/IssueViz.UnitTests/Helpers/ShowInBrowserServiceTests.cs
+++ b/src/IssueViz.UnitTests/Helpers/ShowInBrowserServiceTests.cs
@@ -41,7 +41,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Helpers
             {
                 MefTestHelpers.CreateExport<ISonarQubeService>(Mock.Of<ISonarQubeService>()),
                 MefTestHelpers.CreateExport<IConfigurationProvider>(Mock.Of<IConfigurationProvider>()),
-                MefTestHelpers.CreateExport<IVsBrowserService>(Mock.Of<IVsBrowserService>())
+                MefTestHelpers.CreateExport<IBrowserService>(Mock.Of<IBrowserService>())
             });
         }
 
@@ -64,7 +64,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Helpers
             configurationProvider.Setup(x => x.GetConfiguration()).Returns(BindingConfiguration.Standalone);
 
             var sonarQubeService = new Mock<ISonarQubeService>();
-            var browserService = new Mock<IVsBrowserService>();
+            var browserService = new Mock<IBrowserService>();
 
             var testSubject = CreateTestSubject(sonarQubeService.Object, configurationProvider.Object, browserService.Object);
             testSubject.ShowIssue("issue");
@@ -89,7 +89,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Helpers
                 .Setup(x => x.GetViewIssueUrl(projectKey, issueKey))
                 .Returns(new Uri("http://localhost:123/expected/issue?id=1"));
 
-            var browserService = new Mock<IVsBrowserService>();
+            var browserService = new Mock<IBrowserService>();
 
             var testSubject = CreateTestSubject(sonarQubeService.Object, configurationProvider.Object, browserService.Object);
             testSubject.ShowIssue(issueKey);
@@ -101,7 +101,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Helpers
         [TestMethod]
         public void ShowDocumentation_BrowserOpened()
         {
-            var browserService = new Mock<IVsBrowserService>();
+            var browserService = new Mock<IBrowserService>();
 
             var testSubject = CreateTestSubject(browserService: browserService.Object);
 
@@ -118,7 +118,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Helpers
             const string ruleUrl = "some url";
 
             var helpLinkProvider = new Mock<IRuleHelpLinkProvider>();
-            var browserService = new Mock<IVsBrowserService>();
+            var browserService = new Mock<IBrowserService>();
             helpLinkProvider.Setup(x => x.GetHelpLink(ruleKey)).Returns(ruleUrl);
 
             var testSubject = CreateTestSubject(browserService: browserService.Object, helpLinkProvider: helpLinkProvider.Object);
@@ -131,12 +131,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Helpers
 
         private ShowInBrowserService CreateTestSubject(ISonarQubeService sonarQubeService = null,
             IConfigurationProvider configurationProvider = null,
-            IVsBrowserService browserService = null,
+            IBrowserService browserService = null,
             IRuleHelpLinkProvider helpLinkProvider = null)
         {
             sonarQubeService ??= Mock.Of<ISonarQubeService>();
             configurationProvider ??= Mock.Of<IConfigurationProvider>();
-            browserService ??= Mock.Of<IVsBrowserService>();
+            browserService ??= Mock.Of<IBrowserService>();
             helpLinkProvider ??= Mock.Of<IRuleHelpLinkProvider>();
 
             return new ShowInBrowserService(sonarQubeService, configurationProvider, browserService, helpLinkProvider);

--- a/src/IssueViz/Helpers/ShowInBrowserService.cs
+++ b/src/IssueViz/Helpers/ShowInBrowserService.cs
@@ -42,20 +42,20 @@ namespace SonarLint.VisualStudio.IssueVisualization.Helpers
     {
         private readonly ISonarQubeService sonarQubeService;
         private readonly IConfigurationProvider configurationProvider;
-        private readonly IVsBrowserService vsBrowserService;
+        private readonly IBrowserService vsBrowserService;
         private readonly IRuleHelpLinkProvider ruleHelpLinkProvider;
 
         [ImportingConstructor]
         public ShowInBrowserService(ISonarQubeService sonarQubeService,
             IConfigurationProvider configurationProvider,
-            IVsBrowserService vsBrowserService)
+            IBrowserService vsBrowserService)
             : this(sonarQubeService, configurationProvider, vsBrowserService, new RuleHelpLinkProvider())
         {
         }
 
         internal ShowInBrowserService(ISonarQubeService sonarQubeService,
             IConfigurationProvider configurationProvider,
-            IVsBrowserService vsBrowserService,
+            IBrowserService vsBrowserService,
             IRuleHelpLinkProvider ruleHelpLinkProvider)
         {
             this.sonarQubeService = sonarQubeService;


### PR DESCRIPTION
Previously, the interface was in `Infrastructure.VS`, but there are no VS types in the interface so it could be in `Core`.

The first commit moves the interface.
The second changes the namespace.
The third renames the class from `IVsBrowserService` to `IBrowserService`.

I thought this change would help make the "More info" (show wiki page) action for the NodeJS notification slightly cleaner, but on looking at it again it doesn't make any difference in that case since the `TypeScript` project already referenced `Infrastructure.VS`. Still, it is a cleaner separation so I think it's worth keeping.