### PR TITLE
Add data binding for priority column

### DIFF
--- a/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/HotspotViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/HotspotViewModelTests.cs
@@ -190,7 +190,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Hotspots.
         {
             securityCategoryDisplayNameProvider ??= Mock.Of<ISecurityCategoryDisplayNameProvider>();
             positionCalculator ??= Mock.Of<IIssueVizDisplayPositionCalculator>();
-            return new HotspotViewModel(issueViz, securityCategoryDisplayNameProvider, positionCalculator);
+            return new HotspotViewModel(issueViz, default, securityCategoryDisplayNameProvider, positionCalculator);
         }
     }
 }

--- a/src/IssueViz.Security.UnitTests/Hotspots/LocalHotspotTests.cs
+++ b/src/IssueViz.Security.UnitTests/Hotspots/LocalHotspotTests.cs
@@ -33,6 +33,7 @@ public class LocalHotspotTests
     public void Ctor_VisualizationIsNull_Throws()
     {
         Action test = () => new LocalHotspot(null,
+            default,
             new SonarQubeHotspot(string.Empty,
                 string.Empty,
                 string.Empty,

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml
@@ -46,7 +46,7 @@
                 <Setter Property="TextAlignment" Value="Center"/>
                 <Setter Property="VerticalAlignment" Value="Center"/>
                 <Setter Property="Margin" Value="1"/>
-                <Setter Property="Background" Value="{Binding Path=DataContext.Hotspot.Issue.Rule.Priority, RelativeSource={RelativeSource Self}, Converter={StaticResource PriorityToBackgroundConverter}}"/>
+                <Setter Property="Background" Value="{Binding Path=DataContext.HotspotPriority, RelativeSource={RelativeSource Self}, Converter={StaticResource PriorityToBackgroundConverter}}"/>
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -113,7 +113,7 @@
                 <DataGridTemplateColumn CanUserSort="True" SortMemberPath="Hotspot.Issue.Rule.Priority" Header="Priority" Width="90"  MinWidth="64">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding Hotspot.Issue.Rule.Priority}" 
+                            <TextBlock Text="{Binding HotspotPriority}" 
                                        Style="{StaticResource PriorityColumnCellTextBlockStyle}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>

--- a/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotViewModel.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotViewModel.cs
@@ -38,6 +38,8 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
         string DisplayPath { get; }
 
         string CategoryDisplayName { get; }
+        
+        HotspotPriority HotspotPriority { get; }
     }
 
     internal sealed class HotspotViewModel : IHotspotViewModel
@@ -45,20 +47,26 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
         private readonly ISecurityCategoryDisplayNameProvider categoryDisplayNameProvider;
         private readonly IIssueVizDisplayPositionCalculator positionCalculator;
 
-        public HotspotViewModel(IAnalysisIssueVisualization hotspot)
-            : this(hotspot, new SecurityCategoryDisplayNameProvider(), new IssueVizDisplayPositionCalculator())
+        public HotspotViewModel(IAnalysisIssueVisualization hotspot, HotspotPriority hotspotPriority)
+            : this(hotspot, hotspotPriority, new SecurityCategoryDisplayNameProvider(), new IssueVizDisplayPositionCalculator())
         {
         }
 
-        internal HotspotViewModel(IAnalysisIssueVisualization hotspot, ISecurityCategoryDisplayNameProvider categoryDisplayNameProvider, IIssueVizDisplayPositionCalculator positionCalculator)
+        internal HotspotViewModel(IAnalysisIssueVisualization hotspot, 
+            HotspotPriority hotspotPriority,
+            ISecurityCategoryDisplayNameProvider categoryDisplayNameProvider,
+            IIssueVizDisplayPositionCalculator positionCalculator)
         {
             this.categoryDisplayNameProvider = categoryDisplayNameProvider;
             this.positionCalculator = positionCalculator;
             Hotspot = hotspot;
+            HotspotPriority = hotspotPriority;
             Hotspot.PropertyChanged += Hotspot_PropertyChanged;
         }
 
         public IAnalysisIssueVisualization Hotspot { get; }
+        
+        public HotspotPriority HotspotPriority { get; }
 
         public int Line => positionCalculator.GetLine(Hotspot);
 

--- a/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
@@ -98,7 +98,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
                 Hotspots.Clear();
                 foreach (var localHotspot in store.GetAllLocalHotspots())
                 {
-                    Hotspots.Add(new HotspotViewModel(localHotspot.Visualization));
+                    Hotspots.Add(new HotspotViewModel(localHotspot.Visualization, localHotspot.Priority));
                 }
 
                 return System.Threading.Tasks.Task.FromResult(true);

--- a/src/IssueViz.Security/Hotspots/LocalHotspot.cs
+++ b/src/IssueViz.Security/Hotspots/LocalHotspot.cs
@@ -20,6 +20,7 @@
 
 using System;
 using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.Models;
 using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots
@@ -27,15 +28,18 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots
     internal class LocalHotspot
     {
         /// <param name="visualization">Locally analyzed hotspot visualization</param>
+        /// <param name="priority">Hotspot review priority</param>
         /// <param name="serverHotspot">Matched server hotspot. Can be null</param>
         /// <exception cref="ArgumentNullException">Visualization can't be null</exception>
-        public LocalHotspot(IAnalysisIssueVisualization visualization, SonarQubeHotspot serverHotspot = null)
+        public LocalHotspot(IAnalysisIssueVisualization visualization, HotspotPriority priority, SonarQubeHotspot serverHotspot = null)
         {
             Visualization = visualization ?? throw new ArgumentNullException(nameof(visualization));
+            Priority = priority;
             ServerHotspot = serverHotspot;
         }
 
         public IAnalysisIssueVisualization Visualization { get; }
         public SonarQubeHotspot ServerHotspot { get;  }
+        public HotspotPriority Priority { get; }
     }
 }


### PR DESCRIPTION
* LocalHotspot now has Priority
* LocalHotspotsStore uses PriorityProvider to create LocalHotspot
* HotspotViewModel uses Priority from LocalHotspot
* HotspotsControl displays the new Priority of HotspotViewModel

Implements #4532