### PR TITLE
Handle null collections when parsing server rule info

### DIFF
--- a/src/Rules.UnitTests/RuleInfoTests.cs
+++ b/src/Rules.UnitTests/RuleInfoTests.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarLint.VisualStudio.Rules.UnitTests
+{
+    [TestClass]
+    public class RuleInfoTests
+    {
+        [TestMethod]
+        public void Ctor_NullCollectionsAreAllowed_SetToEmptyCollections()
+        {
+            var testSubject = new RuleInfo(
+                languageKey: null,
+                fullRuleKey: null,
+                description: null,
+                name: null,
+                RuleIssueSeverity.Unknown,
+                RuleIssueType.Unknown,
+                isActiveByDefault: false,
+                tags: null,
+                descriptionSections: null,
+                educationPrinciples: null,
+                htmlNote: null);
+
+            testSubject.Tags.Should().NotBeNull();
+            testSubject.DescriptionSections.Should().NotBeNull();
+            testSubject.EducationPrinciples.Should().NotBeNull();
+
+            testSubject.Tags.Should().HaveCount(0);
+            testSubject.DescriptionSections.Should().HaveCount(0);
+            testSubject.EducationPrinciples.Should().HaveCount(0);
+        }
+    }
+}

--- a/src/Rules/IRuleInfo.cs
+++ b/src/Rules/IRuleInfo.cs
@@ -120,13 +120,19 @@ namespace SonarLint.VisualStudio.Rules
         /// </summary>
         string Description { get; }
 
+        /// <summary>
+        /// List of tags. Can be empty. Will not be null.
+        /// </summary>
         IReadOnlyList<string> Tags { get; }
 
         /// <summary>
-        /// Tabs for new educational format
+        /// Tabs for new educational format. Can be empty. Will not be null.
         /// </summary>
         IReadOnlyList<IDescriptionSection> DescriptionSections { get; }
 
+        /// <summary>
+        /// Education principles for the new educational format. Can be empty. Will not be null.
+        /// </summary>
         IReadOnlyList<string> EducationPrinciples { get; }
 
         string HtmlNote { get; }
@@ -148,9 +154,9 @@ namespace SonarLint.VisualStudio.Rules
             IssueType = issueType;
             IsActiveByDefault = isActiveByDefault;
             Tags = tags ?? Array.Empty<string>();
-            DescriptionSections = descriptionSections;
-            EducationPrinciples = educationPrinciples;
-            HtmlNote = htmlNote;
+            DescriptionSections = descriptionSections ?? Array.Empty<IDescriptionSection>();
+            EducationPrinciples = educationPrinciples ?? Array.Empty<string>();
+            HtmlNote = htmlNote ;
         }
 
         public string FullRuleKey { get; private set; }

--- a/src/Rules/ServerRuleMetadataProvider.cs
+++ b/src/Rules/ServerRuleMetadataProvider.cs
@@ -70,9 +70,10 @@ namespace SonarLint.VisualStudio.Rules
             {
                 logger.WriteLine(Resources.ServerMetadataProvider_GetRulesError, ruleId.ToString(), ex.Message);
             }
-            if (sqRule == null) return null;
+            
+            if (sqRule == null) { return null; }
 
-            var descriptionSections = sqRule.DescriptionSections.Select(ds => ds.ToDescriptionSection()).ToList();
+            var descriptionSections = sqRule.DescriptionSections?.Select(ds => ds.ToDescriptionSection()).ToList();
 
             return new RuleInfo(sqRule.RepositoryKey,
                 sqRule.GetCompositeKey(),

--- a/src/Rules/ServerRuleMetadataProvider.cs
+++ b/src/Rules/ServerRuleMetadataProvider.cs
@@ -61,31 +61,32 @@ namespace SonarLint.VisualStudio.Rules
 
         public async Task<IRuleInfo> GetRuleInfoAsync(SonarCompositeRuleId ruleId, string qualityProfileKey, CancellationToken token)
         {
-            SonarQubeRule sqRule = null;
             try
             {
-                sqRule = await service.GetRuleByKeyAsync(ruleId.ToString(), qualityProfileKey, token);
+                var sqRule = await service.GetRuleByKeyAsync(ruleId.ToString(), qualityProfileKey, token);
+
+                if (sqRule == null) { return null; }
+
+                var descriptionSections = sqRule.DescriptionSections?.Select(ds => ds.ToDescriptionSection()).ToList();
+
+                return new RuleInfo(sqRule.RepositoryKey,
+                    sqRule.GetCompositeKey(),
+                    HtmlXmlCompatibilityHelper.EnsureHtmlIsXml(sqRule.Description),
+                    sqRule.Name,
+                    sqRule.Severity.ToRuleIssueSeverity(),
+                    sqRule.IssueType.ToRuleIssueType(),
+                    sqRule.IsActive,
+                    sqRule.Tags,
+                    descriptionSections,
+                    sqRule.EducationPrinciples,
+                    HtmlXmlCompatibilityHelper.EnsureHtmlIsXml(sqRule.HtmlNote));
             }
             catch (Exception ex)
             {
                 logger.WriteLine(Resources.ServerMetadataProvider_GetRulesError, ruleId.ToString(), ex.Message);
             }
-            
-            if (sqRule == null) { return null; }
 
-            var descriptionSections = sqRule.DescriptionSections?.Select(ds => ds.ToDescriptionSection()).ToList();
-
-            return new RuleInfo(sqRule.RepositoryKey,
-                sqRule.GetCompositeKey(),
-                HtmlXmlCompatibilityHelper.EnsureHtmlIsXml(sqRule.Description),
-                sqRule.Name,
-                sqRule.Severity.ToRuleIssueSeverity(),
-                sqRule.IssueType.ToRuleIssueType(),
-                sqRule.IsActive,
-                sqRule.Tags,
-                descriptionSections,
-                sqRule.EducationPrinciples,
-                HtmlXmlCompatibilityHelper.EnsureHtmlIsXml(sqRule.HtmlNote));
+            return null;
         }
     }
 }


### PR DESCRIPTION
Handle null collections when processing server rule info

Last part of the fix for #3973