### PR TITLE
(2) Remove IProjectSystemHelper.GetFilteredSolutionProjects

### DIFF
--- a/src/Integration.UnitTests/LocalServices/ProjectSystemHelperTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ProjectSystemHelperTests.cs
@@ -325,40 +325,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void ProjectSystemHelper_GetFilteredSolutionProjects()
-        {
-            ProjectMock csProject = this.solutionMock.AddOrGetProject("c#");
-            csProject.SetExtObjProperty(VSConstants.VSITEMID_ROOT, csProject);
-            csProject.ProjectKind = ProjectSystemHelper.CSharpProjectKind;
-            projectToLanguageMapper.Setup(x => x.HasSupportedLanguage(csProject)).Returns(true);
-
-            ProjectMock vbProject = this.solutionMock.AddOrGetProject("vb.net");
-            vbProject.SetExtObjProperty(VSConstants.VSITEMID_ROOT, vbProject);
-            vbProject.ProjectKind = ProjectSystemHelper.VbProjectKind;
-            projectToLanguageMapper.Setup(x => x.HasSupportedLanguage(vbProject)).Returns(true);
-
-            ProjectMock otherProject = this.solutionMock.AddOrGetProject("other");
-            otherProject.SetExtObjProperty(VSConstants.VSITEMID_ROOT, otherProject);
-            otherProject.ProjectKind = "other";
-            projectToLanguageMapper.Setup(x => x.HasSupportedLanguage(otherProject)).Returns(false);
-
-            ProjectMock erronousProject = this.solutionMock.AddOrGetProject("err");
-            erronousProject.SetExtObjProperty(VSConstants.VSITEMID_ROOT, null);
-            erronousProject.ProjectKind = ProjectSystemHelper.VbProjectKind;
-            projectToLanguageMapper.Setup(x => x.HasSupportedLanguage(erronousProject)).Returns(true);
-
-            // Filter out C#, keep VB
-            projectFilter.MatchingProjects.Add(vbProject);
-
-            // Act
-            var actual = this.testSubject.GetFilteredSolutionProjects().ToArray();
-
-            // Assert
-            CollectionAssert.AreEqual(new[] { vbProject }, actual,
-                "Unexpected projects: {0}", string.Join(", ", actual.Select(p => p.Name)));
-        }
-
-        [TestMethod]
         public void ProjectSystemHelper_AddFileToProject_ProjectArgCheck()
         {
             Action act = () => this.testSubject.AddFileToProject(null, "file");

--- a/src/Integration/LocalServices/IProjectSystemHelper.cs
+++ b/src/Integration/LocalServices/IProjectSystemHelper.cs
@@ -78,14 +78,6 @@ namespace SonarLint.VisualStudio.Integration
         IEnumerable<Project> GetSolutionProjects();
 
         /// <summary>
-        /// Returns only the filtered project based on a common filter.
-        /// This should only be called after we connected to a SonarQube server,
-        /// since some of the filtering is SonarQube server instance specific.
-        /// <seealso cref="IProjectSystemFilter"/> which is used internally.
-        /// </summary>
-        IEnumerable<Project> GetFilteredSolutionProjects();
-
-        /// <summary>
         /// Returns the <seealso cref="IVsHierarchy"/> for a <see cref="Project"/>
         /// </summary>
         IVsHierarchy GetIVsHierarchy(Project dteProject);

--- a/src/Integration/LocalServices/ProjectSystemHelper.cs
+++ b/src/Integration/LocalServices/ProjectSystemHelper.cs
@@ -97,14 +97,6 @@ namespace SonarLint.VisualStudio.Integration
             }
         }
 
-        public IEnumerable<Project> GetFilteredSolutionProjects()
-        {
-            var projectFilter = this.serviceProvider.GetService<IProjectSystemFilter>();
-            projectFilter.AssertLocalServiceIsNotNull();
-
-            return GetSolutionProjects().Where(x => projectFilter.IsAccepted(x));
-        }
-
         public Project GetProject(IVsHierarchy projectHierarchy)
         {
             if (projectHierarchy == null)

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -67,11 +67,6 @@ namespace SonarLint.VisualStudio.TestInfrastructure
             return this.Projects ?? Enumerable.Empty<Project>();
         }
 
-        IEnumerable<Project> IProjectSystemHelper.GetFilteredSolutionProjects()
-        {
-            return this.FilteredProjects ?? Enumerable.Empty<Project>();
-        }
-
         bool IProjectSystemHelper.IsFileInProject(Project project, string file)
         {
             return this.IsFileInProjectAction?.Invoke(project, file) ?? false;


### PR DESCRIPTION
- no longer called. With the new binding model, we don't need to check which projects contain supported languages since 1) we won't make changes to individual project files, and 2) we download QPs for all supported languages if a project does not have any supported languages.

Part of #4120