### PR TITLE
Add check for secrets in ProjectToLanguageMapper

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingProcessImplTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingProcessImplTests.cs
@@ -38,6 +38,7 @@ using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.CFamily;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Resources;
@@ -81,7 +82,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.serviceProvider.RegisterService(typeof(ISolutionRuleSetsInformationProvider), this.ruleSetsInformationProvider);
 
             jstsIndicator = new Mock<IJsTsProjectTypeIndicator>();
-            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), jstsIndicator.Object);
+            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), jstsIndicator.Object, Mock.Of<IConnectedModeSecrets>());
 
             folderWorkspaceService = new Mock<IFolderWorkspaceService>();
 

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingOperationTests.cs
@@ -39,6 +39,7 @@ using SonarLint.VisualStudio.Integration.Binding;
 using Language = SonarLint.VisualStudio.Core.Language;
 using VsRuleSet = Microsoft.VisualStudio.CodeAnalysis.RuleSets.RuleSet;
 using CoreRuleSet = SonarLint.VisualStudio.Core.CSharpVB.RuleSet;
+using SonarLint.VisualStudio.Core.Secrets;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 {
@@ -76,7 +77,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 new SolutionRuleSetsInformationProvider(this.serviceProvider, new Mock<ILogger>().Object,  new MockFileSystem()));
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystemHelper);
 
-            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>());
+            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(),Mock.Of<IConnectedModeSecrets>());
             var mefHost = ConfigurableComponentModel.CreateWithExports(MefTestHelpers.CreateExport<IProjectToLanguageMapper>(projectToLanguageMapper));
             serviceProvider.RegisterService(typeof(SComponentModel), mefHost);
 

--- a/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/NuGetBindingOperationTests.cs
@@ -31,6 +31,7 @@ using NuGet.VisualStudio;
 using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Core.CSharpVB;
 using SonarLint.VisualStudio.Core.JsTs;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Infrastructure.VS;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Resources;
@@ -269,7 +270,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             var packageInstaller = new ConfigurablePackageInstaller(nugetPackagesByLanguage.Values.SelectMany(x => x));
 
-            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>());
+            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(), Mock.Of<IConnectedModeSecrets>());
 
             this.serviceProvider.RegisterService(typeof(SComponentModel),
                 ConfigurableComponentModel.CreateWithExports(

--- a/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.CFamily;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Core.JsTs;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Persistence;
@@ -85,7 +86,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.serviceProvider.RegisterService(typeof(IRuleSetSerializer), this.ruleFS);
             this.serviceProvider.RegisterService(typeof(ISolutionRuleSetsInformationProvider), this.ruleSetInfo);
 
-            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>());
+            var projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(), Mock.Of<IConnectedModeSecrets>());
             var mefHost = ConfigurableComponentModel.CreateWithExports(MefTestHelpers.CreateExport<IProjectToLanguageMapper>(projectToLanguageMapper));
             serviceProvider.RegisterService(typeof(SComponentModel), mefHost);
 

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.CFamily;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.Resources;
@@ -80,7 +81,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             var mefModel = ConfigurableComponentModel.CreateWithExports(
                 MefTestHelpers.CreateExport<IFolderWorkspaceService>(folderWorkspaceService.Object),
                 MefTestHelpers.CreateExport<ISonarLintSettings>(settings),
-                MefTestHelpers.CreateExport<IProjectToLanguageMapper>(new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>())));
+                MefTestHelpers.CreateExport<IProjectToLanguageMapper>(new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(), Mock.Of<IConnectedModeSecrets>())));
 
             this.serviceProvider.RegisterService(typeof(SComponentModel), mefModel);
 

--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
@@ -35,6 +35,7 @@ using SonarQube.Client.Models;
 using SonarQube.Client;
 using Language = SonarLint.VisualStudio.Core.Language;
 using SonarLint.VisualStudio.Integration.Binding;
+using SonarLint.VisualStudio.Core.Secrets;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
@@ -60,7 +61,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.serviceProvider.RegisterService(typeof(IConfigurationProviderService), this.configProvider);
 
             var mefHost = ConfigurableComponentModel.CreateWithExports(
-                MefTestHelpers.CreateExport<IProjectToLanguageMapper>(new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>())));
+                MefTestHelpers.CreateExport<IProjectToLanguageMapper>(new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(), Mock.Of<IConnectedModeSecrets>())));
             this.serviceProvider.RegisterService(typeof(SComponentModel), mefHost);
 
             logger = new TestLogger();

--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarControllerTests.cs
@@ -34,6 +34,7 @@ using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.CFamily;
 using SonarLint.VisualStudio.Core.InfoBar;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.Resources;
@@ -74,7 +75,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 {
                     MefTestHelpers.CreateExport<ITeamExplorerController>(this.teamExplorerController),
                     MefTestHelpers.CreateExport<IInfoBarManager>(this.infoBarManager),
-                    MefTestHelpers.CreateExport<IProjectToLanguageMapper>(new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>()))
+                    MefTestHelpers.CreateExport<IProjectToLanguageMapper>(new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(), Mock.Of<IConnectedModeSecrets>()))
                 });
             this.serviceProvider.RegisterService(typeof(SComponentModel), componentModel);
 

--- a/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
+++ b/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.CFamily;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.NewConnectedMode;
 using SonarLint.VisualStudio.Integration.ProfileConflicts;
@@ -79,7 +80,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             logger = new TestLogger();
             serviceProvider.RegisterService(typeof(ILogger), logger);
 
-            projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>());
+            projectToLanguageMapper = new ProjectToLanguageMapper(Mock.Of<ICMakeProjectTypeIndicator>(), Mock.Of<IJsTsProjectTypeIndicator>(), Mock.Of<IConnectedModeSecrets>());
 
             var mefHost = ConfigurableComponentModel.CreateWithExports(
                 MefTestHelpers.CreateExport<IProjectToLanguageMapper>(projectToLanguageMapper));

--- a/src/Integration/ProjectToLanguageMapper.cs
+++ b/src/Integration/ProjectToLanguageMapper.cs
@@ -24,6 +24,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using EnvDTE;
 using SonarLint.VisualStudio.Core.CFamily;
+using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Integration.Binding;
 using Language = SonarLint.VisualStudio.Core.Language;
 
@@ -51,6 +52,7 @@ namespace SonarLint.VisualStudio.Integration
     {
         private readonly ICMakeProjectTypeIndicator cmakeProjectTypeIndicator;
         private readonly IJsTsProjectTypeIndicator jsTsProjectTypeIndicator;
+        private readonly IConnectedModeSecrets connectedModeSecrets;
 
         internal static readonly IDictionary<Guid, Language> KnownProjectTypes = new Dictionary<Guid, Language>()
         {
@@ -62,10 +64,12 @@ namespace SonarLint.VisualStudio.Integration
 
         [ImportingConstructor]
         public ProjectToLanguageMapper(ICMakeProjectTypeIndicator cmakeProjectTypeIndicator,
-            IJsTsProjectTypeIndicator jsTsProjectTypeIndicator)
+            IJsTsProjectTypeIndicator jsTsProjectTypeIndicator,
+            IConnectedModeSecrets connectedModeSecrets)
         {
             this.cmakeProjectTypeIndicator = cmakeProjectTypeIndicator;
             this.jsTsProjectTypeIndicator = jsTsProjectTypeIndicator;
+            this.connectedModeSecrets = connectedModeSecrets;
         }
 
         public IEnumerable<Language> GetAllBindingLanguagesForProject(Project dteProject)
@@ -108,6 +112,11 @@ namespace SonarLint.VisualStudio.Integration
             {
                 languages.Add(Language.Js);
                 languages.Add(Language.Ts);
+            }
+
+            if (connectedModeSecrets.AreSecretsAvailable())
+            {
+                languages.Add(Language.Secrets);
             }
 
             if (languages.Any())


### PR DESCRIPTION
fixes part 4 of https://github.com/SonarSource/sonarlint-visualstudio/issues/3673

When connecting to SonarCloud / SonarQube >= v9.9 secrets settings get downloaded.
When the slconfig secrets time stamp is out of date a gold bar asks to update it.
When updating it the slconfig gets correctly updated.