### PR TITLE
Extract xaml header and closer generation to a separate class

### DIFF
--- a/src/Education.UnitTests/XamlGeneratorHelperTests.cs
+++ b/src/Education.UnitTests/XamlGeneratorHelperTests.cs
@@ -1,0 +1,79 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Education.XamlGenerator;
+using SonarLint.VisualStudio.Rules;
+
+namespace SonarLint.VisualStudio.Education.UnitTests
+{
+    [TestClass]
+    public class XamlGeneratorHelperTests
+    {
+        [TestMethod]
+        public void Factory_Create_ReturnsNonNull()
+        {
+            var testSubject = new XamlGeneratorHelperFactory();
+
+            var xamlGeneratorHelper = testSubject.Create(Mock.Of<XmlWriter>());
+
+            xamlGeneratorHelper.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void WriteDocumentHeaderAndEndDocument_ProduceCorrectStructure()
+        {
+            var sb = new StringBuilder();
+            var xmlWriter = RuleHelpXamlTranslator.CreateXmlWriter(sb);
+            var ruleInfo = new RuleInfo("cs", "cs:123", "<p>Hi</p>", "Hi", RuleIssueSeverity.Critical,
+                RuleIssueType.Vulnerability, true, new List<string>(), new List<IDescriptionSection>(),
+                new List<string>());
+
+            var testSubject = (new XamlGeneratorHelperFactory()).Create(xmlWriter);
+
+            testSubject.WriteDocumentHeader(ruleInfo);
+            xmlWriter.WriteStartElement("LineBreak");
+            xmlWriter.WriteEndElement();
+            testSubject.EndDocument();
+
+            sb.ToString().Should().BeEquivalentTo(
+@"<FlowDocument xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"">
+  <Paragraph Style=""{DynamicResource Title_Paragraph}"">Hi</Paragraph>
+  <Paragraph Style=""{DynamicResource Title_Paragraph}"">
+    <Span Style=""{DynamicResource SubtitleElement_Span}"">
+      <InlineUIContainer>
+        <Image Style=""{DynamicResource SubtitleElement_Image}"" Source=""{DynamicResource vulnerabilityDrawingImage}"" />
+      </InlineUIContainer>Vulnerability</Span>
+    <Span Style=""{DynamicResource SubtitleElement_Span}"">
+      <InlineUIContainer>
+        <Image Style=""{DynamicResource SubtitleElement_Image}"" Source=""{DynamicResource criticalDrawingImage}"" />
+      </InlineUIContainer>Critical</Span>
+    <Span Style=""{DynamicResource SubtitleElement_Span}"">cs:123</Span>
+  </Paragraph>
+  <LineBreak />
+</FlowDocument>");
+        }
+    }
+}

--- a/src/Education/Education.cs
+++ b/src/Education/Education.cs
@@ -45,7 +45,7 @@ namespace SonarLint.VisualStudio.Education
 
         [ImportingConstructor]
         public Education(IToolWindowService toolWindowService, IRuleMetadataProvider ruleMetadataProvider, IShowRuleInBrowser showRuleInBrowser, ILogger logger)
-            : this(toolWindowService, ruleMetadataProvider, showRuleInBrowser, logger, new SimpleRuleHelpXamlBuilder(), ThreadHandling.Instance) { }
+            : this(toolWindowService, ruleMetadataProvider, showRuleInBrowser, logger, new SimpleRuleHelpXamlBuilder(new RuleHelpXamlTranslator(), new XamlGeneratorHelperFactory()), ThreadHandling.Instance) { }
 
         internal /* for testing */ Education(IToolWindowService toolWindowService,
             IRuleMetadataProvider ruleMetadataProvider,

--- a/src/Education/XamlGenerator/SimpleRuleHelpXamlBuilder.cs
+++ b/src/Education/XamlGenerator/SimpleRuleHelpXamlBuilder.cs
@@ -21,7 +21,6 @@
 using System.Text;
 using System.Windows.Documents;
 using System.Windows.Markup;
-using System.Xml;
 using SonarLint.VisualStudio.Rules;
 
 namespace SonarLint.VisualStudio.Education.XamlGenerator
@@ -38,12 +37,8 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
         FlowDocument Create(IRuleInfo ruleInfo);
     }
 
-    internal partial class SimpleRuleHelpXamlBuilder : ISimpleRuleHelpXamlBuilder
+    internal class SimpleRuleHelpXamlBuilder : ISimpleRuleHelpXamlBuilder
     {
-        private const string XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
-
-        private XmlWriter writer;
-
         private readonly IRuleHelpXamlTranslator translator;
 
         public SimpleRuleHelpXamlBuilder()
@@ -59,107 +54,17 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
             return flowDocument;
         }
 
-        internal string CreateXamlString(IRuleInfo ruleInfo)
+        private string CreateXamlString(IRuleInfo ruleInfo)
         {
             var sb = new StringBuilder();
-            writer = RuleHelpXamlTranslator.CreateXmlWriter(sb);
-            WriteDocumentHeader(ruleInfo);
+            var writer = RuleHelpXamlTranslator.CreateXmlWriter(sb);
+            var helper = new XamlGeneratorHelper(writer);
 
-            var htmlContent = translator.TranslateHtmlToXaml(ruleInfo.Description);
-
-            EndDocument(htmlContent);
+            helper.WriteDocumentHeader(ruleInfo);
+            writer.WriteRaw(translator.TranslateHtmlToXaml(ruleInfo.Description));
+            helper.EndDocument();
 
             return sb.ToString();
-        }
-
-        private void EndDocument(string htmlContent)
-        {
-            writer.WriteRaw(htmlContent);
-            writer.WriteEndElement();
-            writer.Close();
-        }
-
-        private void WriteDocumentHeader(IRuleInfo ruleInfo)
-        {
-            writer.WriteStartElement("FlowDocument", XamlNamespace);
-            writer.WriteAttributeString("xmlns", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
-
-            WriteTitle(ruleInfo.Name);
-            WriteSubTitle(ruleInfo);
-        }
-
-        private void WriteTitle(string text)
-        {
-            writer.WriteStartElement("Paragraph");
-            writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
-            writer.WriteString(text);
-            writer.WriteEndElement();
-        }
-
-        private void WriteSubTitle(IRuleInfo ruleInfo)
-        {
-            writer.WriteStartElement("Paragraph");
-            writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
-
-            WriteSubTitleElement_IssueType(ruleInfo);
-            WriteSubTitleElement_Severity(ruleInfo);
-            WriteSubTitleElement_RuleKey(ruleInfo);
-            WriteSubTitleElement_Tags(ruleInfo);
-
-            writer.WriteEndElement();
-        }
-
-        private void WriteSubTitleElement_IssueType(IRuleInfo ruleInfo)
-        {
-            var imageInfo = SubTitleImageInfo.IssueTypeImages[ruleInfo.IssueType];
-            WriteSubTitleElementWithImage(imageInfo);
-        }
-
-        private void WriteSubTitleElement_Severity(IRuleInfo ruleInfo)
-        {
-            var imageInfo = SubTitleImageInfo.SeverityImages[ruleInfo.DefaultSeverity];
-            WriteSubTitleElementWithImage(imageInfo);
-        }
-
-        private void WriteSubTitleElementWithImage(SubTitleImageInfo imageInfo)
-        {
-            writer.WriteStartElement("Span");
-            writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
-
-            if (imageInfo.ImageResourceName != null)
-            {
-                writer.WriteStartElement("InlineUIContainer");
-                writer.WriteStartElement("Image");
-                writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Image);
-                writer.WriteAttributeString("Source", $"{{DynamicResource {imageInfo.ImageResourceName}}}");
-                writer.WriteEndElement(); // Image
-                writer.WriteEndElement(); // InlineUIContainer
-            }
-
-            writer.WriteString(imageInfo.DisplayText);
-            writer.WriteEndElement(); // Span
-        }
-
-        private void WriteSubTitleElement_Tags(IRuleInfo ruleInfo)
-        {
-            if (ruleInfo.Tags.Count == 0)
-            {
-                return;
-            }
-
-            // TODO: icon
-            WriteSubTitleElement("Tags: " + string.Join(" ", ruleInfo.Tags));
-        }
-
-        private void WriteSubTitleElement_RuleKey(IRuleInfo ruleInfo)
-            => WriteSubTitleElement(ruleInfo.FullRuleKey);
-
-        private void WriteSubTitleElement(string text)
-        {
-            writer.WriteStartElement("Span");
-            writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
-            writer.WriteString(text);
-            writer.WriteEndElement();
         }
     }
 }

--- a/src/Education/XamlGenerator/SimpleRuleHelpXamlBuilder.cs
+++ b/src/Education/XamlGenerator/SimpleRuleHelpXamlBuilder.cs
@@ -39,11 +39,13 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
 
     internal class SimpleRuleHelpXamlBuilder : ISimpleRuleHelpXamlBuilder
     {
-        private readonly IRuleHelpXamlTranslator translator;
+        private readonly IXamlGeneratorHelperFactory xamlGeneratorHelperFactory;
+        private readonly IRuleHelpXamlTranslator ruleHelpXamlTranslator;
 
-        public SimpleRuleHelpXamlBuilder()
+        public SimpleRuleHelpXamlBuilder(IRuleHelpXamlTranslator ruleHelpXamlTranslator, IXamlGeneratorHelperFactory xamlGeneratorHelperFactory)
         {
-            translator = new RuleHelpXamlTranslator();
+            this.xamlGeneratorHelperFactory = xamlGeneratorHelperFactory;
+            this.ruleHelpXamlTranslator = ruleHelpXamlTranslator;
         }
 
         public FlowDocument Create(IRuleInfo ruleInfo)
@@ -58,10 +60,10 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
         {
             var sb = new StringBuilder();
             var writer = RuleHelpXamlTranslator.CreateXmlWriter(sb);
-            var helper = new XamlGeneratorHelper(writer);
+            var helper = xamlGeneratorHelperFactory.Create(writer);
 
             helper.WriteDocumentHeader(ruleInfo);
-            writer.WriteRaw(translator.TranslateHtmlToXaml(ruleInfo.Description));
+            writer.WriteRaw(ruleHelpXamlTranslator.TranslateHtmlToXaml(ruleInfo.Description));
             helper.EndDocument();
 
             return sb.ToString();

--- a/src/Education/XamlGenerator/XamlGeneratorHelper.cs
+++ b/src/Education/XamlGenerator/XamlGeneratorHelper.cs
@@ -1,0 +1,125 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Xml;
+using SonarLint.VisualStudio.Rules;
+
+namespace SonarLint.VisualStudio.Education.XamlGenerator
+{
+    internal class XamlGeneratorHelper
+    {
+        private const string XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+        private readonly XmlWriter writer;
+
+        public XamlGeneratorHelper(XmlWriter writer)
+        {
+            this.writer = writer;
+        }
+
+        public void EndDocument()
+        {
+            writer.WriteEndElement();
+            writer.Close();
+        }
+
+        public void WriteDocumentHeader(IRuleInfo ruleInfo)
+        {
+            writer.WriteStartElement("FlowDocument", XamlNamespace);
+            writer.WriteAttributeString("xmlns", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+
+            WriteTitle(ruleInfo.Name);
+            WriteSubTitle(ruleInfo);
+        }
+
+        private void WriteTitle(string text)
+        {
+            writer.WriteStartElement("Paragraph");
+            writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
+            writer.WriteString(text);
+            writer.WriteEndElement();
+        }
+
+        private void WriteSubTitle(IRuleInfo ruleInfo)
+        {
+            writer.WriteStartElement("Paragraph");
+            writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
+
+            WriteSubTitleElement_IssueType(ruleInfo);
+            WriteSubTitleElement_Severity(ruleInfo);
+            WriteSubTitleElement_RuleKey(ruleInfo);
+            WriteSubTitleElement_Tags(ruleInfo);
+
+            writer.WriteEndElement();
+        }
+
+        private void WriteSubTitleElement_IssueType(IRuleInfo ruleInfo)
+        {
+            var imageInfo = SubTitleImageInfo.IssueTypeImages[ruleInfo.IssueType];
+            WriteSubTitleElementWithImage(imageInfo);
+        }
+
+        private void WriteSubTitleElement_Severity(IRuleInfo ruleInfo)
+        {
+            var imageInfo = SubTitleImageInfo.SeverityImages[ruleInfo.DefaultSeverity];
+            WriteSubTitleElementWithImage(imageInfo);
+        }
+
+        private void WriteSubTitleElementWithImage(SubTitleImageInfo imageInfo)
+        {
+            writer.WriteStartElement("Span");
+            writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
+
+            if (imageInfo.ImageResourceName != null)
+            {
+                writer.WriteStartElement("InlineUIContainer");
+                writer.WriteStartElement("Image");
+                writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Image);
+                writer.WriteAttributeString("Source", $"{{DynamicResource {imageInfo.ImageResourceName}}}");
+                writer.WriteEndElement(); // Image
+                writer.WriteEndElement(); // InlineUIContainer
+            }
+
+            writer.WriteString(imageInfo.DisplayText);
+            writer.WriteEndElement(); // Span
+        }
+
+        private void WriteSubTitleElement_Tags(IRuleInfo ruleInfo)
+        {
+            if (ruleInfo.Tags.Count == 0)
+            {
+                return;
+            }
+
+            // TODO: icon
+            WriteSubTitleElement("Tags: " + string.Join(" ", ruleInfo.Tags));
+        }
+
+        private void WriteSubTitleElement_RuleKey(IRuleInfo ruleInfo)
+            => WriteSubTitleElement(ruleInfo.FullRuleKey);
+
+        private void WriteSubTitleElement(string text)
+        {
+            writer.WriteStartElement("Span");
+            writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
+            writer.WriteString(text);
+            writer.WriteEndElement();
+        }
+    }
+}

--- a/src/Education/XamlGenerator/XamlGeneratorHelper.cs
+++ b/src/Education/XamlGenerator/XamlGeneratorHelper.cs
@@ -41,7 +41,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
             return new XamlGeneratorHelper(writer);
         }
 
-        private class XamlGeneratorHelper : IXamlGeneratorHelper
+        private sealed class XamlGeneratorHelper : IXamlGeneratorHelper
         {
             private const string XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
             private readonly XmlWriter writer;

--- a/src/Education/XamlGenerator/XamlGeneratorHelper.cs
+++ b/src/Education/XamlGenerator/XamlGeneratorHelper.cs
@@ -23,103 +23,124 @@ using SonarLint.VisualStudio.Rules;
 
 namespace SonarLint.VisualStudio.Education.XamlGenerator
 {
-    internal class XamlGeneratorHelper
+    internal interface IXamlGeneratorHelper
     {
-        private const string XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
-        private readonly XmlWriter writer;
+        void WriteDocumentHeader(IRuleInfo ruleInfo);
+        void EndDocument();
+    }
 
-        public XamlGeneratorHelper(XmlWriter writer)
+    internal interface IXamlGeneratorHelperFactory
+    {
+        IXamlGeneratorHelper Create(XmlWriter writer);
+    }
+
+    internal class XamlGeneratorHelperFactory : IXamlGeneratorHelperFactory
+    {
+        public IXamlGeneratorHelper Create(XmlWriter writer)
         {
-            this.writer = writer;
+            return new XamlGeneratorHelper(writer);
         }
 
-        public void EndDocument()
+        private class XamlGeneratorHelper : IXamlGeneratorHelper
         {
-            writer.WriteEndElement();
-            writer.Close();
-        }
+            private const string XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+            private readonly XmlWriter writer;
 
-        public void WriteDocumentHeader(IRuleInfo ruleInfo)
-        {
-            writer.WriteStartElement("FlowDocument", XamlNamespace);
-            writer.WriteAttributeString("xmlns", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
-
-            WriteTitle(ruleInfo.Name);
-            WriteSubTitle(ruleInfo);
-        }
-
-        private void WriteTitle(string text)
-        {
-            writer.WriteStartElement("Paragraph");
-            writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
-            writer.WriteString(text);
-            writer.WriteEndElement();
-        }
-
-        private void WriteSubTitle(IRuleInfo ruleInfo)
-        {
-            writer.WriteStartElement("Paragraph");
-            writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
-
-            WriteSubTitleElement_IssueType(ruleInfo);
-            WriteSubTitleElement_Severity(ruleInfo);
-            WriteSubTitleElement_RuleKey(ruleInfo);
-            WriteSubTitleElement_Tags(ruleInfo);
-
-            writer.WriteEndElement();
-        }
-
-        private void WriteSubTitleElement_IssueType(IRuleInfo ruleInfo)
-        {
-            var imageInfo = SubTitleImageInfo.IssueTypeImages[ruleInfo.IssueType];
-            WriteSubTitleElementWithImage(imageInfo);
-        }
-
-        private void WriteSubTitleElement_Severity(IRuleInfo ruleInfo)
-        {
-            var imageInfo = SubTitleImageInfo.SeverityImages[ruleInfo.DefaultSeverity];
-            WriteSubTitleElementWithImage(imageInfo);
-        }
-
-        private void WriteSubTitleElementWithImage(SubTitleImageInfo imageInfo)
-        {
-            writer.WriteStartElement("Span");
-            writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
-
-            if (imageInfo.ImageResourceName != null)
+            public XamlGeneratorHelper(XmlWriter writer)
             {
-                writer.WriteStartElement("InlineUIContainer");
-                writer.WriteStartElement("Image");
-                writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Image);
-                writer.WriteAttributeString("Source", $"{{DynamicResource {imageInfo.ImageResourceName}}}");
-                writer.WriteEndElement(); // Image
-                writer.WriteEndElement(); // InlineUIContainer
+                this.writer = writer;
             }
 
-            writer.WriteString(imageInfo.DisplayText);
-            writer.WriteEndElement(); // Span
-        }
-
-        private void WriteSubTitleElement_Tags(IRuleInfo ruleInfo)
-        {
-            if (ruleInfo.Tags.Count == 0)
+            public void WriteDocumentHeader(IRuleInfo ruleInfo)
             {
-                return;
+                writer.WriteStartElement("FlowDocument", XamlNamespace);
+                writer.WriteAttributeString("xmlns", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+
+                WriteTitle(ruleInfo.Name);
+                WriteSubTitle(ruleInfo);
             }
 
-            // TODO: icon
-            WriteSubTitleElement("Tags: " + string.Join(" ", ruleInfo.Tags));
-        }
+            public void EndDocument()
+            {
+                writer.WriteEndElement();
+                writer.Close();
+            }
 
-        private void WriteSubTitleElement_RuleKey(IRuleInfo ruleInfo)
-            => WriteSubTitleElement(ruleInfo.FullRuleKey);
+            private void WriteTitle(string text)
+            {
+                writer.WriteStartElement("Paragraph");
+                writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
+                writer.WriteString(text);
+                writer.WriteEndElement();
+            }
 
-        private void WriteSubTitleElement(string text)
-        {
-            writer.WriteStartElement("Span");
-            writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
-            writer.WriteString(text);
-            writer.WriteEndElement();
+            private void WriteSubTitle(IRuleInfo ruleInfo)
+            {
+                writer.WriteStartElement("Paragraph");
+                writer.ApplyStyleToElement(StyleResourceNames.Title_Paragraph);
+
+                WriteSubTitleElement_IssueType(ruleInfo);
+                WriteSubTitleElement_Severity(ruleInfo);
+                WriteSubTitleElement_RuleKey(ruleInfo);
+                WriteSubTitleElement_Tags(ruleInfo);
+
+                writer.WriteEndElement();
+            }
+
+            private void WriteSubTitleElement_IssueType(IRuleInfo ruleInfo)
+            {
+                var imageInfo = SubTitleImageInfo.IssueTypeImages[ruleInfo.IssueType];
+                WriteSubTitleElementWithImage(imageInfo);
+            }
+
+            private void WriteSubTitleElement_Severity(IRuleInfo ruleInfo)
+            {
+                var imageInfo = SubTitleImageInfo.SeverityImages[ruleInfo.DefaultSeverity];
+                WriteSubTitleElementWithImage(imageInfo);
+            }
+
+            private void WriteSubTitleElementWithImage(SubTitleImageInfo imageInfo)
+            {
+                writer.WriteStartElement("Span");
+                writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
+
+                if (imageInfo.ImageResourceName != null)
+                {
+                    writer.WriteStartElement("InlineUIContainer");
+                    writer.WriteStartElement("Image");
+                    writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Image);
+                    writer.WriteAttributeString("Source", $"{{DynamicResource {imageInfo.ImageResourceName}}}");
+                    writer.WriteEndElement(); // Image
+                    writer.WriteEndElement(); // InlineUIContainer
+                }
+
+                writer.WriteString(imageInfo.DisplayText);
+                writer.WriteEndElement(); // Span
+            }
+
+            private void WriteSubTitleElement_Tags(IRuleInfo ruleInfo)
+            {
+                if (ruleInfo.Tags.Count == 0)
+                {
+                    return;
+                }
+
+                // TODO: icon
+                WriteSubTitleElement("Tags: " + string.Join(" ", ruleInfo.Tags));
+            }
+
+            private void WriteSubTitleElement_RuleKey(IRuleInfo ruleInfo)
+            {
+                WriteSubTitleElement(ruleInfo.FullRuleKey);
+            }
+
+            private void WriteSubTitleElement(string text)
+            {
+                writer.WriteStartElement("Span");
+                writer.ApplyStyleToElement(StyleResourceNames.SubtitleElement_Span);
+                writer.WriteString(text);
+                writer.WriteEndElement();
+            }
         }
     }
 }


### PR DESCRIPTION
It is going to be reused by Simple and Rich layout generators.

NOTE: no new code, just moved the bits to a separate class