### PR TITLE
Working configuration for VSTHRD Analyzer to recognize ThrowIfNotOnUIThread in the IThreadHandling class.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
+	<AdditionalFiles Include="$(MSBuildThisFileDirectory)vs-threading.MainThreadAssertingMethods.txt">
+	      <Link>Properties\vs-threading.MainThreadAssertingMethods.txt</Link>
+    </AdditionalFiles>
   </ItemGroup>
 
 </Project>

--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -83,8 +83,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         private async System.Threading.Tasks.Task InitOnUIThreadAsync()
         {
-            threadHandling.ThrowIfNotOnUIThread();
-
             try
             {
                 logger = await this.GetMefServiceAsync<ILogger>();

--- a/src/vs-threading.MainThreadAssertingMethods.txt
+++ b/src/vs-threading.MainThreadAssertingMethods.txt
@@ -1,0 +1,1 @@
+[SonarLint.VisualStudio.Core.IThreadHandling]::ThrowIfNotOnUIThread


### PR DESCRIPTION
Fixes https://github.com/SonarSource/sonarlint-visualstudio/issues/3169

The only method that is available to be recognized is ThrowIfNotOnUIThread as our method signature for RunOnUIThread differs from the original implementation.