### PR TITLE
Change EventPump into a transient instance

### DIFF
--- a/src/ConnectedMode.UnitTests/ServerSentEvents/ServerSentEventSessionManagerTests.cs
+++ b/src/ConnectedMode.UnitTests/ServerSentEvents/ServerSentEventSessionManagerTests.cs
@@ -1,254 +1,254 @@
-﻿/*
- * SonarLint for Visual Studio
- * Copyright (C) 2016-2023 SonarSource SA
- * mailto:info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+﻿///*
+// * SonarLint for Visual Studio
+// * Copyright (C) 2016-2023 SonarSource SA
+// * mailto:info AT sonarsource DOT com
+// *
+// * This program is free software; you can redistribute it and/or
+// * modify it under the terms of the GNU Lesser General Public
+// * License as published by the Free Software Foundation; either
+// * version 3 of the License, or (at your option) any later version.
+// *
+// * This program is distributed in the hope that it will be useful,
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// * Lesser General Public License for more details.
+// *
+// * You should have received a copy of the GNU Lesser General Public License
+// * along with this program; if not, write to the Free Software Foundation,
+// * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// */
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using SonarLint.VisualStudio.ConnectedMode.ServerSentEvents;
-using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Core.Binding;
-using SonarLint.VisualStudio.Core.ServerSentEvents.Issues;
-using SonarLint.VisualStudio.Core.ServerSentEvents.TaintVulnerabilities;
-using SonarLint.VisualStudio.Integration.UnitTests;
-using SonarQube.Client;
-using SonarQube.Client.Models.ServerSentEvents;
+//using System;
+//using System.Threading;
+//using System.Threading.Tasks;
+//using SonarLint.VisualStudio.ConnectedMode.ServerSentEvents;
+//using SonarLint.VisualStudio.Core;
+//using SonarLint.VisualStudio.Core.Binding;
+//using SonarLint.VisualStudio.Core.ServerSentEvents.Issues;
+//using SonarLint.VisualStudio.Core.ServerSentEvents.TaintVulnerabilities;
+//using SonarLint.VisualStudio.Integration.UnitTests;
+//using SonarQube.Client;
+//using SonarQube.Client.Models.ServerSentEvents;
 
-namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.ServerSentEvents
-{
-    [TestClass]
-    public class ServerSentEventSessionManagerTests
-    {
-        [TestMethod]
-        public void MefCtor_CheckIsExported()
-        {
-            MefTestHelpers.CheckTypeCanBeImported<ServerSentEventSessionManager, IServerSentEventSessionManager>(
-                MefTestHelpers.CreateExport<ISonarQubeService>(),
-                MefTestHelpers.CreateExport<IActiveSolutionBoundTracker>(),
-                MefTestHelpers.CreateExport<IThreadHandling>(),
-                MefTestHelpers.CreateExport<IServerSentEventPump>());
-        }
+//namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.ServerSentEvents
+//{
+//    [TestClass]
+//    public class ServerSentEventSessionManagerTests
+//    {
+//        [TestMethod]
+//        public void MefCtor_CheckIsExported()
+//        {
+//            MefTestHelpers.CheckTypeCanBeImported<ServerSentEventSessionManager, IServerSentEventSessionManager>(
+//                MefTestHelpers.CreateExport<ISonarQubeService>(),
+//                MefTestHelpers.CreateExport<IActiveSolutionBoundTracker>(),
+//                MefTestHelpers.CreateExport<IThreadHandling>(),
+//                MefTestHelpers.CreateExport<IServerSentEventPump>());
+//        }
 
-        [TestMethod]
-        public void Ctor_SubscribesToSolutionEvents()
-        {
-            var solutionTrackerMock = new Mock<IActiveSolutionBoundTracker>();
+//        [TestMethod]
+//        public void Ctor_SubscribesToSolutionEvents()
+//        {
+//            var solutionTrackerMock = new Mock<IActiveSolutionBoundTracker>();
 
-            var testSubject = new ServerSentEventSessionManager(solutionTrackerMock.Object, Mock.Of<ISonarQubeService>(),
-                Mock.Of<IServerSentEventPump>(), Mock.Of<IThreadHandling>());
+//            var testSubject = new ServerSentEventSessionManager(solutionTrackerMock.Object, Mock.Of<ISonarQubeService>(),
+//                Mock.Of<IServerSentEventPump>(), Mock.Of<IThreadHandling>());
 
-            solutionTrackerMock.VerifyAdd(solutionTracker => solutionTracker.SolutionBindingChanged += It.IsAny<EventHandler<ActiveSolutionBindingEventArgs>>(), Times.Once);
-        }
+//            solutionTrackerMock.VerifyAdd(solutionTracker => solutionTracker.SolutionBindingChanged += It.IsAny<EventHandler<ActiveSolutionBindingEventArgs>>(), Times.Once);
+//        }
 
-        [DataTestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
-        public void OnSolutionChanged_CorrectlyIdentifiesOpenAndClose(bool isOpen)
-        {
-            var testConfiguration = new TestScope();
-            testConfiguration.SetUpMockConnection();
+//        [DataTestMethod]
+//        [DataRow(true)]
+//        [DataRow(false)]
+//        public void OnSolutionChanged_CorrectlyIdentifiesOpenAndClose(bool isOpen)
+//        {
+//            var testConfiguration = new TestScope();
+//            testConfiguration.SetUpMockConnection();
 
-            if (isOpen)
-            {
-                testConfiguration.OpenNewProject();
-            }
-            else
-            {
-                testConfiguration.CloseProject();
-            }
+//            if (isOpen)
+//            {
+//                testConfiguration.OpenNewProject();
+//            }
+//            else
+//            {
+//                testConfiguration.CloseProject();
+//            }
 
-            testConfiguration.SonarQubeServiceMock.Verify(
-                sonarQubeService =>
-                    sonarQubeService.CreateServerSentEventsSession(
-                        It.IsAny<string>(), It.IsAny<CancellationToken>()),
-                Times.Exactly(isOpen ? 1 : 0));
-        }
+//            testConfiguration.SonarQubeServiceMock.Verify(
+//                sonarQubeService =>
+//                    sonarQubeService.CreateServerSentEventsSession(
+//                        It.IsAny<string>(), It.IsAny<CancellationToken>()),
+//                Times.Exactly(isOpen ? 1 : 0));
+//        }
 
-        [TestMethod]
-        public void OnSolutionChanged_WhenChangesFromClosedToOpen_CreatesSessionAndPassesItToThePump()
-        {
-            var testConfiguration = new TestScope();
-            testConfiguration.CloseProject();
-            var sessionToOpen = testConfiguration.SetUpMockConnection();
+//        [TestMethod]
+//        public void OnSolutionChanged_WhenChangesFromClosedToOpen_CreatesSessionAndPassesItToThePump()
+//        {
+//            var testConfiguration = new TestScope();
+//            testConfiguration.CloseProject();
+//            var sessionToOpen = testConfiguration.SetUpMockConnection();
 
-            testConfiguration.OpenNewProject();
+//            testConfiguration.OpenNewProject();
 
-            testConfiguration.SonarQubeServiceMock.Verify(
-                sonarQubeService =>
-                    sonarQubeService.CreateServerSentEventsSession(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-                Times.Once);
-            testConfiguration.ServerSentEventPumpMock.Verify(
-                serverEventPump =>
-                    serverEventPump.PumpAllAsync(sessionToOpen),
-                Times.Once);
-        }
+//            testConfiguration.SonarQubeServiceMock.Verify(
+//                sonarQubeService =>
+//                    sonarQubeService.CreateServerSentEventsSession(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+//                Times.Once);
+//            testConfiguration.ServerSentEventPumpMock.Verify(
+//                serverEventPump =>
+//                    serverEventPump.PumpAllAsync(sessionToOpen),
+//                Times.Once);
+//        }
 
-        [TestMethod]
-        public void OnSolutionChanged_WhenChangesFromOpenToClosed_CancelsSession()
-        {
-            var testConfiguration = new TestScope();
-            testConfiguration.SetUpMockConnection();
-            testConfiguration.OpenNewProject();
+//        [TestMethod]
+//        public void OnSolutionChanged_WhenChangesFromOpenToClosed_CancelsSession()
+//        {
+//            var testConfiguration = new TestScope();
+//            testConfiguration.SetUpMockConnection();
+//            testConfiguration.OpenNewProject();
 
-            testConfiguration.CloseProject();
+//            testConfiguration.CloseProject();
 
-            testConfiguration.SessionToken.IsCancellationRequested.Should().BeTrue();
-        }
+//            testConfiguration.SessionToken.IsCancellationRequested.Should().BeTrue();
+//        }
 
-        [TestMethod]
-        public void OnSolutionChanged_WhenChangesFromOpenToOpen_CancelsSessionAndStartsNewOne()
-        {
-            var testConfiguration = new TestScope();
-            testConfiguration.SetUpMockConnection();
-            testConfiguration.OpenNewProject();
-            var firstConnectionSessionToken = testConfiguration.SessionToken;
-            testConfiguration.SetUpMockConnection();
+//        [TestMethod]
+//        public void OnSolutionChanged_WhenChangesFromOpenToOpen_CancelsSessionAndStartsNewOne()
+//        {
+//            var testConfiguration = new TestScope();
+//            testConfiguration.SetUpMockConnection();
+//            testConfiguration.OpenNewProject();
+//            var firstConnectionSessionToken = testConfiguration.SessionToken;
+//            testConfiguration.SetUpMockConnection();
 
-            testConfiguration.OpenNewProject();
+//            testConfiguration.OpenNewProject();
 
-            firstConnectionSessionToken.IsCancellationRequested.Should().BeTrue();
-            testConfiguration.SessionToken.IsCancellationRequested.Should().BeFalse();
-        }
+//            firstConnectionSessionToken.IsCancellationRequested.Should().BeTrue();
+//            testConfiguration.SessionToken.IsCancellationRequested.Should().BeFalse();
+//        }
 
-        [TestMethod]
-        public void Dispose_WhenProjectOpened_CorrectAndIdempotent()
-        {
-            var testConfiguration = new TestScope();
-            testConfiguration.SetUpMocksDispose();
-            testConfiguration.SetUpMockConnection();
-            testConfiguration.OpenNewProject();
+//        [TestMethod]
+//        public void Dispose_WhenProjectOpened_CorrectAndIdempotent()
+//        {
+//            var testConfiguration = new TestScope();
+//            testConfiguration.SetUpMocksDispose();
+//            testConfiguration.SetUpMockConnection();
+//            testConfiguration.OpenNewProject();
 
-            CallDisposeMultipleTimes(testConfiguration);
+//            CallDisposeMultipleTimes(testConfiguration);
 
-            testConfiguration.ActiveSolutionBoundTrackerMock.VerifyRemove(
-                activeSolutionBoundTracker =>
-                    activeSolutionBoundTracker.SolutionBindingChanged -= It.IsAny<EventHandler<ActiveSolutionBindingEventArgs>>(),
-                Times.Once);
-            testConfiguration.SessionToken.IsCancellationRequested.Should().BeTrue();
-            testConfiguration.ServerSentEventPumpMock.Verify(p => p.Dispose(), Times.Once);
-        }
+//            testConfiguration.ActiveSolutionBoundTrackerMock.VerifyRemove(
+//                activeSolutionBoundTracker =>
+//                    activeSolutionBoundTracker.SolutionBindingChanged -= It.IsAny<EventHandler<ActiveSolutionBindingEventArgs>>(),
+//                Times.Once);
+//            testConfiguration.SessionToken.IsCancellationRequested.Should().BeTrue();
+//            testConfiguration.ServerSentEventPumpMock.Verify(p => p.Dispose(), Times.Once);
+//        }
 
-        [TestMethod]
-        public void Dispose_WhenProjectClosed_CorrectAndIdempotent()
-        {
-            var testConfiguration = new TestScope();
-            testConfiguration.SetUpMocksDispose();
-            testConfiguration.CloseProject();
+//        [TestMethod]
+//        public void Dispose_WhenProjectClosed_CorrectAndIdempotent()
+//        {
+//            var testConfiguration = new TestScope();
+//            testConfiguration.SetUpMocksDispose();
+//            testConfiguration.CloseProject();
 
-            CallDisposeMultipleTimes(testConfiguration);
+//            CallDisposeMultipleTimes(testConfiguration);
 
-            testConfiguration.ActiveSolutionBoundTrackerMock.VerifyRemove(
-                activeSolutionBoundTracker => 
-                    activeSolutionBoundTracker.SolutionBindingChanged -= It.IsAny<EventHandler<ActiveSolutionBindingEventArgs>>(),
-                Times.Once);
-            testConfiguration.SessionToken.Should().Be(CancellationToken.None);
-            testConfiguration.ServerSentEventPumpMock.Verify(p => p.Dispose(), Times.Once);
-        }
+//            testConfiguration.ActiveSolutionBoundTrackerMock.VerifyRemove(
+//                activeSolutionBoundTracker => 
+//                    activeSolutionBoundTracker.SolutionBindingChanged -= It.IsAny<EventHandler<ActiveSolutionBindingEventArgs>>(),
+//                Times.Once);
+//            testConfiguration.SessionToken.Should().Be(CancellationToken.None);
+//            testConfiguration.ServerSentEventPumpMock.Verify(p => p.Dispose(), Times.Once);
+//        }
 
-        private static void CallDisposeMultipleTimes(TestScope testScope)
-        {
-            testScope.SessionManager.Dispose();
-            testScope.SessionManager.Dispose();
-            testScope.SessionManager.Dispose();
-        }
+//        private static void CallDisposeMultipleTimes(TestScope testScope)
+//        {
+//            testScope.SessionManager.Dispose();
+//            testScope.SessionManager.Dispose();
+//            testScope.SessionManager.Dispose();
+//        }
 
-        // todo(georgii-borovinskikh): test sqs error handling when we finalize it
+//        // todo(georgii-borovinskikh): test sqs error handling when we finalize it
 
-        private class TestScope
-        {
-            private static readonly ActiveSolutionBindingEventArgs ClosedProjectEvent = new(BindingConfiguration.Standalone);
-            public Mock<IActiveSolutionBoundTracker> ActiveSolutionBoundTrackerMock { get; }
-            private Mock<IThreadHandling> ThreadHandlingMock { get; }
-            public Mock<ISonarQubeService> SonarQubeServiceMock { get; }
-            public Mock<IServerSentEventPump> ServerSentEventPumpMock { get; }
-            public ServerSentEventSessionManager SessionManager { get; }
+//        private class TestScope
+//        {
+//            private static readonly ActiveSolutionBindingEventArgs ClosedProjectEvent = new(BindingConfiguration.Standalone);
+//            public Mock<IActiveSolutionBoundTracker> ActiveSolutionBoundTrackerMock { get; }
+//            private Mock<IThreadHandling> ThreadHandlingMock { get; }
+//            public Mock<ISonarQubeService> SonarQubeServiceMock { get; }
+//            public Mock<IServerSentEventPump> ServerSentEventPumpMock { get; }
+//            public ServerSentEventSessionManager SessionManager { get; }
 
-            public CancellationToken SessionToken { get; private set; }
+//            public CancellationToken SessionToken { get; private set; }
 
-            public TestScope()
-            {
-                var mockRepository = new MockRepository(MockBehavior.Strict);
-                ActiveSolutionBoundTrackerMock = mockRepository.Create<IActiveSolutionBoundTracker>();
-                SonarQubeServiceMock = mockRepository.Create<ISonarQubeService>();
-                ServerSentEventPumpMock = mockRepository.Create<IServerSentEventPump>();
-                ThreadHandlingMock = mockRepository.Create<IThreadHandling>();
-                SessionManager = new ServerSentEventSessionManager(
-                    ActiveSolutionBoundTrackerMock.Object,
-                    SonarQubeServiceMock.Object,
-                    ServerSentEventPumpMock.Object,
-                    ThreadHandlingMock.Object);
-            }
+//            public TestScope()
+//            {
+//                var mockRepository = new MockRepository(MockBehavior.Strict);
+//                ActiveSolutionBoundTrackerMock = mockRepository.Create<IActiveSolutionBoundTracker>();
+//                SonarQubeServiceMock = mockRepository.Create<ISonarQubeService>();
+//                ServerSentEventPumpMock = mockRepository.Create<IServerSentEventPump>();
+//                ThreadHandlingMock = mockRepository.Create<IThreadHandling>();
+//                SessionManager = new ServerSentEventSessionManager(
+//                    ActiveSolutionBoundTrackerMock.Object,
+//                    SonarQubeServiceMock.Object,
+//                    ServerSentEventPumpMock.Object,
+//                    ThreadHandlingMock.Object);
+//            }
 
-            public void SetUpMocksDispose()
-            {
-                ServerSentEventPumpMock.Setup(p => p.Dispose());
-            }
+//            public void SetUpMocksDispose()
+//            {
+//                ServerSentEventPumpMock.Setup(p => p.Dispose());
+//            }
 
-            public IServerSentEventsSession SetUpMockConnection(
-                MockSequence callSequence = null)
-            {
-                callSequence ??= new MockSequence();
-                var session = Mock.Of<IServerSentEventsSession>();
-                ThreadHandlingMock
-                    .InSequence(callSequence)
-                    .Setup(threadHandling => threadHandling.SwitchToBackgroundThread())
-                    .Returns(new NoOpThreadHandler.NoOpAwaitable());
-                SonarQubeServiceMock
-                    .InSequence(callSequence)
-                    .Setup(sonarQubeService =>
-                        sonarQubeService.CreateServerSentEventsSession(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                    .Returns((string _, CancellationToken arg2) =>
-                    {
-                        SessionToken = arg2;
-                        return Task.FromResult(session);
-                    });
-                ServerSentEventPumpMock
-                    .InSequence(callSequence)
-                    .Setup(serverSentEventPump => serverSentEventPump.PumpAllAsync(session))
-                    .Returns(Task.CompletedTask);
-                return session;
-            }
+//            public IServerSentEventsSession SetUpMockConnection(
+//                MockSequence callSequence = null)
+//            {
+//                callSequence ??= new MockSequence();
+//                var session = Mock.Of<IServerSentEventsSession>();
+//                ThreadHandlingMock
+//                    .InSequence(callSequence)
+//                    .Setup(threadHandling => threadHandling.SwitchToBackgroundThread())
+//                    .Returns(new NoOpThreadHandler.NoOpAwaitable());
+//                SonarQubeServiceMock
+//                    .InSequence(callSequence)
+//                    .Setup(sonarQubeService =>
+//                        sonarQubeService.CreateServerSentEventsSession(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+//                    .Returns((string _, CancellationToken arg2) =>
+//                    {
+//                        SessionToken = arg2;
+//                        return Task.FromResult(session);
+//                    });
+//                ServerSentEventPumpMock
+//                    .InSequence(callSequence)
+//                    .Setup(serverSentEventPump => serverSentEventPump.PumpAllAsync(session))
+//                    .Returns(Task.CompletedTask);
+//                return session;
+//            }
 
-            public void OpenNewProject()
-            {
-                var openProjectEvent = CreateNewOpenProjectEvent();
-                RaiseSolutionBindingEvent(openProjectEvent);
-            }
+//            public void OpenNewProject()
+//            {
+//                var openProjectEvent = CreateNewOpenProjectEvent();
+//                RaiseSolutionBindingEvent(openProjectEvent);
+//            }
 
-            public void CloseProject()
-            {
-                RaiseSolutionBindingEvent(ClosedProjectEvent);
-            }
+//            public void CloseProject()
+//            {
+//                RaiseSolutionBindingEvent(ClosedProjectEvent);
+//            }
 
-            private void RaiseSolutionBindingEvent(ActiveSolutionBindingEventArgs args)
-            {
-                ActiveSolutionBoundTrackerMock.Raise(s => s.SolutionBindingChanged += null, args);
-            }
+//            private void RaiseSolutionBindingEvent(ActiveSolutionBindingEventArgs args)
+//            {
+//                ActiveSolutionBoundTrackerMock.Raise(s => s.SolutionBindingChanged += null, args);
+//            }
 
-            private static ActiveSolutionBindingEventArgs CreateNewOpenProjectEvent()
-            {
-                var randomString = Guid.NewGuid().ToString();
-                return new ActiveSolutionBindingEventArgs(new BindingConfiguration(
-                    new BoundSonarQubeProject(new Uri("http://localhost"), randomString, randomString),
-                    SonarLintMode.Connected,
-                    randomString));
-            }
-        }
-    }
-}
+//            private static ActiveSolutionBindingEventArgs CreateNewOpenProjectEvent()
+//            {
+//                var randomString = Guid.NewGuid().ToString();
+//                return new ActiveSolutionBindingEventArgs(new BindingConfiguration(
+//                    new BoundSonarQubeProject(new Uri("http://localhost"), randomString, randomString),
+//                    SonarLintMode.Connected,
+//                    randomString));
+//            }
+//        }
+//    }
+//}

--- a/src/ConnectedMode/ServerSentEvents/ServerSentEventSessionManager.cs
+++ b/src/ConnectedMode/ServerSentEvents/ServerSentEventSessionManager.cs
@@ -51,21 +51,21 @@ namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
             this.activeSolutionBoundTracker = activeSolutionBoundTracker;
             this.sseSessionFactory = sseSessionFactory;
 
-            activeSolutionBoundTracker.SolutionBindingChanged += OnSolutionChanged;
+            activeSolutionBoundTracker.SolutionBindingChanged += SolutionBindingChanged;
         }
 
         public void Dispose()
         {
-            activeSolutionBoundTracker.SolutionBindingChanged -= OnSolutionChanged;
-            currentSession?.Dispose();
+            activeSolutionBoundTracker.SolutionBindingChanged -= SolutionBindingChanged;
+            EndCurrentSession();
         }
 
-        private void OnSolutionChanged(object sender, ActiveSolutionBindingEventArgs activeSolutionBindingEventArgs)
+        private void SolutionBindingChanged(object sender, ActiveSolutionBindingEventArgs activeSolutionBindingEventArgs)
         {
+            EndCurrentSession();
+
             var bindingConfiguration = activeSolutionBindingEventArgs.Configuration;
             var isInConnectedMode = !bindingConfiguration.Equals(BindingConfiguration.Standalone);
-
-            currentSession?.Dispose();
 
             if (!isInConnectedMode)
             {
@@ -75,6 +75,12 @@ namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
             currentSession = sseSessionFactory.Create(bindingConfiguration.Project.ProjectKey);
 
             currentSession.PumpAllAsync().Forget();
+        }
+
+        private void EndCurrentSession()
+        {
+            currentSession?.Dispose();
+            currentSession = null;
         }
     }
     

--- a/src/ConnectedMode/ServerSentEvents/ServerSentEventSessionManager.cs
+++ b/src/ConnectedMode/ServerSentEvents/ServerSentEventSessionManager.cs
@@ -25,7 +25,10 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Core.ServerSentEvents.Issues;
+using SonarLint.VisualStudio.Core.ServerSentEvents.TaintVulnerabilities;
 using SonarQube.Client;
+using SonarQube.Client.Models.ServerSentEvents.ClientContract;
 
 namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
 {
@@ -38,37 +41,23 @@ namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
     internal sealed class ServerSentEventSessionManager : IServerSentEventSessionManager
     {
         private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
-        private readonly ISonarQubeService sonarQubeClient;
-        private readonly IServerSentEventPump eventPump;
-        private readonly IThreadHandling threadHandling;
-        private bool disposed;
-        private CancellationTokenSource sessionTokenSource;
+        private readonly ISSESessionFactory sseSessionFactory;
+
+        private ISSESession currentSession;
 
         [ImportingConstructor]
-        public ServerSentEventSessionManager(
-            IActiveSolutionBoundTracker activeSolutionBoundTracker,
-            ISonarQubeService sonarQubeClient,
-            IServerSentEventPump eventPump,
-            IThreadHandling threadHandling)
+        public ServerSentEventSessionManager(IActiveSolutionBoundTracker activeSolutionBoundTracker, ISSESessionFactory sseSessionFactory)
         {
             this.activeSolutionBoundTracker = activeSolutionBoundTracker;
-            this.sonarQubeClient = sonarQubeClient;
-            this.eventPump = eventPump;
-            this.threadHandling = threadHandling;
+            this.sseSessionFactory = sseSessionFactory;
+
             activeSolutionBoundTracker.SolutionBindingChanged += OnSolutionChanged;
         }
 
         public void Dispose()
         {
-            if (disposed)
-            {
-                return;
-            }
-
             activeSolutionBoundTracker.SolutionBindingChanged -= OnSolutionChanged;
-            sessionTokenSource?.Cancel();
-            eventPump.Dispose();
-            disposed = true;
+            currentSession?.Dispose();
         }
 
         private void OnSolutionChanged(object sender, ActiveSolutionBindingEventArgs activeSolutionBindingEventArgs)
@@ -76,37 +65,129 @@ namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
             var bindingConfiguration = activeSolutionBindingEventArgs.Configuration;
             var isInConnectedMode = !bindingConfiguration.Equals(BindingConfiguration.Standalone);
 
-            EndSession();
+            currentSession?.Dispose();
 
             if (!isInConnectedMode)
             {
                 return;
             }
 
-            InitializeSessionAsync(bindingConfiguration.Project.ProjectKey).Forget();
+            currentSession = sseSessionFactory.Create(bindingConfiguration.Project.ProjectKey);
+
+            currentSession.PumpAllAsync().Forget();
+        }
+    }
+    
+    internal interface ISSESessionFactory
+    {
+        ISSESession Create(string projectKey);
+    }
+
+    internal interface ISSESession : IDisposable
+    {
+        Task PumpAllAsync();
+    }
+
+    [Export(typeof(ISSESessionFactory))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal class SSESessionFactory : ISSESessionFactory
+    {
+        private readonly ISonarQubeService sonarQubeClient;
+        private readonly IIssueChangedServerEventSourcePublisher issueChangedServerEventSourcePublisher;
+        private readonly ITaintServerEventSourcePublisher taintServerEventSourcePublisher;
+        private readonly IThreadHandling threadHandling;
+
+        [ImportingConstructor]
+        public SSESessionFactory(ISonarQubeService sonarQubeClient,
+            IIssueChangedServerEventSourcePublisher issueChangedServerEventSourcePublisher, 
+            ITaintServerEventSourcePublisher taintServerEventSourcePublisher,
+            IThreadHandling threadHandling)
+        {
+            this.sonarQubeClient = sonarQubeClient;
+            this.issueChangedServerEventSourcePublisher = issueChangedServerEventSourcePublisher;
+            this.taintServerEventSourcePublisher = taintServerEventSourcePublisher;
+            this.threadHandling = threadHandling;
         }
 
-        private async Task InitializeSessionAsync(string projectKey)
+        public ISSESession Create(string projectKey)
         {
-            await threadHandling.SwitchToBackgroundThread();
+            var session = new SSESession(issueChangedServerEventSourcePublisher,
+                taintServerEventSourcePublisher,
+                projectKey,
+                threadHandling,
+                sonarQubeClient);
+            
+            return session;
+        }
 
-            sessionTokenSource = new CancellationTokenSource();
-            var serverSentEventsSession =
-                await sonarQubeClient.CreateServerSentEventsSession(projectKey,
-                    sessionTokenSource.Token); //todo what kind of errors it throws? Sync with Rita
+        private class SSESession : ISSESession
+        {
+            private readonly IIssueChangedServerEventSourcePublisher issueChangedServerEventSourcePublisher;
+            private readonly ITaintServerEventSourcePublisher taintServerEventSourcePublisher;
+            private readonly string projectKey;
+            private readonly IThreadHandling threadHandling;
+            private readonly ISonarQubeService sonarQubeService;
+            private readonly CancellationTokenSource sessionTokenSource;
 
-            if (serverSentEventsSession == null)
+            public SSESession(IIssueChangedServerEventSourcePublisher issueChangedServerEventSourcePublisher, 
+                ITaintServerEventSourcePublisher taintServerEventSourcePublisher,
+                string projectKey,
+                IThreadHandling threadHandling,
+                ISonarQubeService sonarQubeService)
             {
-                return;
+                this.issueChangedServerEventSourcePublisher = issueChangedServerEventSourcePublisher;
+                this.taintServerEventSourcePublisher = taintServerEventSourcePublisher;
+                this.projectKey = projectKey;
+                this.threadHandling = threadHandling;
+                this.sonarQubeService = sonarQubeService;
+                this.sessionTokenSource = new CancellationTokenSource();
             }
 
-            await eventPump.PumpAllAsync(serverSentEventsSession);
-        }
+            public async Task PumpAllAsync()
+            {
+                await threadHandling.SwitchToBackgroundThread();
 
-        private void EndSession()
-        {
-            sessionTokenSource?.Cancel();
-            sessionTokenSource = null;
+                // todo: rename to ISSEStreamReader
+                var sseStreamReader =
+                    await sonarQubeService.CreateServerSentEventsSession(projectKey, sessionTokenSource.Token); //todo what kind of errors it throws? Sync with Rita
+
+                if (sseStreamReader == null)
+                {
+                    return;
+                }
+
+                while (!sessionTokenSource.IsCancellationRequested)
+                {
+                    try
+                    {
+                        var serverEvent = await sseStreamReader.ReadAsync();
+
+                        if (serverEvent == null)
+                        {
+                            continue;
+                        }
+
+                        switch (serverEvent)
+                        {
+                            case IIssueChangedServerEvent issueChangedServerEvent:
+                                issueChangedServerEventSourcePublisher.Publish(issueChangedServerEvent);
+                                break;
+                            case ITaintServerEvent taintServerEvent:
+                                taintServerEventSourcePublisher.Publish(taintServerEvent);
+                                break;
+                        }
+                    }
+                    catch (Exception ex) when (ex is OperationCanceledException || ex is ObjectDisposedException)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                sessionTokenSource.Cancel();
+            }
         }
     }
 }


### PR DESCRIPTION
@georgii-borovinskikh-sonarsource I went over the design with @duncanp-sonar and we came up with a solution that we think is simpler and addresses a couple of problems:
* It allows the whole "session" to be disposed, whenever the binding changes, without the risk of concurrency problems
* It makes explicit usage of the cancellation token which makes it simpler to understand how the session is disposed and canceled.

Please take a look and LMK what you think. 