### PR TITLE
Return default Main branch when there is no git repo or no git head

### DIFF
--- a/src/ConnectedMode.UnitTests/BranchMatcherTests.cs
+++ b/src/ConnectedMode.UnitTests/BranchMatcherTests.cs
@@ -236,13 +236,13 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
         }
 
         [TestMethod]
-        public async Task GetMatchedBranch_RepoHasNoHead_ReturnsMainBranch()
+        public async Task GetMatchedBranch_RepoHasNoHead_ReturnsNull()
         {
             var testSubject = CreateTestSubject(CreateSonarQubeService("any").Object);
 
             var result = await testSubject.GetMatchingBranch("projectKey", Mock.Of<IRepository>(), CancellationToken.None);
 
-            result.Should().Be("any");
+            result.Should().BeNull();
         }
 
         [TestMethod]

--- a/src/ConnectedMode.UnitTests/ServerBranchProviderTests.cs
+++ b/src/ConnectedMode.UnitTests/ServerBranchProviderTests.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -25,6 +26,8 @@ using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Integration;
 using SonarLint.VisualStudio.Integration.UnitTests;
+using SonarQube.Client;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
 {
@@ -37,6 +40,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
             MefTestHelpers.CheckTypeCanBeImported<ServerBranchProvider, IServerBranchProvider>(
                 MefTestHelpers.CreateExport<IConfigurationProvider>(),
                 MefTestHelpers.CreateExport<IGitWorkspaceService>(),
+                MefTestHelpers.CreateExport<ISonarQubeService>(),
                 MefTestHelpers.CreateExport<IBranchMatcher>(),
                 MefTestHelpers.CreateExport<ILogger>());
         }
@@ -48,11 +52,13 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
             var gitWorkspace = new Mock<IGitWorkspaceService>();
             var branchMatcher = new Mock<IBranchMatcher>();
             var logger = new TestLogger(logToConsole: true);
+            var sonarQubeService = CreateSonarQubeService();
 
             var testSubject = CreateTestSubject(configProvider.Object,
                 gitWorkspace.Object,
-                branchMatcher.Object,
-                logger);
+                branchMatcher: branchMatcher.Object,
+                sonarQubeService: sonarQubeService.Object,
+                logger: logger);
 
             var actual = await testSubject.GetServerBranchNameAsync(CancellationToken.None);
             
@@ -61,10 +67,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
             configProvider.VerifyAll();
             gitWorkspace.Invocations.Should().HaveCount(0);
             branchMatcher.Invocations.Should().HaveCount(0);
+            sonarQubeService.Invocations.Should().HaveCount(0);
         }
 
         [TestMethod]
-        public async Task Get_NoGitRepo_ReturnsNull()
+        public async Task Get_NoGitRepo_ReturnsDefaultMainBranch()
         {
             var configProvider = CreateConfigProvider(CreateBindingConfig(SonarLintMode.Connected));
             var gitWorkspace = CreateGitWorkspace(repoRootToReturn: null);
@@ -73,15 +80,18 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
             var logger = new TestLogger(logToConsole: true);
             var createRepoOp = CreateCreateRepoOp(repository: null);
 
+            var sonarQubeService = CreateSonarQubeService(mainBranchName: "main branch name");
+
             var testSubject = CreateTestSubject(configProvider.Object,
                 gitWorkspace.Object,
-                branchMatcher.Object,
-                logger,
-                createRepoOp.Object);
+                sonarQubeService: sonarQubeService.Object,
+                branchMatcher: branchMatcher.Object,
+                logger: logger,
+                createRepoOp: createRepoOp.Object);
 
             var actual = await testSubject.GetServerBranchNameAsync(CancellationToken.None);
 
-            actual.Should().BeNull();
+            actual.Should().Be("main branch name");
             
             configProvider.VerifyAll();
             gitWorkspace.Verify(x => x.GetRepoRoot(), Times.Once);
@@ -103,12 +113,14 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
 
             var repo = Mock.Of<IRepository>();
             var createRepoOp = CreateCreateRepoOp(repository: repo);
+            var sonarQubeService = CreateSonarQubeService();
 
             var testSubject = CreateTestSubject(configProvider.Object,
                 gitWorkspace.Object,
-                branchMatcher.Object,
-                logger,
-                createRepoOp.Object);
+                branchMatcher: branchMatcher.Object,
+                sonarQubeService: sonarQubeService.Object,
+                logger: logger,
+                createRepoOp: createRepoOp.Object);
 
             var actual = await testSubject.GetServerBranchNameAsync(CancellationToken.None);
 
@@ -123,10 +135,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
             gitWorkspace.Invocations.Should().HaveCount(1);
             branchMatcher.Invocations.Should().HaveCount(1);
             createRepoOp.Invocations.Should().HaveCount(1);
+            sonarQubeService.Invocations.Should().HaveCount(0);
         }
 
         [TestMethod]
-        public async Task Get_ConnectedModeAndHasGitRepo_NoMatchingBranch_ReturnsNull()
+        public async Task Get_ConnectedModeAndHasGitRepo_NoMatchingBranch_ReturnsDefaultMainBranch()
         {
             var configProvider = CreateConfigProvider(CreateBindingConfig(SonarLintMode.Connected, "my project key"));
             var gitWorkspace = CreateGitWorkspace("x:\\");
@@ -136,39 +149,43 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
 
             var repo = Mock.Of<IRepository>();
             var createRepoOp = CreateCreateRepoOp(repository: repo);
+            var sonarQubeService = CreateSonarQubeService(mainBranchName: "some main branch");
 
             var testSubject = CreateTestSubject(configProvider.Object,
                 gitWorkspace.Object,
-                branchMatcher.Object,
-                logger,
-                createRepoOp.Object);
+                branchMatcher: branchMatcher.Object,
+                sonarQubeService: sonarQubeService.Object,
+                logger:logger,
+                createRepoOp:createRepoOp.Object);
 
             var actual = await testSubject.GetServerBranchNameAsync(CancellationToken.None);
 
-            actual.Should().BeNull();
+            actual.Should().Be("some main branch");
+
             branchMatcher.Verify(x => x.GetMatchingBranch("my project key", repo, It.IsAny<CancellationToken>()), Times.Once);
-            logger.AssertPartialOutputStringExists(Resources.NullBranchName);
         }
 
         private static ServerBranchProvider CreateTestSubject(
             IConfigurationProvider configurationProvider = null,
             IGitWorkspaceService gitWorkspaceService = null,
+            ISonarQubeService sonarQubeService = null,
             IBranchMatcher branchMatcher = null,
             ILogger logger = null,
             ServerBranchProvider.CreateRepositoryObject createRepoOp = null)
         {
             configurationProvider ??= Mock.Of<IConfigurationProvider>();
             gitWorkspaceService ??= Mock.Of<IGitWorkspaceService>();
+            sonarQubeService ??= Mock.Of<ISonarQubeService>();
             branchMatcher ??= Mock.Of<IBranchMatcher>();
             logger ??= new TestLogger();
             createRepoOp ??= (string repoRoot) => null;
 
-            var testSubject = new ServerBranchProvider(configurationProvider, gitWorkspaceService, branchMatcher, logger, createRepoOp);
+            var testSubject = new ServerBranchProvider(configurationProvider, gitWorkspaceService, sonarQubeService, branchMatcher, logger, createRepoOp);
             return testSubject;
         }
 
         private static BindingConfiguration CreateBindingConfig(SonarLintMode mode = SonarLintMode.Connected, string projectKey = "any")
-            => new BindingConfiguration(new BoundSonarQubeProject { ProjectKey = projectKey }, mode, "any dir");
+            => new(new BoundSonarQubeProject { ProjectKey = projectKey }, mode, "any dir");
 
         private static Mock<IConfigurationProvider> CreateConfigProvider(BindingConfiguration config = null)
         {
@@ -199,6 +216,24 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests
             branchMatcher.Setup(x => x.GetMatchingBranch(It.IsAny<string>(), It.IsAny<IRepository>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(branchToReturn);
             return branchMatcher;
+        }
+
+        private Mock<ISonarQubeService> CreateSonarQubeService(string mainBranchName = "some branch")
+        {
+            var sonarQubeService = new Mock<ISonarQubeService>();
+
+            var serverBranches = new[]
+            {
+                new SonarQubeProjectBranch(Guid.NewGuid().ToString(), false, default),
+                new SonarQubeProjectBranch(mainBranchName, true, default),
+                new SonarQubeProjectBranch(Guid.NewGuid().ToString(), false, default)
+            };
+
+            sonarQubeService
+                .Setup(x => x.GetProjectBranchesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(serverBranches);
+
+            return sonarQubeService;
         }
     }
 }

--- a/src/ConnectedMode/BranchMatcher.cs
+++ b/src/ConnectedMode/BranchMatcher.cs
@@ -35,10 +35,11 @@ namespace SonarLint.VisualStudio.ConnectedMode
     {
         /// <summary>
         /// Calculates the Sonar server branch that is the closest match to the head branch.
-        /// Defaults to branch marked as "main" when no match is found or when there are no head branches.
+        /// Returns null if there are no head branches
         /// </summary>
         /// <remarks>
         /// Compares branches by name and calculates distances by the number of different commits.
+        /// Defaults to branch marked as "main" when no match found.
         /// This is the same algorithm as the other SonarLint flavours (?except in how we treated branch histories.
         /// We treat branch histories as series of linear commits ordered by time, even if there are merges).
         /// </remarks>
@@ -85,13 +86,14 @@ namespace SonarLint.VisualStudio.ConnectedMode
         private async Task<string> DoGetMatchingBranch(string projectKey, IRepository gitRepo, CancellationToken token)
         {
             var head = gitRepo.Head;
-            var remoteBranches = await sonarQubeService.GetProjectBranchesAsync(projectKey, token);
 
             if (head == null)
             {
                 logger.LogVerbose(Resources.BranchMapper_NoHead);
-                return remoteBranches.First(rb => rb.IsMain).Name;
+                return null;
             }
+
+            var remoteBranches = await sonarQubeService.GetProjectBranchesAsync(projectKey, token);
 
             if (remoteBranches.Any(rb => string.Equals(rb.Name, head.FriendlyName, StringComparison.InvariantCultureIgnoreCase)))
             {

--- a/src/ConnectedMode/BranchMatcher.cs
+++ b/src/ConnectedMode/BranchMatcher.cs
@@ -35,7 +35,7 @@ namespace SonarLint.VisualStudio.ConnectedMode
     {
         /// <summary>
         /// Calculates the Sonar server branch that is the closest match to the head branch.
-        /// Returns null if there are no head branches
+        /// Returns null if the repo is currently in detached HEAD.
         /// </summary>
         /// <remarks>
         /// Compares branches by name and calculates distances by the number of different commits.

--- a/src/ConnectedMode/Resources.Designer.cs
+++ b/src/ConnectedMode/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace SonarLint.VisualStudio.ConnectedMode {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [ConnectedMode/BranchMapping] Failed to calculate closest local git branch, defaulting to server main branch..
+        /// </summary>
+        internal static string BranchProvider_FailedToCalculateMatchingBranch {
+            get {
+                return ResourceManager.GetString("BranchProvider_FailedToCalculateMatchingBranch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [ConnectedMode/BranchMapping] Matching Sonar server branch: {0}.
         /// </summary>
         internal static string BranchProvider_MatchingServerBranchName {

--- a/src/ConnectedMode/Resources.Designer.cs
+++ b/src/ConnectedMode/Resources.Designer.cs
@@ -133,7 +133,7 @@ namespace SonarLint.VisualStudio.ConnectedMode {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [ConnectedMode/BranchMapping] Failed to calculate closest local git branch, defaulting to server main branch..
+        ///   Looks up a localized string similar to [ConnectedMode/BranchMapping] Failed to calculate closest local git branch, defaulting to Sonar main branch..
         /// </summary>
         internal static string BranchProvider_FailedToCalculateMatchingBranch {
             get {

--- a/src/ConnectedMode/Resources.resx
+++ b/src/ConnectedMode/Resources.resx
@@ -142,7 +142,7 @@
     <value>[ConnectedMode/BranchMapping] Could not detect a git repo for the current solution</value>
   </data>
   <data name="BranchProvider_FailedToCalculateMatchingBranch" xml:space="preserve">
-    <value>[ConnectedMode/BranchMapping] Failed to calculate closest local git branch, defaulting to server main branch.</value>
+    <value>[ConnectedMode/BranchMapping] Failed to calculate closest local git branch, defaulting to Sonar main branch.</value>
   </data>
   <data name="BranchProvider_MatchingServerBranchName" xml:space="preserve">
     <value>[ConnectedMode/BranchMapping] Matching Sonar server branch: {0}</value>

--- a/src/ConnectedMode/Resources.resx
+++ b/src/ConnectedMode/Resources.resx
@@ -141,6 +141,9 @@
   <data name="BranchProvider_CouldNotDetectGitRepo" xml:space="preserve">
     <value>[ConnectedMode/BranchMapping] Could not detect a git repo for the current solution</value>
   </data>
+  <data name="BranchProvider_FailedToCalculateMatchingBranch" xml:space="preserve">
+    <value>[ConnectedMode/BranchMapping] Failed to calculate closest local git branch, defaulting to server main branch.</value>
+  </data>
   <data name="BranchProvider_MatchingServerBranchName" xml:space="preserve">
     <value>[ConnectedMode/BranchMapping] Matching Sonar server branch: {0}</value>
   </data>

--- a/src/ConnectedMode/ServerBranchProvider.cs
+++ b/src/ConnectedMode/ServerBranchProvider.cs
@@ -19,6 +19,7 @@
  */
 
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,7 +92,9 @@ namespace SonarLint.VisualStudio.ConnectedMode
                 matchingBranchName = remoteBranches.First(rb => rb.IsMain).Name;
             }
 
-            logger.WriteLine(Resources.BranchProvider_MatchingServerBranchName, matchingBranchName ?? Resources.NullBranchName);
+            Debug.Assert(matchingBranchName != null);
+
+            logger.WriteLine(Resources.BranchProvider_MatchingServerBranchName, matchingBranchName);
             return matchingBranchName;
         }
 

--- a/src/Core/IServerBranchProvider.cs
+++ b/src/Core/IServerBranchProvider.cs
@@ -28,11 +28,11 @@ namespace SonarLint.VisualStudio.Core
         /// <summary>
         /// Returns the Sonar server branch to use when requesting data
         /// </summary>
-        /// <returns>The Sonar server branch name,
-        /// or the name of the Sonar server branch marked as "Main" if the branch cannot be determined,
-        /// or null if we are not in connected mode.</returns>
+        /// <returns>The Sonar server branch name, or null if the branch cannot be determined</returns>
         /// <remarks>
         /// Only applies in connected mode.
+        /// "null" is a valid value to pass to the branch-aware Sonar webclient APIs; they will fetch
+        /// the data for the "main" branch in that case.
         /// </remarks>
         Task<string> GetServerBranchNameAsync(CancellationToken token);
     }

--- a/src/Core/IServerBranchProvider.cs
+++ b/src/Core/IServerBranchProvider.cs
@@ -28,11 +28,12 @@ namespace SonarLint.VisualStudio.Core
         /// <summary>
         /// Returns the Sonar server branch to use when requesting data
         /// </summary>
-        /// <returns>The Sonar server branch name, or null if the branch cannot be determined</returns>
+        /// <returns>The Sonar server branch name,
+        /// or the name of the Sonar server branch marked as "Main" if the branch cannot be determined,
+        /// or null if we are not in connected mode.
+        /// </returns>
         /// <remarks>
         /// Only applies in connected mode.
-        /// "null" is a valid value to pass to the branch-aware Sonar webclient APIs; they will fetch
-        /// the data for the "main" branch in that case.
         /// </remarks>
         Task<string> GetServerBranchNameAsync(CancellationToken token);
     }


### PR DESCRIPTION
Fixes [#3697](https://github.com/SonarSource/sonarlint-visualstudio/issues/3697)

I've reverted my previous commit that handled headless branches. This new commit should handle both cases (no git repo + headless).