### PR TITLE
[2] Store the globalconfig and SonarLint.xml without projectKey

### DIFF
--- a/src/ConnectedMode/Embedded/SonarLintTargets.xml
+++ b/src/ConnectedMode/Embedded/SonarLintTargets.xml
@@ -20,11 +20,14 @@
 
     <PropertyGroup Condition="$(BuildingInsideVisualStudio) == 'true'">
         <SolutionDirAsInVs>$([System.IO.Path]::GetDirectoryName($(SolutionDir)))</SolutionDirAsInVs>
+        <SonarLanguage>$(Language)</SonarLanguage>
+        <SonarLanguage Condition=" $(Language) == 'C#' OR $(Language) == 'c#'">csharp</SonarLanguage>
+        <SonarLanguage Condition=" $(Language) == 'VISUALBASIC'">vb</SonarLanguage>
         <!-- C#/VB.NET settings need to be in different folders -->
-        <_SLVSRootFolder>$(APPDATA)\SonarLint for Visual Studio\Bindings\$(SolutionName)_$(SolutionDirAsInVs.GetHashCode())\$(Language)</_SLVSRootFolder>
+        <_SLVSRootFolder>$(APPDATA)\SonarLint for Visual Studio\Bindings\$(SolutionName)_$(SolutionDirAsInVs.GetHashCode())</_SLVSRootFolder>
 
-        <_SLVSGeneratedRoslynConfigFile>$(_SLVSRootFolder)\slvs_generated.globalconfig</_SLVSGeneratedRoslynConfigFile>
-        <_SLVSGeneratedAdditionalFile>$(_SLVSRootFolder)\SonarLint.xml</_SLVSGeneratedAdditionalFile>
+        <_SLVSGeneratedRoslynConfigFile>$(_SLVSRootFolder)\$(SonarLanguage).globalconfig</_SLVSGeneratedRoslynConfigFile>
+        <_SLVSGeneratedAdditionalFile>$(_SLVSRootFolder)\$(SonarLanguage)\SonarLint.xml</_SLVSGeneratedAdditionalFile>
     </PropertyGroup>
 
     <ItemGroup Condition="$(BuildingInsideVisualStudio) == 'true' AND Exists($(_SLVSGeneratedRoslynConfigFile))">
@@ -44,7 +47,7 @@
         </PropertyGroup>
 
         <Message Importance="high" Text="XXX: Building inside VS: $(BuildingInsideVisualStudio)" />
-        <Message Importance="high" Text="XXX: Language: $(Language)" />
+        <Message Importance="high" Text="XXX: SonarLanguage: $(SonarLanguage)" />
         <Message Importance="high" Text="XXX: SolutionDirAsInVs: $(SolutionDirAsInVs)" />
         <Message Importance="high" Text="XXX: SolutionDirAsInVs.GetHashCode: $(SolutionDirAsInVs.GetHashCode())" />
         <Message Importance="high" Text="XXX: SLVSRootFolder: $(_SLVSRootFolder)" />

--- a/src/Core/Binding/BindingConfiguration.cs
+++ b/src/Core/Binding/BindingConfiguration.cs
@@ -92,7 +92,7 @@ namespace SonarLint.VisualStudio.Core.Binding
 
         public string BuildPathUnderConfigDirectory(string fileSuffix = "")
         {
-            var escapedFileName = Helpers.PathHelper.EscapeFileName(Project.ProjectKey + fileSuffix).ToLowerInvariant(); // Must be lower case - see https://github.com/SonarSource/sonarlint-visualstudio/issues/1068;
+            var escapedFileName = Helpers.PathHelper.EscapeFileName(fileSuffix).ToLowerInvariant(); // Must be lower case - see https://github.com/SonarSource/sonarlint-visualstudio/issues/1068;
             
             return Path.Combine(BindingConfigDirectory, escapedFileName);
         }

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -45,11 +45,11 @@ namespace SonarLint.VisualStudio.Core
         public readonly static Language Unknown = new Language();
         public readonly static Language CSharp = new Language("CSharp", CoreStrings.CSharpLanguageName, "csharp.globalconfig", SonarQubeLanguage.CSharp);
         public readonly static Language VBNET = new Language("VB", CoreStrings.VBNetLanguageName, "vb.globalconfig", SonarQubeLanguage.VbNet);
-        public readonly static Language Cpp = new Language("C++", CoreStrings.CppLanguageName, "_cpp_settings.json", SonarQubeLanguage.Cpp);
-        public readonly static Language C = new Language("C", "C", "_c_settings.json", SonarQubeLanguage.C);
-        public readonly static Language Js = new Language("Js", "JavaScript", "_js_settings.json", SonarQubeLanguage.Js);
-        public readonly static Language Ts = new Language("Ts", "TypeScript", "_ts_settings.json", SonarQubeLanguage.Ts);
-        public readonly static Language Secrets = new Language("Secrets", "Secrets", "_secrets_settings.json", SonarQubeLanguage.Secrets);
+        public readonly static Language Cpp = new Language("C++", CoreStrings.CppLanguageName, "cpp_settings.json", SonarQubeLanguage.Cpp);
+        public readonly static Language C = new Language("C", "C", "c_settings.json", SonarQubeLanguage.C);
+        public readonly static Language Js = new Language("Js", "JavaScript", "js_settings.json", SonarQubeLanguage.Js);
+        public readonly static Language Ts = new Language("Ts", "TypeScript", "ts_settings.json", SonarQubeLanguage.Ts);
+        public readonly static Language Secrets = new Language("Secrets", "Secrets", "secrets_settings.json", SonarQubeLanguage.Secrets);
 
         /// <summary>
         /// Returns the language for the specified language key, or null if it does not match a known language

--- a/src/Integration.UnitTests/Binding/CSharpVBBindingConfigProviderTests.cs
+++ b/src/Integration.UnitTests/Binding/CSharpVBBindingConfigProviderTests.cs
@@ -180,7 +180,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             };
             var testSubject = builder.CreateTestSubject();
 
-            var expectedAdditionalFilePath = builder.BindingConfiguration.BuildPathUnderConfigDirectory() + "\\VB\\SonarLint.xml";
+            var expectedAdditionalFilePath = builder.BindingConfiguration.BuildPathUnderConfigDirectory() + "VB\\SonarLint.xml";
 
             var response = await testSubject.GetConfigurationAsync(validQualityProfile, Language.VBNET, builder.BindingConfiguration, CancellationToken.None);
             (response as ICSharpVBBindingConfig).AdditionalFile.Path.Should().Be(expectedAdditionalFilePath);

--- a/src/Integration.UnitTests/NewConnectedMode/BindingConfigurationTests.cs
+++ b/src/Integration.UnitTests/NewConnectedMode/BindingConfigurationTests.cs
@@ -247,12 +247,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         #endregion
 
         [TestMethod]
-        [DataRow("c:\\MY Directory", "mykey>>", "file.SUFFIX", "c:\\MY Directory\\mykey__file.suffix")]
-        [DataRow("c:\\", "MY_KEY", "NAME.txt", "c:\\my_keyname.txt")]
-        [DataRow("c:\\", "My<Key>", "N|a<m>e.txt", "c:\\my_key_n_a_m_e.txt")]
-        public void BuildPathUnderConfigDirectory_GeneratesCorrectFilePath(string rootDirectory, string projectKey, string fileNameSuffixAndExtension, string expectedPath)
+        [DataRow("c:\\MY Directory", "file.SUFFIX", "c:\\MY Directory\\file.suffix")]
+        [DataRow("c:\\", "NAME.txt", "c:\\name.txt")]
+        [DataRow("c:\\", "N|a<m>e.txt", "c:\\n_a_m_e.txt")]
+        public void BuildPathUnderConfigDirectory_GeneratesCorrectFilePath(string rootDirectory, string fileNameSuffixAndExtension, string expectedPath)
         {
-            var project = new BoundSonarQubeProject(new Uri("http://localhost2"), projectKey, "projectName");
+            var project = new BoundSonarQubeProject(new Uri("http://localhost2"), "My<Key>", "projectName");
             var testSubject = BindingConfiguration.CreateBoundConfiguration(project, SonarLintMode.LegacyConnected, rootDirectory);
 
             var result = testSubject.BuildPathUnderConfigDirectory(fileNameSuffixAndExtension);


### PR DESCRIPTION
Fixes [#4203](https://github.com/SonarSource/sonarlint-visualstudio/issues/4203) and [#4188](https://github.com/SonarSource/sonarlint-visualstudio/issues/4188)

As we discussed, I've removed the projectKey distinction. It simplifies things, and we already broke the support of it when we added `sonar.settings.json`.

New folder structure on disk:

![image](https://github.com/SonarSource/sonarlint-visualstudio/assets/60586879/6a6ff512-8e9a-4cab-94db-ae78e82ecbc3)
![image](https://github.com/SonarSource/sonarlint-visualstudio/assets/60586879/09a2b545-ba0e-4e97-82ae-0caed2577f81)
![image](https://github.com/SonarSource/sonarlint-visualstudio/assets/60586879/18e245b4-8748-4a5a-a067-ae626e6adea8)
