### PR TITLE
[WIP] Update CFamily analyzer and add support for MISRA rules

### DIFF
--- a/build/tools/CFamilyJarPreProcessor/Preprocessor.cs
+++ b/build/tools/CFamilyJarPreProcessor/Preprocessor.cs
@@ -36,6 +36,7 @@ namespace CFamilyJarPreProcessor
         {
                 "Sonar_way_profile.json",
                 "RulesList.json",
+                "MisraRulesList.json",
                 TarUnzipSubFolder + @"\subprocess.exe",
                 TarUnzipSubFolder + @"\LICENSE_THIRD_PARTY.txt"
         };
@@ -44,7 +45,8 @@ namespace CFamilyJarPreProcessor
         private readonly string[] MultipleFilesPatterns = new string[]
         {
             @"org\sonar\l10n\cpp\rules\params\*_params.json",
-            @"org\sonar\l10n\cpp\rules\cpp\*.json"
+            @"org\sonar\l10n\cpp\rules\cpp\*.json",
+            @"org\sonar\l10n\cpp\rules\misra23\*.json",
         };
 
         private readonly ILogger logger;

--- a/src/CFamily/Rules/RulesLoader.cs
+++ b/src/CFamily/Rules/RulesLoader.cs
@@ -40,7 +40,10 @@ namespace SonarLint.VisualStudio.CFamily.Rules
         {
             var rulesList = LoadCFamilyJsonFile<List<string>>("RulesList.json");
             Debug.Assert(rulesList != null, "The CFamily RulesList.json should exist and not be empty");
+            var misraRulesList = LoadCFamilyJsonFile<List<string>>("MisraRulesList.json");
+            Debug.Assert(rulesList != null, "The CFamily Misra RulesList.json should exist and not be empty");
 
+            rulesList.AddRange(misraRulesList);
             return rulesList;
         }
 

--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <!-- Note: Guide on how to update the analyzers is on the xtranet! -->
     <EmbeddedSonarAnalyzerVersion>9.6.0.74858</EmbeddedSonarAnalyzerVersion>
-    <EmbeddedSonarCFamilyAnalyzerVersion>6.46.0.62229</EmbeddedSonarCFamilyAnalyzerVersion>
+    <EmbeddedSonarCFamilyAnalyzerVersion>6.47.0.62356</EmbeddedSonarCFamilyAnalyzerVersion>
     <EmbeddedSonarJSAnalyzerVersion>10.3.2.22047</EmbeddedSonarJSAnalyzerVersion>
 
   <!-- Secrets


### PR DESCRIPTION
These changes are enough to execute a MISRA rule if it is explicitly enabled in standalone mode:

```
{
  "sonarlint.rules": {
    "cpp:M23_003": {
      "level": "On"
    }
  }
}
```

![image](https://github.com/SonarSource/sonarlint-visualstudio/assets/10757559/bc27b140-d330-42bd-bf39-4250253880d4)


TODO:
- [ ] fix up tests