### PR TITLE
Update web client to get branch-aware APIs

### DIFF
--- a/src/Integration.UnitTests/Suppression/SonarQubeIssuesProviderTests.cs
+++ b/src/Integration.UnitTests/Suppression/SonarQubeIssuesProviderTests.cs
@@ -734,7 +734,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
                     })
                 .Verifiable();
 
-            mockSqService.Setup(x => x.GetSuppressedIssuesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            mockSqService.Setup(x => x.GetSuppressedIssuesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(serviceFetchIssuesTask)
                 .Verifiable();
         }
@@ -759,12 +759,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Suppression
 
         private void VerifyServiceGetIssues(Times expected)
         {
-            mockSqService.Verify(x => x.GetSuppressedIssuesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), expected);
+            mockSqService.Verify(x => x.GetSuppressedIssuesAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()), expected);
         }
 
         private void VerifyServiceGetIssues(Times expected, string sonarQubeProjectKey)
         {
-            mockSqService.Verify(x => x.GetSuppressedIssuesAsync(sonarQubeProjectKey, It.IsAny<CancellationToken>()), expected);
+            mockSqService.Verify(x => x.GetSuppressedIssuesAsync(sonarQubeProjectKey, null, It.IsAny<CancellationToken>()), expected);
         }
 
         private void VerifyServiceIsConnected(Times expected)

--- a/src/Integration/Suppression/SonarQubeIssuesProvider.cs
+++ b/src/Integration/Suppression/SonarQubeIssuesProvider.cs
@@ -204,6 +204,7 @@ namespace SonarLint.VisualStudio.Integration.Suppression
                     .ToDictionary(x => x.Key, x => x.RelativePathToRoot);
                 this.hasModules = moduleKeyToRelativePathToRoot.Keys.Count > 1;
                 this.allSuppressedIssues = await this.sonarQubeService.GetSuppressedIssuesAsync(sonarQubeProjectKey,
+                    null, // TODO - pass the current branch
                     cancellationTokenSource.Token);
                 this.suppressedModuleIssues = allSuppressedIssues.Where(x => string.IsNullOrEmpty(x.FilePath))
                     .GroupBy(x => x.ModuleKey)

--- a/src/IssueViz.Security.UnitTests/Taint/TaintIssuesSynchronizerTests.cs
+++ b/src/IssueViz.Security.UnitTests/Taint/TaintIssuesSynchronizerTests.cs
@@ -222,7 +222,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Taint
         public async Task SynchronizeWithServer_FailureToSync_StoreCleared()
         {
             var sonarServerMock = CreateSonarService();
-            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, CancellationToken.None))
+            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, CancellationToken.None))
                 .Throws(new Exception("this is a test"));
 
             var taintStore = new Mock<ITaintStore>();
@@ -239,7 +239,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Taint
             var logger = new TestLogger();
 
             var sonarServerMock = CreateSonarService();
-            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, CancellationToken.None))
+            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, CancellationToken.None))
                 .Throws(new Exception("this is a test"));
 
             var testSubject = CreateTestSubject(logger: logger, sonarService: sonarServerMock.Object);
@@ -254,7 +254,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Taint
         public async Task SynchronizeWithServer_CriticalException_ExceptionNotCaught()
         {
             var sonarServerMock = CreateSonarService();
-            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, CancellationToken.None))
+            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, CancellationToken.None))
                 .Throws(new StackOverflowException());
 
             var testSubject = CreateTestSubject(sonarService: sonarServerMock.Object);
@@ -391,7 +391,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Taint
             const uint cookie = 1001;
 
             var sonarServerMock = CreateSonarService();
-            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, CancellationToken.None))
+            sonarServerMock.Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, CancellationToken.None))
                 .Throws(new Exception("this is a test"));
 
             var monitorMock = CreateMonitorSelectionMock(cookie);
@@ -513,10 +513,10 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Taint
             serviceMock.Verify(x => x.GetServerInfo(), Times.Once);
 
         private static void CheckIssuesAreFetched(Mock<ISonarQubeService> serviceMock) =>
-            serviceMock.Verify(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, It.IsAny<CancellationToken>()), Times.Once);
+            serviceMock.Verify(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, It.IsAny<CancellationToken>()), Times.Once);
 
         private static void CheckIssuesAreNotFetched(Mock<ISonarQubeService> serviceMock) =>
-            serviceMock.Verify(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, It.IsAny<CancellationToken>()), Times.Never);
+            serviceMock.Verify(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, It.IsAny<CancellationToken>()), Times.Never);
 
         private static void CheckToolWindowServiceIsCalled(Mock<IToolWindowService> toolWindowServiceMock) =>
             toolWindowServiceMock.Verify(x => x.EnsureToolWindowExists(TaintToolWindow.ToolWindowId), Times.Once);
@@ -549,7 +549,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Taint
         private void SetupTaintIssues(Mock<ISonarQubeService> sonarQubeService, params SonarQubeIssue[] issues)
         {
             sonarQubeService
-                .Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, CancellationToken.None))
+                .Setup(x => x.GetTaintVulnerabilitiesAsync(SharedProjectKey, null, CancellationToken.None))
                 .ReturnsAsync(issues);
         }
     }

--- a/src/IssueViz.Security/Taint/TaintIssuesSynchronizer.cs
+++ b/src/IssueViz.Security/Taint/TaintIssuesSynchronizer.cs
@@ -92,7 +92,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
                 }
 
                 var projectKey = bindingConfiguration.Project.ProjectKey;
-                var taintVulnerabilities = await sonarQubeService.GetTaintVulnerabilitiesAsync(projectKey, CancellationToken.None);
+                var taintVulnerabilities = await sonarQubeService.GetTaintVulnerabilitiesAsync(projectKey,
+                    null, // TODO - pass the current branch
+                    CancellationToken.None);
 
                 logger.WriteLine(TaintResources.Synchronizer_NumberOfServerIssues, taintVulnerabilities.Count);
 


### PR DESCRIPTION
Fix up calling code (by passing `null` for the `branch` parameter)

Fixes #3396
