### PR TITLE
Reinstate OpenInIDE hotspot store and supporting types

### DIFF
--- a/src/IssueViz.Security.UnitTests/OpenInIDE/Api/OpenInIDERequestHandlerTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE/Api/OpenInIDERequestHandlerTests.cs
@@ -17,333 +17,332 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-// todo fix after reintegration
-//
-// using System;
-// using System.Threading;
-// using System.Threading.Tasks;
-// using FluentAssertions;
-// using Microsoft.VisualStudio.TestTools.UnitTesting;
-// using Moq;
-// using SonarLint.VisualStudio.Core;
-// using SonarLint.VisualStudio.Core.Telemetry;
-// using SonarLint.VisualStudio.Integration;
-// using SonarLint.VisualStudio.TestInfrastructure;
-// using SonarLint.VisualStudio.IssueVisualization.Editor;
-// using SonarLint.VisualStudio.IssueVisualization.Models;
-// using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
-// using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList;
-// using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE.Api;
-// using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE.Contract;
-// using SonarLint.VisualStudio.IssueVisualization.Selection;
-// using SonarQube.Client;
-// using SonarQube.Client.Models;
-//
-// namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE.Api
-// {
-//     [TestClass]
-//     public class OpenInIDERequestHandlerTests_MEF
-//     {
-//         [TestMethod]
-//         public void MefCtor_CheckIsExported()
-//         {
-//             MefTestHelpers.CheckTypeCanBeImported<OpenInIDERequestHandler, IOpenInIDERequestHandler>(
-//                 MefTestHelpers.CreateExport<IIDEWindowService>(),
-//                 MefTestHelpers.CreateExport<IToolWindowService>(),
-//                 MefTestHelpers.CreateExport<IOpenInIDEStateValidator>(),
-//                 MefTestHelpers.CreateExport<ISonarQubeService>(),
-//                 MefTestHelpers.CreateExport<IHotspotToIssueVisualizationConverter>(),
-//                 MefTestHelpers.CreateExport<ILocationNavigator>(),
-//                 MefTestHelpers.CreateExport<IHotspotsStore>(),
-//                 MefTestHelpers.CreateExport<IOpenInIDEFailureInfoBar>(),
-//                 MefTestHelpers.CreateExport<IIssueSelectionService>(),
-//                 MefTestHelpers.CreateExport<ITelemetryManager>(),
-//                 MefTestHelpers.CreateExport<ILogger>());
-//         }
-//     }
-//
-//     [TestClass]
-//     public class OpenInIDERequestHandlerTests_Orchestration
-//     {
-//         private readonly IShowHotspotRequest ValidRequest = new TestShowHotspotRequest
-//             {
-//                 ServerUrl = new Uri("http://localhost/"),
-//                 ProjectKey = "project",
-//                 HotspotKey = "any",
-//                 OrganizationKey = "org"
-//             };
-//
-//         private readonly SonarQubeHotspot ValidServerHotspot = new SonarQubeHotspot("hotspotKey", null, null, null, null, null, null, null, null, null, DateTimeOffset.MinValue, DateTimeOffset.MaxValue, null, null);
-//
-//         private Mock<IIDEWindowService> ideWindowServiceMock;
-//         private Mock<IToolWindowService> toolWindowServiceMock;
-//         private Mock<IOpenInIDEStateValidator> stateValidatorMock;
-//         private Mock<ISonarQubeService> serverMock;
-//         private Mock<IHotspotToIssueVisualizationConverter> converterMock;
-//         private Mock<ILocationNavigator> navigatorMock;
-//         private Mock<IHotspotsStore> storeMock;
-//         private Mock<IOpenInIDEFailureInfoBar> failureInfoBarMock;
-//         private Mock<IIssueSelectionService> selectionServiceMock;
-//         private Mock<ITelemetryManager> telemetryManagerMock;
-//         private TestLogger logger;
-//
-//         private IOpenInIDERequestHandler testSubject;
-//
-//         [TestInitialize]
-//         public void TestInitialize()
-//         {
-//             ThreadHelper.SetCurrentThreadAsUIThread();
-//
-//             // The tool window should always be called with the same argument
-//             toolWindowServiceMock = new Mock<IToolWindowService>();
-//             toolWindowServiceMock.Setup(x => x.Show(HotspotsToolWindow.ToolWindowId));
-//
-//             ideWindowServiceMock = new Mock<IIDEWindowService>();
-//             stateValidatorMock = new Mock<IOpenInIDEStateValidator>();
-//             serverMock = new Mock<ISonarQubeService>();
-//             converterMock = new Mock<IHotspotToIssueVisualizationConverter>();
-//             navigatorMock = new Mock<ILocationNavigator>();
-//             storeMock = new Mock<IHotspotsStore>();
-//             failureInfoBarMock = new Mock<IOpenInIDEFailureInfoBar>();
-//             selectionServiceMock = new Mock<IIssueSelectionService>();
-//             telemetryManagerMock = new Mock<ITelemetryManager>();
-//             logger = new TestLogger(logToConsole: true);
-//
-//             testSubject = new OpenInIDERequestHandler(ideWindowServiceMock.Object, toolWindowServiceMock.Object, stateValidatorMock.Object, serverMock.Object,
-//             converterMock.Object, navigatorMock.Object, storeMock.Object, failureInfoBarMock.Object, selectionServiceMock.Object, telemetryManagerMock.Object, logger);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_InvalidArg_Throws()
-//         {
-//             Func<Task> act = async () => await testSubject.ShowHotspotAsync(null);
-//             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("request");
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotpot_IdeNotInCorrectState_NoFurtherProcessing()
-//         {
-//             InitializeStateValidator(ValidRequest, false);
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarShown();
-//
-//             CheckCalled(stateValidatorMock);
-//             CheckNotCalled(serverMock, converterMock, navigatorMock, storeMock, selectionServiceMock);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_FailedToRetrieveHotspotData_NoFurtherProcessing()
-//         {
-//             InitializeStateValidator(ValidRequest, true);
-//             SetServerResponse(ValidRequest, null);
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarShown();
-//
-//             CheckCalled(stateValidatorMock, serverMock);
-//             CheckNotCalled(converterMock, navigatorMock, storeMock, selectionServiceMock);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_ServerThrows_NoFurtherProcessing()
-//         {
-//             InitializeStateValidator(ValidRequest, true);
-//             SetServerToThrow(ValidRequest, new InvalidOperationException("thrown from test code"));
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             logger.AssertPartialOutputStringExists("thrown from test code");
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarShown();
-//
-//             CheckCalled(stateValidatorMock, serverMock);
-//             CheckNotCalled(converterMock, navigatorMock, storeMock, selectionServiceMock);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_ConversionFailed_NoFurtherProcessing()
-//         {
-//             InitializeStateValidator(ValidRequest, true);
-//             SetServerResponse(ValidRequest, ValidServerHotspot);
-//             SetConversionResponse(ValidServerHotspot, null);
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarShown();
-//
-//             CheckCalled(stateValidatorMock, serverMock, converterMock);
-//             CheckNotCalled(navigatorMock, storeMock, selectionServiceMock);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_ConverterThrows_NoFurtherProcessing()
-//         {
-//             InitializeStateValidator(ValidRequest, true);
-//             SetServerResponse(ValidRequest, ValidServerHotspot);
-//             SetConverterToThrow(ValidServerHotspot, new InvalidOperationException("thrown from test code"));
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             logger.AssertPartialOutputStringExists("thrown from test code");
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarShown();
-//
-//             CheckCalled(stateValidatorMock, serverMock, converterMock);
-//             CheckNotCalled(navigatorMock, storeMock, selectionServiceMock);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_DataIsValid_NavigationSucceeded_And_IssueAddedToStoreAndSelected()
-//         {
-//             // Note: this test needs a viz mock that doesn't have any members mocked using Setup(...).
-//             // This is because we don't expect any of the members to be called (and if the mock has any
-//             // members mocked then the call to converterMock.VerifyAll() will fail when the library tries
-//             // to transitively verify the viz members).
-//             var hotspotVizMock = new Mock<IAnalysisIssueVisualization>();
-//
-//             InitializeStateValidator(ValidRequest, true);
-//             SetServerResponse(ValidRequest, ValidServerHotspot);
-//             SetConversionResponse(ValidServerHotspot, hotspotVizMock.Object);
-//             SetNavigationRespone(hotspotVizMock.Object, true);
-//
-//             var addedHotspotVizMock = new Mock<IAnalysisIssueVisualization>();
-//             SetStoreExpectedItem(hotspotVizMock.Object, addedHotspotVizMock.Object);
-//             SetSelectionServiceExpectedItem(addedHotspotVizMock.Object);
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarNotShown();
-//
-//             CheckCalled(stateValidatorMock, serverMock, converterMock, navigatorMock, storeMock, selectionServiceMock);
-//             CheckNotCalled(hotspotVizMock); // shouldn't have accessed any of the members
-//
-//             logger.AssertPartialOutputStringExists(ValidRequest.ServerUrl.ToString(), ValidRequest.ProjectKey, ValidRequest.OrganizationKey, ValidRequest.HotspotKey);
-//         }
-//
-//         [TestMethod]
-//         public async Task ShowHotspot_DataIsValid_NavigationFailed_IssueStillAddedToStoreAndStillSelected()
-//         {
-//             const string hotspotFilePath = "c:\\xx\\yyy.txt";
-//             const int hotspotStartLine = -12345;
-//             var hotspotViz = CreateHotspotVisualization(hotspotFilePath, hotspotStartLine);
-//
-//             InitializeStateValidator(ValidRequest, true);
-//             SetServerResponse(ValidRequest, ValidServerHotspot);
-//             SetConversionResponse(ValidServerHotspot, hotspotViz);
-//             SetNavigationRespone(hotspotViz, false);
-//             SetStoreExpectedItem(hotspotViz, hotspotViz);
-//             SetSelectionServiceExpectedItem(hotspotViz);
-//
-//             // Act
-//             await testSubject.ShowHotspotAsync(ValidRequest)
-//                 .ConfigureAwait(false);
-//
-//             CheckInvariantBehaviours();
-//             CheckInfoBarNotShown();
-//
-//             CheckCalled(stateValidatorMock, serverMock, converterMock, navigatorMock, storeMock, selectionServiceMock);
-//             logger.AssertPartialOutputStringExists(hotspotFilePath, hotspotStartLine.ToString());
-//         }
-//
-//         private static IAnalysisIssueVisualization CreateHotspotVisualization(string filePath, int startLine)
-//         {
-//             var vizMock = new Mock<IAnalysisIssueVisualization>();
-//             // Note: these properties are not marked as Verifiable() since they won't always be read
-//             vizMock.Setup(x => x.FilePath).Returns(filePath);
-//             vizMock.Setup(x => x.StartLine).Returns(startLine);
-//             return vizMock.Object;
-//         }
-//
-//         private void InitializeStateValidator(IShowHotspotRequest expected, bool canHandleRequest) =>
-//             stateValidatorMock.Setup(x => x.CanHandleOpenInIDERequest(expected.ServerUrl, expected.ProjectKey, expected.OrganizationKey))
-//                 .Returns(canHandleRequest);
-//
-//         private void SetServerResponse(IShowHotspotRequest expected, SonarQubeHotspot response) =>
-//             serverMock.Setup(x => x.GetHotspotAsync(expected.HotspotKey, It.IsAny<CancellationToken>()))
-//                 .Returns(Task<SonarQubeHotspot>.FromResult(response));
-//
-//         private void SetServerToThrow(IShowHotspotRequest expected, Exception ex) =>
-//             serverMock.Setup(x => x.GetHotspotAsync(expected.HotspotKey, It.IsAny<CancellationToken>()))
-//             .Throws(ex);
-//
-//         private void SetConversionResponse(SonarQubeHotspot expected, IAnalysisIssueVisualization response) =>
-//             converterMock.Setup(x => x.Convert(expected)).Returns(response);
-//
-//         private void SetConverterToThrow(SonarQubeHotspot expected, Exception ex) =>
-//             converterMock.Setup(x => x.Convert(expected)).Throws(ex);
-//
-//         private void SetNavigationRespone(IAnalysisIssueVisualization expected, bool response) =>
-//             navigatorMock.Setup(x => x.TryNavigate(expected)).Returns(response);
-//
-//         private void SetStoreExpectedItem(IAnalysisIssueVisualization expected, IAnalysisIssueVisualization response) =>
-//             storeMock.Setup(x => x.GetOrAdd(expected)).Returns(response);
-//
-//         private void SetSelectionServiceExpectedItem(IAnalysisIssueVisualization expected) =>
-//             selectionServiceMock.SetupSet(x => x.SelectedIssue = expected);
-//
-//         private void CheckInvariantBehaviours()
-//         {
-//             // Whatever happens, the tool window should be shown, the gold bar
-//             // cleared and the IDE brought to the front
-//             CheckInfoBarCleared();
-//             CheckCalled(ideWindowServiceMock, toolWindowServiceMock, telemetryManagerMock);
-//         }
-//
-//         private static void CheckCalled(params Mock[] mocks)
-//         {
-//             foreach (var mock in mocks)
-//             {
-//                 Console.WriteLine($"Checking mock was called: {mock.Object.GetType()}");
-//                 mock.VerifyAll();
-//                 mock.Invocations.Count.Should().Be(1);
-//             }
-//         }
-//
-//         private static void CheckNotCalled(params Mock[] mocks)
-//         {
-//             foreach(var mock in mocks)
-//             {
-//                 Console.WriteLine($"Checking mock wasn't called: {mock.Object.GetType()}");
-//                 mock.Invocations.Should().BeEmpty();
-//             }
-//         }
-//
-//         private void CheckInfoBarCleared() =>
-//             failureInfoBarMock.Verify(x => x.ClearAsync(), Times.Once);
-//
-//         private void CheckInfoBarNotShown() =>
-//             failureInfoBarMock.Verify(x => x.ShowAsync(It.IsAny<Guid>()), Times.Never);
-//
-//         private void CheckInfoBarShown() =>
-//             failureInfoBarMock.Verify(x => x.ShowAsync(HotspotsToolWindow.ToolWindowId), Times.Once);
-//
-//         private class TestShowHotspotRequest : IShowHotspotRequest
-//         {
-//             public Uri ServerUrl { get; set; }
-//             public string OrganizationKey { get; set; }
-//             public string ProjectKey { get; set; }
-//             public string HotspotKey { get; set; }
-//         }
-//     }
-// }
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Telemetry;
+using SonarLint.VisualStudio.Integration;
+using SonarLint.VisualStudio.IssueVisualization.Editor;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE.Api;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE.Contract;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList;
+using SonarLint.VisualStudio.IssueVisualization.Selection;
+using SonarLint.VisualStudio.TestInfrastructure;
+using SonarQube.Client;
+using SonarQube.Client.Models;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE.Api
+{
+    [TestClass]
+    public class OpenInIDERequestHandlerTests_MEF
+    {
+        [TestMethod]
+        public void MefCtor_CheckIsExported()
+        {
+            MefTestHelpers.CheckTypeCanBeImported<OpenInIDERequestHandler, IOpenInIDERequestHandler>(
+                MefTestHelpers.CreateExport<IIDEWindowService>(),
+                MefTestHelpers.CreateExport<IToolWindowService>(),
+                MefTestHelpers.CreateExport<IOpenInIDEStateValidator>(),
+                MefTestHelpers.CreateExport<ISonarQubeService>(),
+                MefTestHelpers.CreateExport<IHotspotToIssueVisualizationConverter>(),
+                MefTestHelpers.CreateExport<ILocationNavigator>(),
+                MefTestHelpers.CreateExport<IOpenInIDEHotspotsStore>(),
+                MefTestHelpers.CreateExport<IOpenInIDEFailureInfoBar>(),
+                MefTestHelpers.CreateExport<IIssueSelectionService>(),
+                MefTestHelpers.CreateExport<ITelemetryManager>(),
+                MefTestHelpers.CreateExport<ILogger>());
+        }
+    }
+
+    [TestClass]
+    public class OpenInIDERequestHandlerTests_Orchestration
+    {
+        private readonly IShowHotspotRequest ValidRequest = new TestShowHotspotRequest
+        {
+            ServerUrl = new Uri("http://localhost/"),
+            ProjectKey = "project",
+            HotspotKey = "any",
+            OrganizationKey = "org"
+        };
+
+        private readonly SonarQubeHotspot ValidServerHotspot = new SonarQubeHotspot("hotspotKey", null, null, null, null, null, null, null, null, null, DateTimeOffset.MinValue, DateTimeOffset.MaxValue, null, null);
+
+        private Mock<IIDEWindowService> ideWindowServiceMock;
+        private Mock<IToolWindowService> toolWindowServiceMock;
+        private Mock<IOpenInIDEStateValidator> stateValidatorMock;
+        private Mock<ISonarQubeService> serverMock;
+        private Mock<IHotspotToIssueVisualizationConverter> converterMock;
+        private Mock<ILocationNavigator> navigatorMock;
+        private Mock<IOpenInIDEHotspotsStore> storeMock;
+        private Mock<IOpenInIDEFailureInfoBar> failureInfoBarMock;
+        private Mock<IIssueSelectionService> selectionServiceMock;
+        private Mock<ITelemetryManager> telemetryManagerMock;
+        private TestLogger logger;
+
+        private IOpenInIDERequestHandler testSubject;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ThreadHelper.SetCurrentThreadAsUIThread();
+
+            // The tool window should always be called with the same argument
+            toolWindowServiceMock = new Mock<IToolWindowService>();
+            toolWindowServiceMock.Setup(x => x.Show(OpenInIDEHotspotsToolWindow.ToolWindowId));
+
+            ideWindowServiceMock = new Mock<IIDEWindowService>();
+            stateValidatorMock = new Mock<IOpenInIDEStateValidator>();
+            serverMock = new Mock<ISonarQubeService>();
+            converterMock = new Mock<IHotspotToIssueVisualizationConverter>();
+            navigatorMock = new Mock<ILocationNavigator>();
+            storeMock = new Mock<IOpenInIDEHotspotsStore>();
+            failureInfoBarMock = new Mock<IOpenInIDEFailureInfoBar>();
+            selectionServiceMock = new Mock<IIssueSelectionService>();
+            telemetryManagerMock = new Mock<ITelemetryManager>();
+            logger = new TestLogger(logToConsole: true);
+
+            testSubject = new OpenInIDERequestHandler(ideWindowServiceMock.Object, toolWindowServiceMock.Object, stateValidatorMock.Object, serverMock.Object,
+            converterMock.Object, navigatorMock.Object, storeMock.Object, failureInfoBarMock.Object, selectionServiceMock.Object, telemetryManagerMock.Object, logger);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_InvalidArg_Throws()
+        {
+            Func<Task> act = async () => await testSubject.ShowHotspotAsync(null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("request");
+        }
+
+        [TestMethod]
+        public async Task ShowHotpot_IdeNotInCorrectState_NoFurtherProcessing()
+        {
+            InitializeStateValidator(ValidRequest, false);
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            CheckInvariantBehaviours();
+            CheckInfoBarShown();
+
+            CheckCalled(stateValidatorMock);
+            CheckNotCalled(serverMock, converterMock, navigatorMock, storeMock, selectionServiceMock);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_FailedToRetrieveHotspotData_NoFurtherProcessing()
+        {
+            InitializeStateValidator(ValidRequest, true);
+            SetServerResponse(ValidRequest, null);
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            CheckInvariantBehaviours();
+            CheckInfoBarShown();
+
+            CheckCalled(stateValidatorMock, serverMock);
+            CheckNotCalled(converterMock, navigatorMock, storeMock, selectionServiceMock);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_ServerThrows_NoFurtherProcessing()
+        {
+            InitializeStateValidator(ValidRequest, true);
+            SetServerToThrow(ValidRequest, new InvalidOperationException("thrown from test code"));
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            logger.AssertPartialOutputStringExists("thrown from test code");
+
+            CheckInvariantBehaviours();
+            CheckInfoBarShown();
+
+            CheckCalled(stateValidatorMock, serverMock);
+            CheckNotCalled(converterMock, navigatorMock, storeMock, selectionServiceMock);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_ConversionFailed_NoFurtherProcessing()
+        {
+            InitializeStateValidator(ValidRequest, true);
+            SetServerResponse(ValidRequest, ValidServerHotspot);
+            SetConversionResponse(ValidServerHotspot, null);
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            CheckInvariantBehaviours();
+            CheckInfoBarShown();
+
+            CheckCalled(stateValidatorMock, serverMock, converterMock);
+            CheckNotCalled(navigatorMock, storeMock, selectionServiceMock);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_ConverterThrows_NoFurtherProcessing()
+        {
+            InitializeStateValidator(ValidRequest, true);
+            SetServerResponse(ValidRequest, ValidServerHotspot);
+            SetConverterToThrow(ValidServerHotspot, new InvalidOperationException("thrown from test code"));
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            logger.AssertPartialOutputStringExists("thrown from test code");
+
+            CheckInvariantBehaviours();
+            CheckInfoBarShown();
+
+            CheckCalled(stateValidatorMock, serverMock, converterMock);
+            CheckNotCalled(navigatorMock, storeMock, selectionServiceMock);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_DataIsValid_NavigationSucceeded_And_IssueAddedToStoreAndSelected()
+        {
+            // Note: this test needs a viz mock that doesn't have any members mocked using Setup(...).
+            // This is because we don't expect any of the members to be called (and if the mock has any
+            // members mocked then the call to converterMock.VerifyAll() will fail when the library tries
+            // to transitively verify the viz members).
+            var hotspotVizMock = new Mock<IAnalysisIssueVisualization>();
+
+            InitializeStateValidator(ValidRequest, true);
+            SetServerResponse(ValidRequest, ValidServerHotspot);
+            SetConversionResponse(ValidServerHotspot, hotspotVizMock.Object);
+            SetNavigationRespone(hotspotVizMock.Object, true);
+
+            var addedHotspotVizMock = new Mock<IAnalysisIssueVisualization>();
+            SetStoreExpectedItem(hotspotVizMock.Object, addedHotspotVizMock.Object);
+            SetSelectionServiceExpectedItem(addedHotspotVizMock.Object);
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            CheckInvariantBehaviours();
+            CheckInfoBarNotShown();
+
+            CheckCalled(stateValidatorMock, serverMock, converterMock, navigatorMock, storeMock, selectionServiceMock);
+            CheckNotCalled(hotspotVizMock); // shouldn't have accessed any of the members
+
+            logger.AssertPartialOutputStringExists(ValidRequest.ServerUrl.ToString(), ValidRequest.ProjectKey, ValidRequest.OrganizationKey, ValidRequest.HotspotKey);
+        }
+
+        [TestMethod]
+        public async Task ShowHotspot_DataIsValid_NavigationFailed_IssueStillAddedToStoreAndStillSelected()
+        {
+            const string hotspotFilePath = "c:\\xx\\yyy.txt";
+            const int hotspotStartLine = -12345;
+            var hotspotViz = CreateHotspotVisualization(hotspotFilePath, hotspotStartLine);
+
+            InitializeStateValidator(ValidRequest, true);
+            SetServerResponse(ValidRequest, ValidServerHotspot);
+            SetConversionResponse(ValidServerHotspot, hotspotViz);
+            SetNavigationRespone(hotspotViz, false);
+            SetStoreExpectedItem(hotspotViz, hotspotViz);
+            SetSelectionServiceExpectedItem(hotspotViz);
+
+            // Act
+            await testSubject.ShowHotspotAsync(ValidRequest)
+                .ConfigureAwait(false);
+
+            CheckInvariantBehaviours();
+            CheckInfoBarNotShown();
+
+            CheckCalled(stateValidatorMock, serverMock, converterMock, navigatorMock, storeMock, selectionServiceMock);
+            logger.AssertPartialOutputStringExists(hotspotFilePath, hotspotStartLine.ToString());
+        }
+
+        private static IAnalysisIssueVisualization CreateHotspotVisualization(string filePath, int startLine)
+        {
+            var vizMock = new Mock<IAnalysisIssueVisualization>();
+            // Note: these properties are not marked as Verifiable() since they won't always be read
+            vizMock.Setup(x => x.FilePath).Returns(filePath);
+            vizMock.Setup(x => x.StartLine).Returns(startLine);
+            return vizMock.Object;
+        }
+
+        private void InitializeStateValidator(IShowHotspotRequest expected, bool canHandleRequest) =>
+            stateValidatorMock.Setup(x => x.CanHandleOpenInIDERequest(expected.ServerUrl, expected.ProjectKey, expected.OrganizationKey))
+                .Returns(canHandleRequest);
+
+        private void SetServerResponse(IShowHotspotRequest expected, SonarQubeHotspot response) =>
+            serverMock.Setup(x => x.GetHotspotAsync(expected.HotspotKey, It.IsAny<CancellationToken>()))
+                .Returns(Task<SonarQubeHotspot>.FromResult(response));
+
+        private void SetServerToThrow(IShowHotspotRequest expected, Exception ex) =>
+            serverMock.Setup(x => x.GetHotspotAsync(expected.HotspotKey, It.IsAny<CancellationToken>()))
+            .Throws(ex);
+
+        private void SetConversionResponse(SonarQubeHotspot expected, IAnalysisIssueVisualization response) =>
+            converterMock.Setup(x => x.Convert(expected)).Returns(response);
+
+        private void SetConverterToThrow(SonarQubeHotspot expected, Exception ex) =>
+            converterMock.Setup(x => x.Convert(expected)).Throws(ex);
+
+        private void SetNavigationRespone(IAnalysisIssueVisualization expected, bool response) =>
+            navigatorMock.Setup(x => x.TryNavigate(expected)).Returns(response);
+
+        private void SetStoreExpectedItem(IAnalysisIssueVisualization expected, IAnalysisIssueVisualization response) =>
+            storeMock.Setup(x => x.GetOrAdd(expected)).Returns(response);
+
+        private void SetSelectionServiceExpectedItem(IAnalysisIssueVisualization expected) =>
+            selectionServiceMock.SetupSet(x => x.SelectedIssue = expected);
+
+        private void CheckInvariantBehaviours()
+        {
+            // Whatever happens, the tool window should be shown, the gold bar
+            // cleared and the IDE brought to the front
+            CheckInfoBarCleared();
+            CheckCalled(ideWindowServiceMock, toolWindowServiceMock, telemetryManagerMock);
+        }
+
+        private static void CheckCalled(params Mock[] mocks)
+        {
+            foreach (var mock in mocks)
+            {
+                Console.WriteLine($"Checking mock was called: {mock.Object.GetType()}");
+                mock.VerifyAll();
+                mock.Invocations.Count.Should().Be(1);
+            }
+        }
+
+        private static void CheckNotCalled(params Mock[] mocks)
+        {
+            foreach (var mock in mocks)
+            {
+                Console.WriteLine($"Checking mock wasn't called: {mock.Object.GetType()}");
+                mock.Invocations.Should().BeEmpty();
+            }
+        }
+
+        private void CheckInfoBarCleared() =>
+            failureInfoBarMock.Verify(x => x.ClearAsync(), Times.Once);
+
+        private void CheckInfoBarNotShown() =>
+            failureInfoBarMock.Verify(x => x.ShowAsync(It.IsAny<Guid>()), Times.Never);
+
+        private void CheckInfoBarShown() =>
+            failureInfoBarMock.Verify(x => x.ShowAsync(OpenInIDEHotspotsToolWindow.ToolWindowId), Times.Once);
+
+        private class TestShowHotspotRequest : IShowHotspotRequest
+        {
+            public Uri ServerUrl { get; set; }
+            public string OrganizationKey { get; set; }
+            public string ProjectKey { get; set; }
+            public string HotspotKey { get; set; }
+        }
+    }
+}

--- a/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotViewModelTests.cs
@@ -1,0 +1,197 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE_Hotspots.HotspotsList
+{
+    [TestClass]
+    public class OpenInIDEHotspotViewModelTests
+    {
+        [TestMethod]
+        public void Ctor_RegisterToHotspotPropertyChangedEvent()
+        {
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+            issueViz.SetupAdd(x => x.PropertyChanged += null);
+
+            CreateTestSubject(issueViz.Object);
+
+            issueViz.VerifyAdd(x => x.PropertyChanged += It.IsAny<PropertyChangedEventHandler>(), Times.Once);
+        }
+
+        [TestMethod]
+        public void Dispose_UnregisterFromHotspotPropertyChangedEvent()
+        {
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+            issueViz.SetupRemove(x => x.PropertyChanged -= null);
+
+            var testSubject = CreateTestSubject(issueViz.Object);
+            testSubject.Dispose();
+
+            issueViz.VerifyRemove(x => x.PropertyChanged -= It.IsAny<PropertyChangedEventHandler>(), Times.Once);
+        }
+
+        [TestMethod]
+        public void HotspotPropertyChanged_UnknownProperty_NoPropertyChangedEvent()
+        {
+            var eventHandler = new Mock<PropertyChangedEventHandler>();
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+
+            var testSubject = CreateTestSubject(issueViz.Object);
+            testSubject.PropertyChanged += eventHandler.Object;
+
+            eventHandler.VerifyNoOtherCalls();
+
+            issueViz.Raise(x => x.PropertyChanged += null, new PropertyChangedEventArgs("some dummy property"));
+
+            eventHandler.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void HotspotPropertyChanged_SpanProperty_RaisesPropertyChangedForLineAndColumn()
+        {
+            var eventHandler = new Mock<PropertyChangedEventHandler>();
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+
+            var testSubject = CreateTestSubject(issueViz.Object);
+            testSubject.PropertyChanged += eventHandler.Object;
+
+            eventHandler.VerifyNoOtherCalls();
+
+            issueViz.Raise(x => x.PropertyChanged += null, new PropertyChangedEventArgs(nameof(IAnalysisIssueVisualization.Span)));
+
+            eventHandler.Verify(x => x(testSubject,
+                    It.Is((PropertyChangedEventArgs args) => args.PropertyName == nameof(IOpenInIDEHotspotViewModel.Line))),
+                Times.Once);
+
+            eventHandler.Verify(x => x(testSubject,
+                    It.Is((PropertyChangedEventArgs args) => args.PropertyName == nameof(IOpenInIDEHotspotViewModel.Column))),
+                Times.Once);
+
+            eventHandler.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void Line_ReturnsDisplayPosition()
+        {
+            var issueViz = Mock.Of<IAnalysisIssueVisualization>();
+
+            var positionCalculatorMock = new Mock<IIssueVizDisplayPositionCalculator>();
+            positionCalculatorMock.Setup(x => x.GetLine(issueViz)).Returns(123);
+
+            // Act
+            var testSubject = CreateTestSubject(issueViz, positionCalculator: positionCalculatorMock.Object);
+
+            testSubject.Line.Should().Be(123);
+            positionCalculatorMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void Column_ReturnsDisplayPosition()
+        {
+            var issueViz = Mock.Of<IAnalysisIssueVisualization>();
+
+            var positionCalculatorMock = new Mock<IIssueVizDisplayPositionCalculator>();
+            positionCalculatorMock.Setup(x => x.GetColumn(issueViz)).Returns(999);
+
+            // Act
+            var testSubject = CreateTestSubject(issueViz, positionCalculator: positionCalculatorMock.Object);
+
+            testSubject.Column.Should().Be(999);
+            positionCalculatorMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void DisplayPath_HotspotHasNoFilePath_ReturnsServerPath()
+        {
+            var hotspot = new Mock<IHotspot>();
+            hotspot.Setup(x => x.ServerFilePath).Returns("\\some\\server\\path.cs");
+
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+            issueViz.Setup(x => x.CurrentFilePath).Returns((string)null);
+            issueViz.Setup(x => x.Issue).Returns(hotspot.Object);
+
+            var testSubject = CreateTestSubject(issueViz.Object);
+            testSubject.DisplayPath.Should().Be("path.cs");
+        }
+
+        [TestMethod]
+        public void DisplayPath_HotspotHasFilePath_ReturnsFilePath()
+        {
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+            issueViz.Setup(x => x.CurrentFilePath).Returns("c:\\some\\local\\path.cs");
+
+            var testSubject = CreateTestSubject(issueViz.Object);
+            testSubject.DisplayPath.Should().Be("path.cs");
+        }
+
+        [TestMethod]
+        public void CategoryDisplayName_ReturnsFriendlyName()
+        {
+            var hotspot = new Mock<IHotspot>();
+            hotspot.Setup(x => x.Rule.SecurityCategory).Returns("some category");
+
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+            issueViz.Setup(x => x.Issue).Returns(hotspot.Object);
+
+            var categoryDisplayNameProvider = new Mock<ISecurityCategoryDisplayNameProvider>();
+            categoryDisplayNameProvider.Setup(x => x.Get("some category")).Returns("some display name");
+
+            var testSubject = CreateTestSubject(issueViz.Object, categoryDisplayNameProvider.Object);
+            testSubject.CategoryDisplayName.Should().Be("some display name");
+        }
+
+        [TestMethod]
+        public void HotspotPropertyChanged_CurrentFilePathProperty_RaisesPropertyChangedForDisplayPath()
+        {
+            var eventHandler = new Mock<PropertyChangedEventHandler>();
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+
+            var testSubject = CreateTestSubject(issueViz.Object);
+            testSubject.PropertyChanged += eventHandler.Object;
+
+            eventHandler.VerifyNoOtherCalls();
+
+            issueViz.Raise(x => x.PropertyChanged += null, new PropertyChangedEventArgs(nameof(IAnalysisIssueVisualization.CurrentFilePath)));
+
+            eventHandler.Verify(x => x(testSubject,
+                    It.Is((PropertyChangedEventArgs args) => args.PropertyName == nameof(IHotspotViewModel.DisplayPath))),
+                Times.Once);
+
+            eventHandler.VerifyNoOtherCalls();
+        }
+
+        private static HotspotViewModel CreateTestSubject(IAnalysisIssueVisualization issueViz,
+            ISecurityCategoryDisplayNameProvider securityCategoryDisplayNameProvider = null,
+            IIssueVizDisplayPositionCalculator positionCalculator = null)
+        {
+            securityCategoryDisplayNameProvider ??= Mock.Of<ISecurityCategoryDisplayNameProvider>();
+            positionCalculator ??= Mock.Of<IIssueVizDisplayPositionCalculator>();
+            return new HotspotViewModel(issueViz, securityCategoryDisplayNameProvider, positionCalculator);
+        }
+    }
+}

--- a/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotViewModelTests.cs
@@ -23,9 +23,9 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.IssueVisualization.Models;
-using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels;
+using SharedProvider = SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE_Hotspots.HotspotsList
 {
@@ -158,7 +158,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE
             var issueViz = new Mock<IAnalysisIssueVisualization>();
             issueViz.Setup(x => x.Issue).Returns(hotspot.Object);
 
-            var categoryDisplayNameProvider = new Mock<ISecurityCategoryDisplayNameProvider>();
+            var categoryDisplayNameProvider = new Mock<SharedProvider.ISecurityCategoryDisplayNameProvider>();
             categoryDisplayNameProvider.Setup(x => x.Get("some category")).Returns("some display name");
 
             var testSubject = CreateTestSubject(issueViz.Object, categoryDisplayNameProvider.Object);
@@ -179,19 +179,19 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE
             issueViz.Raise(x => x.PropertyChanged += null, new PropertyChangedEventArgs(nameof(IAnalysisIssueVisualization.CurrentFilePath)));
 
             eventHandler.Verify(x => x(testSubject,
-                    It.Is((PropertyChangedEventArgs args) => args.PropertyName == nameof(IHotspotViewModel.DisplayPath))),
+                    It.Is((PropertyChangedEventArgs args) => args.PropertyName == nameof(IOpenInIDEHotspotViewModel.DisplayPath))),
                 Times.Once);
 
             eventHandler.VerifyNoOtherCalls();
         }
 
-        private static HotspotViewModel CreateTestSubject(IAnalysisIssueVisualization issueViz,
-            ISecurityCategoryDisplayNameProvider securityCategoryDisplayNameProvider = null,
+        private static OpenInIDEHotspotViewModel CreateTestSubject(IAnalysisIssueVisualization issueViz,
+            SharedProvider.ISecurityCategoryDisplayNameProvider securityCategoryDisplayNameProvider = null,
             IIssueVizDisplayPositionCalculator positionCalculator = null)
         {
-            securityCategoryDisplayNameProvider ??= Mock.Of<ISecurityCategoryDisplayNameProvider>();
+            securityCategoryDisplayNameProvider ??= Mock.Of<SharedProvider.ISecurityCategoryDisplayNameProvider>();
             positionCalculator ??= Mock.Of<IIssueVizDisplayPositionCalculator>();
-            return new HotspotViewModel(issueViz, securityCategoryDisplayNameProvider, positionCalculator);
+            return new OpenInIDEHotspotViewModel(issueViz, securityCategoryDisplayNameProvider, positionCalculator);
         }
     }
 }

--- a/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
@@ -1,0 +1,409 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.TestInfrastructure;
+using SonarLint.VisualStudio.IssueVisualization.Editor;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels;
+using SonarLint.VisualStudio.IssueVisualization.Selection;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE_Hotspots.HotspotsList
+{
+    [TestClass]
+    public class HotspotsControlViewModelTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // HotspotsControlViewModel needs to be created on the UI thread
+            ThreadHelper.SetCurrentThreadAsUIThread();
+        }
+
+        [TestMethod]
+        public void Ctor_RegisterToStoreCollectionChanges()
+        {
+            var store = new Mock<IOpenInIDEHotspotsStore>();
+            var testSubject = CreateTestSubject(hotspotsStore: store);
+
+            var issueViz1 = Mock.Of<IAnalysisIssueVisualization>();
+            var issueViz2 = Mock.Of<IAnalysisIssueVisualization>();
+            var issueViz3 = Mock.Of<IAnalysisIssueVisualization>();
+
+            RaiseStoreIssuesChangedEvent(store, issueViz1);
+
+            testSubject.Hotspots.Count.Should().Be(1);
+            testSubject.Hotspots[0].Hotspot.Should().Be(issueViz1);
+
+            RaiseStoreIssuesChangedEvent(store, issueViz1, issueViz2, issueViz3);
+
+            testSubject.Hotspots.Count.Should().Be(3);
+            testSubject.Hotspots[0].Hotspot.Should().Be(issueViz1);
+            testSubject.Hotspots[1].Hotspot.Should().Be(issueViz2);
+            testSubject.Hotspots[2].Hotspot.Should().Be(issueViz3);
+
+            RaiseStoreIssuesChangedEvent(store, issueViz1, issueViz3);
+
+            testSubject.Hotspots.Count.Should().Be(2);
+            testSubject.Hotspots[0].Hotspot.Should().Be(issueViz1);
+            testSubject.Hotspots[1].Hotspot.Should().Be(issueViz3);
+        }
+
+        [TestMethod]
+        public void Ctor_InitializeListWithHotspotsStoreCollection()
+        {
+            var issueViz1 = Mock.Of<IAnalysisIssueVisualization>();
+            var issueViz2 = Mock.Of<IAnalysisIssueVisualization>();
+            var storeHotspots = new ObservableCollection<IAnalysisIssueVisualization> { issueViz1, issueViz2 };
+
+            var testSubject = CreateTestSubject(storeHotspots);
+
+            testSubject.Hotspots.Count.Should().Be(2);
+            testSubject.Hotspots.First().Hotspot.Should().Be(issueViz1);
+            testSubject.Hotspots.Last().Hotspot.Should().Be(issueViz2);
+        }
+
+        [TestMethod]
+        public void Dispose_UnregisterFromHotspotsCollectionChanges()
+        {
+            var storeHotspots = new ObservableCollection<IAnalysisIssueVisualization>();
+            var testSubject = CreateTestSubject(storeHotspots);
+
+            testSubject.Dispose();
+
+            var issueViz = Mock.Of<IAnalysisIssueVisualization>();
+            storeHotspots.Add(issueViz);
+
+            testSubject.Hotspots.Count.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void Ctor_RegisterToSelectionChangedEvent()
+        {
+            var selectionService = new Mock<IIssueSelectionService>();
+            selectionService.SetupAdd(x => x.SelectedIssueChanged += null);
+
+            CreateTestSubject(selectionService: selectionService.Object);
+
+            selectionService.VerifyAdd(x => x.SelectedIssueChanged += It.IsAny<EventHandler>(), Times.Once());
+            selectionService.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void Dispose_UnregisterFromSelectionChangedEvent()
+        {
+            var selectionService = new Mock<IIssueSelectionService>();
+            var testSubject = CreateTestSubject(selectionService: selectionService.Object);
+
+            selectionService.Reset();
+            selectionService.SetupRemove(x => x.SelectedIssueChanged -= null);
+
+            testSubject.Dispose();
+
+            selectionService.VerifyRemove(x => x.SelectedIssueChanged -= It.IsAny<EventHandler>(), Times.Once());
+        }
+
+        [TestMethod]
+        public void SelectionChanged_SelectedHotspotExistsInList_HotspotSelected()
+        {
+            var issueViz = Mock.Of<IAnalysisIssueVisualization>();
+            var storeHotspots = new ObservableCollection<IAnalysisIssueVisualization> { issueViz };
+            var selectionService = new Mock<IIssueSelectionService>();
+
+            var testSubject = CreateTestSubject(storeHotspots, selectionService: selectionService.Object);
+
+            testSubject.SelectedHotspot.Should().BeNull();
+
+            RaiseSelectionChangedEvent(selectionService, issueViz);
+
+            testSubject.SelectedHotspot.Should().NotBeNull();
+            testSubject.SelectedHotspot.Hotspot.Should().Be(issueViz);
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void SelectionChanged_SelectedHotspotIsNotInList_SelectionSetToNull(bool isSelectedNull)
+        {
+            var selectionService = new Mock<IIssueSelectionService>();
+
+            var testSubject = CreateTestSubject(selectionService: selectionService.Object);
+
+            var oldSelection = new OpenInIDEHotspotViewModel(Mock.Of<IAnalysisIssueVisualization>());
+            testSubject.SelectedHotspot = oldSelection;
+            testSubject.SelectedHotspot.Should().Be(oldSelection);
+
+            var selectedIssue = isSelectedNull ? null : Mock.Of<IAnalysisIssueVisualization>();
+
+            RaiseSelectionChangedEvent(selectionService, selectedIssue);
+
+            testSubject.SelectedHotspot.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void SelectionChanged_SelectedHotspotExistsInList_RaisesPropertyChanged()
+        {
+            var issueViz = Mock.Of<IAnalysisIssueVisualization>();
+            var storeHotspots = new ObservableCollection<IAnalysisIssueVisualization> { issueViz };
+            var selectionService = new Mock<IIssueSelectionService>();
+
+            var testSubject = CreateTestSubject(storeHotspots, selectionService: selectionService.Object);
+
+            var eventHandler = new Mock<PropertyChangedEventHandler>();
+            testSubject.PropertyChanged += eventHandler.Object;
+
+            eventHandler.VerifyNoOtherCalls();
+
+            RaiseSelectionChangedEvent(selectionService, issueViz);
+
+            eventHandler.Verify(x => x(testSubject,
+                It.Is((PropertyChangedEventArgs args) =>
+                    args.PropertyName == nameof(IOpenInIDEHotspotsControlViewModel.SelectedHotspot))), Times.Once);
+
+            eventHandler.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void SelectionChanged_SelectedHotspotIsNotInList_RaisesPropertyChanged(bool isSelectedNull)
+        {
+            var selectionService = new Mock<IIssueSelectionService>();
+
+            var testSubject = CreateTestSubject(selectionService: selectionService.Object);
+
+            var eventHandler = new Mock<PropertyChangedEventHandler>();
+            testSubject.PropertyChanged += eventHandler.Object;
+
+            eventHandler.VerifyNoOtherCalls();
+
+            var selectedIssue = isSelectedNull ? null : Mock.Of<IAnalysisIssueVisualization>();
+
+            RaiseSelectionChangedEvent(selectionService, selectedIssue);
+
+            eventHandler.Verify(x => x(testSubject,
+                It.Is((PropertyChangedEventArgs args) =>
+                    args.PropertyName == nameof(IOpenInIDEHotspotsControlViewModel.SelectedHotspot))), Times.Once);
+
+            eventHandler.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Verify that there is no callback, selection service -> property -> selection service")]
+        public void SelectionChanged_HotspotSelected_SelectionServiceNotCalledAgain()
+        {
+            var selectedIssue = Mock.Of<IAnalysisIssueVisualization>();
+            var storeHotspots = new ObservableCollection<IAnalysisIssueVisualization> { selectedIssue };
+            var selectionService = new Mock<IIssueSelectionService>();
+
+            CreateTestSubject(storeHotspots, selectionService: selectionService.Object);
+
+            RaiseSelectionChangedEvent(selectionService, selectedIssue);
+
+            selectionService.VerifySet(x=> x.SelectedIssue = It.IsAny<IAnalysisIssueVisualization>(), Times.Never);
+        }
+
+        [TestMethod]
+        public void NavigateCommand_CanExecute_NullParameter_False()
+        {
+            var locationNavigator = new Mock<ILocationNavigator>();
+
+            var testSubject = CreateTestSubject(locationNavigator: locationNavigator.Object);
+            var result = testSubject.NavigateCommand.CanExecute(null);
+            result.Should().BeFalse();
+
+            locationNavigator.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void NavigateCommand_CanExecute_ParameterIsNotHotspotViewModel_False()
+        {
+            var locationNavigator = new Mock<ILocationNavigator>();
+
+            var testSubject = CreateTestSubject(locationNavigator: locationNavigator.Object);
+            var result = testSubject.NavigateCommand.CanExecute("something");
+            result.Should().BeFalse();
+
+            locationNavigator.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void NavigateCommand_CanExecute_ParameterIsHotspotViewModel_True()
+        {
+            var locationNavigator = new Mock<ILocationNavigator>();
+
+            var testSubject = CreateTestSubject(locationNavigator: locationNavigator.Object);
+            var result = testSubject.NavigateCommand.CanExecute(Mock.Of<IOpenInIDEHotspotViewModel>());
+            result.Should().BeTrue();
+
+            locationNavigator.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void NavigateCommand_Execute_LocationNavigated()
+        {
+            var locationNavigator = new Mock<ILocationNavigator>();
+
+            var hotspot = Mock.Of<IAnalysisIssueVisualization>();
+            var viewModel = new Mock<IOpenInIDEHotspotViewModel>();
+            viewModel.Setup(x => x.Hotspot).Returns(hotspot);
+
+            var testSubject = CreateTestSubject(locationNavigator: locationNavigator.Object);
+            testSubject.NavigateCommand.Execute(viewModel.Object);
+
+            locationNavigator.Verify(x => x.TryNavigate(hotspot), Times.Once);
+            locationNavigator.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void RemoveCommand_CanExecute_NullParameter_False()
+        {
+            var hotspotsStore = new Mock<IOpenInIDEHotspotsStore>();
+
+            var testSubject = CreateTestSubject(hotspotsStore: hotspotsStore);
+            var result = testSubject.RemoveCommand.CanExecute(null);
+            result.Should().BeFalse();
+
+            hotspotsStore.Verify(x => x.Remove(It.IsAny<IAnalysisIssueVisualization>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void RemoveCommand_CanExecute_ParameterIsNotHotspotViewModel_False()
+        {
+            var hotspotsStore = new Mock<IOpenInIDEHotspotsStore>();
+
+            var testSubject = CreateTestSubject(hotspotsStore: hotspotsStore);
+            var result = testSubject.RemoveCommand.CanExecute("something");
+            result.Should().BeFalse();
+
+            hotspotsStore.Verify(x => x.Remove(It.IsAny<IAnalysisIssueVisualization>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void RemoveCommand_CanExecute_ParameterIsHotspotViewModel_True()
+        {
+            var hotspotsStore = new Mock<IOpenInIDEHotspotsStore>();
+
+            var testSubject = CreateTestSubject(hotspotsStore: hotspotsStore);
+            var result = testSubject.RemoveCommand.CanExecute(Mock.Of<IOpenInIDEHotspotViewModel>());
+            result.Should().BeTrue();
+
+            hotspotsStore.Verify(x => x.Remove(It.IsAny<IAnalysisIssueVisualization>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void RemoveCommand_Execute_HotspotRemoved()
+        {
+            var hotspotsStore = new Mock<IOpenInIDEHotspotsStore>();
+
+            var hotspot = Mock.Of<IAnalysisIssueVisualization>();
+            var viewModel = new Mock<IOpenInIDEHotspotViewModel>();
+            viewModel.Setup(x => x.Hotspot).Returns(hotspot);
+
+            var testSubject = CreateTestSubject(hotspotsStore: hotspotsStore);
+            testSubject.RemoveCommand.Execute(viewModel.Object);
+
+            hotspotsStore.Verify(x => x.Remove(hotspot), Times.Once);
+        }
+
+        [TestMethod]
+        public void SetSelectedHotspot_HotspotSet()
+        {
+            var testSubject = CreateTestSubject();
+
+            var selection = new OpenInIDEHotspotViewModel(Mock.Of<IAnalysisIssueVisualization>());
+            testSubject.SelectedHotspot = selection;
+
+            testSubject.SelectedHotspot.Should().Be(selection);
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void SetSelectedHotspot_SelectionChanged_SelectionServiceIsCalled(bool isSelectedNull)
+        {
+            var selectionService = new Mock<IIssueSelectionService>();
+            var testSubject = CreateTestSubject(selectionService: selectionService.Object);
+
+            var oldSelection = isSelectedNull ? new OpenInIDEHotspotViewModel(Mock.Of<IAnalysisIssueVisualization>()) : null;
+            var newSelection = isSelectedNull ? null : new OpenInIDEHotspotViewModel(Mock.Of<IAnalysisIssueVisualization>());
+
+            testSubject.SelectedHotspot = oldSelection;
+
+            selectionService.Reset();
+
+            testSubject.SelectedHotspot = newSelection;
+
+            selectionService.VerifySet(x=> x.SelectedIssue = newSelection?.Hotspot, Times.Once);
+            selectionService.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public void SetSelectedHotspot_ValueIsTheSame_SelectionServiceNotCalled()
+        {
+            var selectionService = new Mock<IIssueSelectionService>();
+            var testSubject = CreateTestSubject(selectionService: selectionService.Object);
+
+            var selection = new OpenInIDEHotspotViewModel(Mock.Of<IAnalysisIssueVisualization>());
+            testSubject.SelectedHotspot = selection;
+
+            selectionService.Reset();
+
+            testSubject.SelectedHotspot = selection;
+
+            selectionService.VerifyNoOtherCalls();
+        }
+
+        private static OpenInIDEHotspotsControlViewModel CreateTestSubject(ObservableCollection<IAnalysisIssueVisualization> originalCollection = null,
+            ILocationNavigator locationNavigator = null,
+            Mock<IOpenInIDEHotspotsStore> hotspotsStore = null,
+            IIssueSelectionService selectionService = null)
+        {
+            originalCollection ??= new ObservableCollection<IAnalysisIssueVisualization>();
+            var readOnlyWrapper = new ReadOnlyObservableCollection<IAnalysisIssueVisualization>(originalCollection);
+
+            hotspotsStore ??= new Mock<IOpenInIDEHotspotsStore>();
+            hotspotsStore.Setup(x => x.GetAll()).Returns(readOnlyWrapper);
+
+            selectionService ??= Mock.Of<IIssueSelectionService>();
+
+            return new OpenInIDEHotspotsControlViewModel(hotspotsStore.Object, locationNavigator, selectionService);
+        }
+
+        private static void RaiseStoreIssuesChangedEvent(Mock<IOpenInIDEHotspotsStore> store, params IAnalysisIssueVisualization[] issueVizs)
+        {
+            store.Setup(x => x.GetAll()).Returns(issueVizs);
+            store.Raise(x => x.IssuesChanged += null, null, new IssuesStore.IssuesChangedEventArgs(null, null));
+        }
+
+        private static void RaiseSelectionChangedEvent(Mock<IIssueSelectionService> selectionService, IAnalysisIssueVisualization selectedIssue)
+        {
+            selectionService.Setup(x => x.SelectedIssue).Returns(selectedIssue);
+            selectionService.Raise(x => x.SelectedIssueChanged += null, EventArgs.Empty);
+        }
+    }
+}

--- a/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
@@ -35,7 +35,7 @@ using SonarLint.VisualStudio.IssueVisualization.Selection;
 namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE_Hotspots.HotspotsList
 {
     [TestClass]
-    public class HotspotsControlViewModelTests
+    public class OpenInIDEHotspotsControlViewModelTests
     {
         [TestInitialize]
         public void TestInitialize()

--- a/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsStoreTests.cs
+++ b/src/IssueViz.Security.UnitTests/OpenInIDE_Hotspots/HotspotsStoreTests.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarLint.VisualStudio.TestInfrastructure;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.OpenInIDE_Hotspots
+{
+    [TestClass]
+    public class OpenInIDEHotspotsStoreTests
+    {
+        [TestMethod]
+        public void MefCtor_CheckExports()
+        {
+            var batch = new CompositionBatch();
+
+            var storeImport = new SingleObjectImporter<IOpenInIDEHotspotsStore>();
+            var issuesStoreImport = new SingleObjectImporter<IIssuesStore>();
+            batch.AddPart(storeImport);
+            batch.AddPart(issuesStoreImport);
+
+            var catalog = new TypeCatalog(typeof(OpenInIDEHotspotsStore));
+            using var container = new CompositionContainer(catalog);
+            container.Compose(batch);
+
+            storeImport.Import.Should().NotBeNull();
+            issuesStoreImport.Import.Should().NotBeNull();
+
+            storeImport.Import.Should().BeSameAs(issuesStoreImport.Import);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_NoExistingHotspots_HotspotAdded()
+        {
+            var testSubject = CreateTestSubject();
+
+            var hotspotToAdd = CreateIssueViz(hotspotKey: "some hotspot");
+            var addedHotspot = testSubject.GetOrAdd(hotspotToAdd);
+
+            addedHotspot.Should().BeSameAs(hotspotToAdd);
+            testSubject.GetAll().Count().Should().Be(1);
+            testSubject.GetAll().First().Should().BeSameAs(hotspotToAdd);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_NoMatchingHotspot_HotspotAdded()
+        {
+            var testSubject = CreateTestSubject();
+
+            var someOtherHotspot = CreateIssueViz(hotspotKey: "some hotspot 1");
+            testSubject.GetOrAdd(someOtherHotspot);
+
+            var hotspotToAdd = CreateIssueViz(hotspotKey: "some hotspot 2");
+            var addedHotspot = testSubject.GetOrAdd(hotspotToAdd);
+
+            addedHotspot.Should().BeSameAs(hotspotToAdd);
+
+            var hotspots = testSubject.GetAll().ToList();
+            hotspots.Count.Should().Be(2);
+            hotspots[0].Should().BeSameAs(someOtherHotspot);
+            hotspots[1].Should().BeSameAs(hotspotToAdd);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_HasMatchingHotspot_HotspotNotAdded()
+        {
+            var testSubject = CreateTestSubject();
+
+            var firstHotspot = CreateIssueViz(hotspotKey: "some hotspot");
+            var secondHotspot = CreateIssueViz(hotspotKey: "some hotspot");
+
+            testSubject.GetOrAdd(firstHotspot);
+            var secondAddedHotspot = testSubject.GetOrAdd(secondHotspot);
+
+            secondAddedHotspot.Should().BeSameAs(firstHotspot);
+            var hotspots = testSubject.GetAll().ToList();
+            hotspots.Count.Should().Be(1);
+            hotspots[0].Should().BeSameAs(firstHotspot);
+        }
+
+        [TestMethod]
+        public void Remove_HotspotRemoved()
+        {
+            var testSubject = CreateTestSubject();
+
+            var firstHotspot = CreateIssueViz(hotspotKey: "some hotspot1");
+            var secondHotspot = CreateIssueViz(hotspotKey: "some hotspot2");
+
+            testSubject.GetOrAdd(firstHotspot);
+            testSubject.GetOrAdd(secondHotspot);
+            testSubject.Remove(firstHotspot);
+
+            var hotspots = testSubject.GetAll().ToList();
+            hotspots.Count.Should().Be(1);
+            hotspots[0].Should().BeSameAs(secondHotspot);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_HasSubscribersToIssuesChanged_SubscribersNotified()
+        {
+            var testSubject = CreateTestSubject();
+
+            var callCount = 0;
+            IssuesChangedEventArgs suppliedArgs = null;
+            testSubject.IssuesChanged += (sender, args) => { callCount++; suppliedArgs = args; };
+
+            var addedIssueViz = testSubject.GetOrAdd(CreateIssueViz(hotspotKey: "some hotspot"));
+
+            callCount.Should().Be(1);
+            suppliedArgs.RemovedIssues.Should().BeEmpty();
+            suppliedArgs.AddedIssues.Should().BeEquivalentTo(addedIssueViz);
+        }
+
+        [TestMethod]
+        public void Remove_HasSubscribersToIssuesChanged_SubscribersNotified()
+        {
+            var testSubject = CreateTestSubject();
+
+            var callCount = 0;
+            IssuesChangedEventArgs suppliedArgs = null;
+            testSubject.IssuesChanged += (sender, args) => { callCount++; suppliedArgs = args; };
+
+            var addedIssueViz1 = testSubject.GetOrAdd(CreateIssueViz(hotspotKey: "some hotspot1"));
+            testSubject.GetOrAdd(CreateIssueViz(hotspotKey: "some hotspot2"));
+
+            callCount = 0;
+            testSubject.Remove(addedIssueViz1);
+
+            callCount.Should().Be(1);
+            suppliedArgs.RemovedIssues.Should().BeEquivalentTo(addedIssueViz1);
+            suppliedArgs.AddedIssues.Should().BeEmpty();
+        }
+
+        private static IAnalysisIssueVisualization CreateIssueViz(string hotspotKey)
+        {
+            var hotspot = new Mock<IHotspot>();
+            hotspot.Setup(x => x.HotspotKey).Returns(hotspotKey);
+
+            var issueViz = new Mock<IAnalysisIssueVisualization>();
+            issueViz.Setup(x => x.Issue).Returns(hotspot.Object);
+
+            return issueViz.Object;
+        }
+
+        private IOpenInIDEHotspotsStore CreateTestSubject()
+        {
+            return new OpenInIDEHotspotsStore();
+        }
+    }
+}

--- a/src/IssueViz.Security/IssueViz.Security.csproj
+++ b/src/IssueViz.Security/IssueViz.Security.csproj
@@ -58,6 +58,10 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
+    <Page Include="OpenInIDE_Hotspots\HotspotsList\OpenInIDEHotspotsControl.xaml">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <Generator>XamlIntelliSenseFileGenerator</Generator>
+    </Page>
     <Page Include="SharedUI\SharedResources.xaml">
       <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>

--- a/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/HotspotsToolWindow.cs
+++ b/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/HotspotsToolWindow.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.IssueVisualization.Editor;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels;
+using SonarLint.VisualStudio.IssueVisualization.Selection;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList
+{
+    [Guid(ToolWindowIdAsString)]
+    public class OpenInIDEHotspotsToolWindow : ToolWindowPane
+    {
+        private const string ToolWindowIdAsString = "D71842F7-4DB3-4AC1-A91A-D16D1A514242";
+        public static readonly Guid ToolWindowId = new Guid(ToolWindowIdAsString);
+
+        public OpenInIDEHotspotsToolWindow(IServiceProvider serviceProvider)
+        {
+            Caption = Resources.HotspotsToolWindowCaption;
+
+            var componentModel = serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
+
+            var store = componentModel.GetService<IOpenInIDEHotspotsStore>();
+            var locationNavigator = componentModel.GetService<ILocationNavigator>();
+            var selectionService = componentModel.GetService<IIssueSelectionService>();
+
+            var viewModel = new OpenInIDEHotspotsControlViewModel(store, locationNavigator, selectionService);
+            var hotspotsControl = new OpenInIDEHotspotsControl(viewModel);
+
+            Content = hotspotsControl;
+        }
+    }
+}

--- a/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/OpenInIDEHotspotsControl.xaml
+++ b/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/OpenInIDEHotspotsControl.xaml
@@ -1,0 +1,156 @@
+﻿<UserControl x:Class="SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.OpenInIDEHotspotsControl"
+             x:ClassModifier="internal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vsCatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:vsImaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:vsTheming="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:converter="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList"
+             xmlns:core="clr-namespace:SonarLint.VisualStudio.Core.WPF;assembly=SonarLint.VisualStudio.Core"
+             DataContext="{Binding ViewModel, RelativeSource={RelativeSource Mode=Self}}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../../SharedUI/SharedResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <converter:PriorityToBackgroundConverter x:Key="PriorityToBackgroundConverter" />
+            <core:NullableSelectedItemConverter x:Key="NullableSelectedItemConverter"/>
+
+            <ContextMenu x:Key="RowMenu" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                <MenuItem Header="Remove" 
+                    CommandParameter="{Binding}"
+                    Command="{Binding DataContext.RemoveCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}">
+                    <MenuItem.Icon>
+                        <vsImaging:CrispImage Moniker="{x:Static vsCatalog:KnownMonikers.DeleteTableRow}"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+            
+            <!-- Extend the shared data grid row style to add the context menu and navigability data bindings -->
+            <Style BasedOn="{StaticResource BaseDataGridRow}"
+                   TargetType="DataGridRow">
+                <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
+                <Setter Property="Background" Value="{DynamicResource {x:Static vsTheming:TreeViewColors.BackgroundBrushKey}}"/>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Hotspot.Span, Converter={StaticResource SpanToNavigabilityConverter}}" Value="False">
+                        <Setter Property="FontStyle" Value="Italic"/>
+                        <Setter Property="ToolTip" Value="Cannot navigate to location. The source code is different from the analyzed version."/>
+                        <Setter Property="ToolTipService.IsEnabled" Value="true"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="PriorityColumnCellTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="TextWrapping" Value="Wrap"/>
+                <Setter Property="TextAlignment" Value="Center"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="1"/>
+                <Setter Property="Background" Value="{Binding Path=DataContext.Hotspot.Issue.Rule.Priority, RelativeSource={RelativeSource Self}, Converter={StaticResource PriorityToBackgroundConverter}}"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid UseLayoutRounding="True">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Name="Table" Width="*"/>
+        </Grid.ColumnDefinitions>
+        <DataGrid Grid.Column="0" 
+                  SelectedItem="{Binding SelectedHotspot, Mode=TwoWay, Converter={StaticResource NullableSelectedItemConverter}}"
+                  ItemsSource="{Binding Hotspots}"
+                  >
+            <DataGrid.InputBindings>
+                <MouseBinding
+                    MouseAction="LeftDoubleClick"
+                    Command="{Binding NavigateCommand}"
+                    CommandParameter="{Binding Hotspots/}"/>
+                <KeyBinding
+                    Key="Enter"
+                    Command="{Binding NavigateCommand}"
+                    CommandParameter="{Binding Hotspots/}"/>
+                <KeyBinding
+                    Key="Delete"
+                    Command="{Binding RemoveCommand}"
+                    CommandParameter="{Binding Hotspots/}"/>
+            </DataGrid.InputBindings>
+            <DataGrid.Columns>
+                <DataGridTemplateColumn CanUserSort="False" CanUserResize="False" Width="30">
+                    <DataGridTemplateColumn.HeaderStyle>
+                        <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
+                            <Setter Property="ToolTipService.ToolTip" Value="Location navigability status" />
+                        </Style>
+                    </DataGridTemplateColumn.HeaderStyle>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <vsImaging:CrispImage Height="16" Width="16"
+                                                      Moniker="{x:Static vsCatalog:KnownMonikers.DocumentWarning}" 
+                                                      Visibility="{Binding Hotspot.Span, Converter={StaticResource SpanToInvertedVisibilityConverter}, Mode=OneWay}"/>
+                                <vsImaging:CrispImage Height="16" Width="16"
+                                                      Margin="-5,0,0,0"
+                                                      ToolTipService.ToolTip="Location is navigable. Use double-click or Enter to open the document."
+                                                      Moniker="{x:Static vsCatalog:KnownMonikers.DocumentSource}" 
+                                                      Visibility="{Binding Hotspot.Span, Converter={StaticResource SpanToVisibilityConverter}, Mode=OneWay}"/>
+                            </Grid>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Hotspot.Issue.RuleKey" Header="Code" Width="130" MinWidth="54">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Hotspot.Issue.RuleKey}" 
+                                       Style="{StaticResource CellTextBlockStyle}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="CategoryDisplayName" Header="Category" Width="Auto"  MinWidth="74">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding CategoryDisplayName}" 
+                                       Style="{StaticResource CellTextBlockStyle}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Hotspot.Issue.Rule.Priority" Header="Priority" Width="90"  MinWidth="64">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Hotspot.Issue.Rule.Priority}" 
+                                       Style="{StaticResource PriorityColumnCellTextBlockStyle}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Hotspot.Issue.PrimaryLocation.Message" Header="Description" Width="*" MinWidth="150">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Hotspot.Issue.PrimaryLocation.Message}" 
+                                       Style="{StaticResource CellTextBlockStyle}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="DisplayPath" Header="File" Width="180"  MinWidth="80">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding DisplayPath}" 
+                                       Style="{StaticResource CellTextBlockStyle}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Line" Header="Line" Width="48"  MinWidth="48">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Line}" 
+                                       Style="{StaticResource CellTextBlockStyle}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Column" Header="Col" Width="44"  MinWidth="44">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Column}" 
+                                       Style="{StaticResource CellTextBlockStyle}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/OpenInIDEHotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/OpenInIDEHotspotsControl.xaml.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Windows.Controls;
+using SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList
+{
+    internal sealed partial class OpenInIDEHotspotsControl : UserControl
+    {
+        public IOpenInIDEHotspotsControlViewModel ViewModel { get; }
+
+        public OpenInIDEHotspotsControl(IOpenInIDEHotspotsControlViewModel viewModel)
+        {
+            ViewModel = viewModel;
+
+            InitializeComponent();
+        }
+    }
+}

--- a/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/ViewModels/HotspotViewModel.cs
+++ b/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/ViewModels/HotspotViewModel.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.Models;
+using SharedProvider = SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels
+{
+    internal interface IOpenInIDEHotspotViewModel : INotifyPropertyChanged, IDisposable
+    {
+        IAnalysisIssueVisualization Hotspot { get; }
+
+        int Line { get; }
+
+        int Column { get; }
+
+        string DisplayPath { get; }
+
+        string CategoryDisplayName { get; }
+    }
+
+    internal sealed class OpenInIDEHotspotViewModel : IOpenInIDEHotspotViewModel
+    {
+        private readonly SharedProvider.ISecurityCategoryDisplayNameProvider categoryDisplayNameProvider;
+        private readonly IIssueVizDisplayPositionCalculator positionCalculator;
+
+        public OpenInIDEHotspotViewModel(IAnalysisIssueVisualization hotspot)
+            : this(hotspot, new SharedProvider.SecurityCategoryDisplayNameProvider(), new IssueVizDisplayPositionCalculator())
+        {
+        }
+
+        internal OpenInIDEHotspotViewModel(IAnalysisIssueVisualization hotspot,
+            SharedProvider.ISecurityCategoryDisplayNameProvider categoryDisplayNameProvider,
+            IIssueVizDisplayPositionCalculator positionCalculator)
+        {
+            this.categoryDisplayNameProvider = categoryDisplayNameProvider;
+            this.positionCalculator = positionCalculator;
+            Hotspot = hotspot;
+            Hotspot.PropertyChanged += Hotspot_PropertyChanged;
+        }
+
+        public IAnalysisIssueVisualization Hotspot { get; }
+
+        public int Line => positionCalculator.GetLine(Hotspot);
+
+        public int Column => positionCalculator.GetColumn(Hotspot);
+
+        public string DisplayPath =>
+            Path.GetFileName(Hotspot.CurrentFilePath ?? ((IHotspot)Hotspot.Issue).ServerFilePath);
+
+        public string CategoryDisplayName =>
+            categoryDisplayNameProvider.Get(((IHotspot) Hotspot.Issue).Rule.SecurityCategory);
+
+        private void Hotspot_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(IAnalysisIssueVisualization.Span))
+            {
+                NotifyPropertyChanged(nameof(Line));
+                NotifyPropertyChanged(nameof(Column));
+            }
+            else if (e.PropertyName == nameof(IAnalysisIssueVisualization.CurrentFilePath))
+            {
+                NotifyPropertyChanged(nameof(DisplayPath));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public void Dispose()
+        {
+            Hotspot.PropertyChanged -= Hotspot_PropertyChanged;
+        }
+    }
+}

--- a/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
+++ b/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
@@ -1,0 +1,148 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Data;
+using System.Windows.Input;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.IssueVisualization.Editor;
+using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
+using SonarLint.VisualStudio.IssueVisualization.Selection;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots.HotspotsList.ViewModels
+{
+    internal interface IOpenInIDEHotspotsControlViewModel : IDisposable
+    {
+        ObservableCollection<IOpenInIDEHotspotViewModel> Hotspots { get; }
+
+        IOpenInIDEHotspotViewModel SelectedHotspot { get; }
+
+        ICommand NavigateCommand { get; }
+
+        ICommand RemoveCommand { get; }
+    }
+
+    internal sealed class OpenInIDEHotspotsControlViewModel : IOpenInIDEHotspotsControlViewModel, INotifyPropertyChanged
+    {
+        private readonly object Lock = new object();
+        private readonly IIssueSelectionService selectionService;
+        private readonly IOpenInIDEHotspotsStore store;
+        private IOpenInIDEHotspotViewModel selectedHotspot;
+
+        public ObservableCollection<IOpenInIDEHotspotViewModel> Hotspots { get; } = new ObservableCollection<IOpenInIDEHotspotViewModel>();
+
+        public ICommand NavigateCommand { get; private set; }
+
+        public ICommand RemoveCommand { get; private set; }
+
+        public OpenInIDEHotspotsControlViewModel(IOpenInIDEHotspotsStore hotspotsStore,
+            ILocationNavigator locationNavigator,
+            IIssueSelectionService selectionService)
+        {
+            AllowMultiThreadedAccessToHotspotsList();
+
+            this.selectionService = selectionService;
+            selectionService.SelectedIssueChanged += SelectionService_SelectionChanged;
+
+            this.store = hotspotsStore;
+            store.IssuesChanged += Store_IssuesChanged;
+
+            UpdateHotspotsList();
+
+            SetCommands(hotspotsStore, locationNavigator);
+        }
+
+        public IOpenInIDEHotspotViewModel SelectedHotspot
+        {
+            get => selectedHotspot;
+            set
+            {
+                if (selectedHotspot != value)
+                {
+                    selectedHotspot = value;
+                    selectionService.SelectedIssue = selectedHotspot?.Hotspot;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Allow the observable collection <see cref="Hotspots"/> to be modified from non-UI thread. 
+        /// </summary>
+        private void AllowMultiThreadedAccessToHotspotsList()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            BindingOperations.EnableCollectionSynchronization(Hotspots, Lock);
+        }
+
+        private void SetCommands(IOpenInIDEHotspotsStore hotspotsStore, ILocationNavigator locationNavigator)
+        {
+            NavigateCommand = new DelegateCommand(parameter =>
+            {
+                var hotspot = (IOpenInIDEHotspotViewModel)parameter;
+                locationNavigator.TryNavigate(hotspot.Hotspot);
+            }, parameter => parameter is IOpenInIDEHotspotViewModel);
+
+            RemoveCommand = new DelegateCommand(parameter =>
+            {
+                var hotspot = (IOpenInIDEHotspotViewModel)parameter;
+                hotspotsStore.Remove(hotspot.Hotspot);
+            }, parameter => parameter is IOpenInIDEHotspotViewModel);
+        }
+
+        private void UpdateHotspotsList()
+        {
+            Hotspots.Clear();
+
+            foreach (var issueViz in store.GetAll())
+            {
+                Hotspots.Add(new OpenInIDEHotspotViewModel(issueViz));
+            }
+        }
+
+        private void Store_IssuesChanged(object sender, IssuesChangedEventArgs e)
+        {
+            UpdateHotspotsList();
+        }
+
+        private void SelectionService_SelectionChanged(object sender, EventArgs e)
+        {
+            selectedHotspot = Hotspots.FirstOrDefault(x => x.Hotspot == selectionService.SelectedIssue);
+            NotifyPropertyChanged(nameof(SelectedHotspot));
+        }
+
+        public void Dispose()
+        {
+            store.IssuesChanged -= Store_IssuesChanged;
+            selectionService.SelectedIssueChanged -= SelectionService_SelectionChanged;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsStore.cs
+++ b/src/IssueViz.Security/OpenInIDE_Hotspots/HotspotsStore.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.OpenInIDE_Hotspots
+{
+    internal interface IOpenInIDEHotspotsStore : IIssuesStore
+    {
+        /// <summary>
+        /// Adds a given visualization to the list if it does not already exist.
+        /// Returns the given visualization, or the existing visualization with the same hotspot key.
+        /// </summary>
+        IAnalysisIssueVisualization GetOrAdd(IAnalysisIssueVisualization hotspotViz);
+
+        void Remove(IAnalysisIssueVisualization hotspotViz);
+    }
+
+    [Export(typeof(IOpenInIDEHotspotsStore))]
+    [Export(typeof(IIssuesStore))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal sealed class OpenInIDEHotspotsStore : IOpenInIDEHotspotsStore
+    {
+        private readonly List<IAnalysisIssueVisualization> hotspots = new List<IAnalysisIssueVisualization>();
+
+        public IReadOnlyCollection<IAnalysisIssueVisualization> GetAll() => hotspots;
+
+        public event EventHandler<IssuesChangedEventArgs> IssuesChanged;
+
+        public IAnalysisIssueVisualization GetOrAdd(IAnalysisIssueVisualization hotspotViz)
+        {
+            var existingHotspot = FindExisting(hotspotViz);
+
+            if (existingHotspot != null)
+            {
+                return existingHotspot;
+            }
+
+            hotspots.Add(hotspotViz);
+
+            NotifyIssuesChanged(new IssuesChangedEventArgs(
+                Array.Empty<IAnalysisIssueVisualization>(),
+                new[] {hotspotViz}));
+
+            return hotspotViz;
+        }
+
+        public void Remove(IAnalysisIssueVisualization hotspotViz)
+        {
+            hotspots.Remove(hotspotViz);
+
+            NotifyIssuesChanged(new IssuesChangedEventArgs(
+                new[] {hotspotViz},
+                Array.Empty<IAnalysisIssueVisualization>()));
+        }
+
+        private IAnalysisIssueVisualization FindExisting(IAnalysisIssueVisualization hotspotViz)
+        {
+            var key = ((IHotspot)hotspotViz.Issue).HotspotKey;
+
+            return hotspots.FirstOrDefault(x => ((IHotspot)x.Issue).HotspotKey == key);
+        }
+
+        private void NotifyIssuesChanged(IssuesChangedEventArgs args)
+        {
+            IssuesChanged?.Invoke(this, args);
+        }
+    }
+}


### PR DESCRIPTION
Part of #4559

- reverts changes in https://github.com/SonarSource/sonarlint-visualstudio/commit/997d521b9a3688c25cae2976b3f8ada40408dc86
- renamed duplicated classes with `OpenInIDE` e.g. `OpenInIDEHotspotsToolWindow`