### PR TITLE
Make QualityProfileDownloader return if there were changes

### DIFF
--- a/src/ConnectedMode/Binding/BindingProcessImpl.cs
+++ b/src/ConnectedMode/Binding/BindingProcessImpl.cs
@@ -72,9 +72,19 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding
         public async Task<bool> DownloadQualityProfileAsync(IProgress<FixedStepsProgress> progress, CancellationToken cancellationToken)
         {
             var boundProject = CreateNewBindingConfig();
-            var result = await qualityProfileDownloader.UpdateAsync(boundProject, progress, cancellationToken);
 
-            return result;
+            try
+            {
+                await qualityProfileDownloader.UpdateAsync(boundProject, progress, cancellationToken);
+                // ignore the UpdateAsync result, as the return value of false indicates error, rather than lack of changes
+                return true;
+            }
+            catch (InvalidOperationException e)
+            {
+                logger.LogVerbose(e.ToString());
+            }
+
+            return false;
         }
 
         private BoundSonarQubeProject CreateNewBindingConfig()
@@ -106,10 +116,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding
         }
 
         public bool BindOperationSucceeded => InternalState.BindingOperationSucceeded;
-
-        #endregion
-
-        #region Private methods
 
         #endregion
 

--- a/src/ConnectedMode/Binding/BindingProcessImpl.cs
+++ b/src/ConnectedMode/Binding/BindingProcessImpl.cs
@@ -81,7 +81,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding
             }
             catch (InvalidOperationException e)
             {
-                logger.LogVerbose(e.ToString());
+                logger.LogVerbose($"[{nameof(BindingProcessImpl)}] {e}");
             }
 
             return false;

--- a/src/ConnectedMode/Binding/BindingStrings.Designer.cs
+++ b/src/ConnectedMode/Binding/BindingStrings.Designer.cs
@@ -70,6 +70,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All quality profiles are up to date.
+        /// </summary>
+        internal static string DownloadingQualityProfilesNotNeeded {
+            get {
+                return ResourceManager.GetString("DownloadingQualityProfilesNotNeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to create the configuration for language {0}.
         /// </summary>
         internal static string FailedToCreateBindingConfigForLanguage {

--- a/src/ConnectedMode/Binding/BindingStrings.resx
+++ b/src/ConnectedMode/Binding/BindingStrings.resx
@@ -141,4 +141,7 @@
     <value>   {0}</value>
     <comment>Output window message format. Used whenever the message should be displayed as a sub-message from a step message so the user can clearly identify the grouping. {0} the actual message to display.</comment>
   </data>
+  <data name="DownloadingQualityProfilesNotNeeded" xml:space="preserve">
+    <value>All quality profiles are up to date</value>
+  </data>
 </root>

--- a/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
+++ b/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
@@ -38,6 +38,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
         /// <summary>
         /// Ensures that the Quality Profiles for all supported languages are to date
         /// </summary>
+        /// <returns>true if there were changes updated, false if everything is up to date</returns>
+        /// <exception cref="InvalidOperationException">If binding failed for one of the languages</exception>
         Task<bool> UpdateAsync(BoundSonarQubeProject boundProject, IProgress<FixedStepsProgress> progress, CancellationToken cancellationToken);
     }
     

--- a/src/ConnectedMode/QualityProfiles/QualityProfileUpdater.cs
+++ b/src/ConnectedMode/QualityProfiles/QualityProfileUpdater.cs
@@ -66,7 +66,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             var config = configProvider.GetConfiguration();
             if (config.Mode != SonarLintMode.Connected)
             {
-                logger.LogVerbose($"[QualityProfiles] Skipping Quality Profile update. Solution is not bound. Mode: {config.Mode}");
+                logger.LogVerbose($"[{nameof(QualityProfileUpdater)}] Skipping Quality Profile update. Solution is not bound. Mode: {config.Mode}");
                 return;
             }
 
@@ -82,8 +82,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             }
             catch (Exception e) when (e is OperationCanceledException || e is InvalidOperationException)
             {
-                // no-op - job was cancelled
-                logger.LogVerbose(e.ToString());
+                logger.LogVerbose($"[{nameof(QualityProfileUpdater)}] {e}");
             }
         }
 


### PR DESCRIPTION
Implements #4705

* QualityProfileDownloader returns false when no QPs updated, true if at least one

* QualityProfileDownloader throws InvalidOperationException if binding config not found

* QualityProfileUpdater only raises the event if QualityProfileDownloader returns true

* QualityProfileUpdater handles InvalidOperationException from QualityProfileDownloader

* BindingProcessImpl handles InvalidOperationException from QualityProfileDownloader