### PR TITLE
Change Tfvc migration help URL

### DIFF
--- a/src/ConnectedMode/Migration/MigrationStrings.Designer.cs
+++ b/src/ConnectedMode/Migration/MigrationStrings.Designer.cs
@@ -278,7 +278,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Migration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://github.com/SonarSource/sonarlint-visualstudio/wiki/migrate-connected-mode-to-v7-tfvc.
+        ///   Looks up a localized string similar to https://github.com/SonarSource/sonarlint-visualstudio/wiki/migrate-connected-mode-to-v7#additional-notes-for-tfvc-users.
         /// </summary>
         internal static string Url_TfvcHelp {
             get {

--- a/src/ConnectedMode/Migration/MigrationStrings.resx
+++ b/src/ConnectedMode/Migration/MigrationStrings.resx
@@ -198,7 +198,7 @@
     <value>Error during migration. See the Output Window for more information.</value>
   </data>
   <data name="Url_TfvcHelp" xml:space="preserve">
-    <value>https://github.com/SonarSource/sonarlint-visualstudio/wiki/migrate-connected-mode-to-v7-tfvc</value>
+    <value>https://github.com/SonarSource/sonarlint-visualstudio/wiki/migrate-connected-mode-to-v7#additional-notes-for-tfvc-users</value>
   </data>
   <data name="VSFileSystem_FailedToCheckOutFilesForEditing" xml:space="preserve">
     <value>Failed to check out files for editing. Error flags: {0}</value>


### PR DESCRIPTION
- changed to a section on the migration page rather than a separate page.