### PR TITLE
Remove NuGet steps from binding process

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingProcessImplTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingProcessImplTests.cs
@@ -468,35 +468,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void InstallPackages_Succeeds_SuccessPropertyIsTrue()
-        {
-            // Arrange
-            var bindingArgs = CreateBindCommandArgs("projectKey", "projectName", new ConnectionInformation(new Uri("http://connected")));
-
-            var slnBindOpMock = new Mock<ISolutionBindingOperation>();
-            var configProvider = new Mock<IBindingConfigProvider>();
-            var exclusionSettingsStorage = Mock.Of<IExclusionSettingsStorage>();
-
-            var testSubject = new BindingProcessImpl(this.host, bindingArgs, slnBindOpMock.Object, configProvider.Object, SonarLintMode.Connected, exclusionSettingsStorage);
-
-            var project = Mock.Of<Project>();
-            testSubject.InternalState.BindingProjects.Clear();
-            testSubject.InternalState.BindingProjects.Add(project);
-
-            var progressEvents = new ConfigurableProgressStepExecutionEvents();
-            var progressAdapter = new FixedStepsProgressAdapter(progressEvents);
-            var cts = new CancellationTokenSource();
-
-            testSubject.InternalState.BindingOperationSucceeded = false;
-
-            // Act
-            testSubject.InstallPackages(progressAdapter, cts.Token);
-
-            // Assert
-            testSubject.InternalState.BindingOperationSucceeded.Should().BeTrue();
-        }
-
-        [TestMethod]
         public void EmitBindingCompleteMessage()
         {
             // Arrange

--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -146,20 +146,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void BindingWorkflow_InstallPackages_NoError()
-        {
-            // Arrange
-            var progressEvents = new ConfigurableProgressStepExecutionEvents();
-            var cts = new CancellationTokenSource();
-
-            // Act
-            testSubject.InstallPackages(progressEvents, cts.Token);
-
-            // Assert
-            mockBindingProcess.Verify(x => x.InstallPackages(It.IsAny<IProgress<FixedStepsProgress>>(), cts.Token), Times.Once);
-        }
-
-        [TestMethod]
         public void BindingWorkflow_InitializeSolutionBindingOnBackgroundThread_NoError()
         {
             // Arrange
@@ -218,17 +204,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Assert
             mockBindingProcess.Verify(x => x.FinishSolutionBindingOnUIThread(), Times.Once);
             controller.NumberOfAbortRequests.Should().Be(1);
-        }
-
-        [TestMethod]
-        public void BindingWorkflow_PrepareToInstallPackages_Passthrough()
-        {
-            // Arrange
-            // Act
-            testSubject.PrepareToInstallPackages();
-
-            // Assert
-            mockBindingProcess.Verify(x => x.PrepareToInstallPackages(), Times.Once);
         }
 
         [TestMethod]

--- a/src/Integration/Binding/BindingProcessImpl.cs
+++ b/src/Integration/Binding/BindingProcessImpl.cs
@@ -197,12 +197,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
             return configurationPersister.Persist(bound, bindingMode);
         }
 
-        public void PrepareToInstallPackages()
-        {
-            // TODO - CM cleanup
-            // no-op
-        }
-
         public async Task<bool> SaveServerExclusionsAsync(CancellationToken cancellationToken)
         {
             try
@@ -216,12 +210,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 return false;
             }
             return true;
-        }
-
-        public void InstallPackages(IProgress<FixedStepsProgress> progress, CancellationToken cancellationToken)
-        {
-            // TODO - CM cleanup
-            this.InternalState.BindingOperationSucceeded = true;
         }
 
         public void InitializeSolutionBindingOnBackgroundThread()

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -108,17 +108,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
                         (token, notifications) => this.DownloadQualityProfileAsync(controller, notifications, token).GetAwaiter().GetResult()),
 
                 //*****************************************************************
-                // NuGet package handling
-                //*****************************************************************
-                // Initialize the VS NuGet installer service
-                new ProgressStepDefinition(null, HiddenIndeterminateNonImpactingNonCancellableUIStep,
-                        (token, notifications) => { this.PrepareToInstallPackages(); }),
-
-                // Install the appropriate package for each project
-                new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
-                        (token, notifications) => this.InstallPackages(notifications, token)),
-
-                //*****************************************************************
                 // Solution update phase
                 //*****************************************************************
                 // * copy shared ruleset to shared location
@@ -224,17 +213,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
             {
                 AbortWorkflow(controller, token);
             }
-        }
-
-        internal /*for testing purposes*/ void PrepareToInstallPackages()
-        {
-            bindingProcess.PrepareToInstallPackages();
-        }
-
-        internal /*for testing purposes*/ void InstallPackages(IProgressStepExecutionEvents notificationEvents, CancellationToken token)
-        {
-            var progressAdapter = new FixedStepsProgressAdapter(notificationEvents);
-            bindingProcess.InstallPackages(progressAdapter, token);
         }
 
         internal /*for testing purposes*/ void SilentSaveSolutionIfDirty()

--- a/src/Integration/Binding/IBindingProcess.cs
+++ b/src/Integration/Binding/IBindingProcess.cs
@@ -42,10 +42,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         Task<bool> SaveServerExclusionsAsync(CancellationToken cancellationToken);
 
-        void PrepareToInstallPackages();
-
-        void InstallPackages(IProgress<FixedStepsProgress> progress, CancellationToken cancellationToken);
-
         void InitializeSolutionBindingOnBackgroundThread();
 
         void PrepareSolutionBinding(CancellationToken cancellationToken);


### PR DESCRIPTION
- most of the implement was removed in a previous commit. This removes the entry points that called the now-removed code.

Part of #4120