### PR TITLE
Remove ProjectGuid field from IFilterableIssue

### DIFF
--- a/src/ConnectedMode.UnitTests/Suppressions/SuppressedIssueMatcherTests.cs
+++ b/src/ConnectedMode.UnitTests/Suppressions/SuppressedIssueMatcherTests.cs
@@ -135,7 +135,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
                 RuleId = ruleId,
                 StartLine = startLine,
                 LineHash = lineHash,
-                ProjectGuid = "well known project guid",
                 FilePath = "well known file path"
             };
 
@@ -166,7 +165,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
             public string LineHash { get; set; }
             public int? StartLine { get; set; }
             public string FilePath { get; set; }
-            public string ProjectGuid { get; set; }
 
             // Not expecting the other property to be used
             public string WholeLineText => throw new NotImplementedException();

--- a/src/Core/Suppressions/IFilterableIssue.cs
+++ b/src/Core/Suppressions/IFilterableIssue.cs
@@ -29,7 +29,6 @@ namespace SonarLint.VisualStudio.Core.Suppression
         string RuleId { get; }
         string FilePath { get; }
         string LineHash { get; }
-        string ProjectGuid { get; }
         int? StartLine { get; }
     }
 }

--- a/src/IssueViz.UnitTests/Models/AnalysisIssueVisualizationTests.cs
+++ b/src/IssueViz.UnitTests/Models/AnalysisIssueVisualizationTests.cs
@@ -227,7 +227,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Models
             filterable.FilePath.Should().Be(issueMock.Object.PrimaryLocation.FilePath);
             filterable.StartLine.Should().Be(issueMock.Object.PrimaryLocation.TextRange.StartLine);
             filterable.LineHash.Should().Be(issueMock.Object.PrimaryLocation.TextRange.LineHash);
-            filterable.ProjectGuid.Should().BeNull();
         }
 
         private SnapshotSpan CreateSpan()

--- a/src/IssueViz/Models/AnalysisIssueVisualization.cs
+++ b/src/IssueViz/Models/AnalysisIssueVisualization.cs
@@ -113,8 +113,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.Models
 
         string IFilterableIssue.LineHash => Issue.PrimaryLocation.TextRange.LineHash;
 
-        string IFilterableIssue.ProjectGuid => null; // not used for non-Roslyn issues
-
         int? IFilterableIssue.StartLine => Issue.PrimaryLocation.TextRange.StartLine;
     }
 


### PR DESCRIPTION
- no longer used. It was used by the old Roslyn suppressions code, but that was removed March 2022.

Fixes #3888