### PR TITLE
[CAYC] Move XAML generator tests to match product folder structure

### DIFF
--- a/src/Education.UnitTests/XamlGenerator/CustomTextMarkupParserTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/CustomTextMarkupParserTests.cs
@@ -21,9 +21,9 @@
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Education.XamlGenerator;
 
-
-namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator
 {
     [TestClass]
     public class CustomTextMarkupParserTests
@@ -35,7 +35,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
                           "\n Implements a check " +
                           "\non";
 
-            var result = XamlGenerator.CustomTextMarkupParser.Parse(text).ToArray();
+            var result = CustomTextMarkupParser.Parse(text).ToArray();
 
             result.Should().HaveCount(3);
 
@@ -62,7 +62,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
         {
             string text = " {rule:javascript:S1656} - Implements a check on";
 
-            var result = XamlGenerator.CustomTextMarkupParser.Parse(text).ToArray();
+            var result = CustomTextMarkupParser.Parse(text).ToArray();
 
             result.Should().HaveCount(3);
 
@@ -89,7 +89,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
         {
             string text = "{rule:cpp:S165}";
 
-            var result = XamlGenerator.CustomTextMarkupParser.Parse(text).ToArray();
+            var result = CustomTextMarkupParser.Parse(text).ToArray();
 
             result.Should().HaveCount(1);
 
@@ -106,7 +106,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
         {
             string text = "also found {rule:cpp:S165} hello this is a test {rule:c:S1111}";
 
-            var result = XamlGenerator.CustomTextMarkupParser.Parse(text).ToArray();
+            var result = CustomTextMarkupParser.Parse(text).ToArray();
 
             result.Should().HaveCount(4);
 
@@ -141,7 +141,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
         {
             string text = "this is a text without any cross references";
 
-            var result = XamlGenerator.CustomTextMarkupParser.Parse(text).ToArray();
+            var result = CustomTextMarkupParser.Parse(text).ToArray();
 
             result.Should().HaveCount(1);
 
@@ -156,7 +156,7 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator.UnitTests
         {
             string text = "";
 
-            var result = XamlGenerator.CustomTextMarkupParser.Parse(text);
+            var result = CustomTextMarkupParser.Parse(text);
 
             result.Should().HaveCount(0);
         }

--- a/src/Education.UnitTests/XamlGenerator/RichRuleHelpXamlBuilderTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/RichRuleHelpXamlBuilderTests.cs
@@ -12,7 +12,7 @@ using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.Rules;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator
 {
     [TestClass]
     public class RichRuleHelpXamlBuilderTests

--- a/src/Education.UnitTests/XamlGenerator/RuleHelpXamlBuilderTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/RuleHelpXamlBuilderTests.cs
@@ -25,7 +25,7 @@ using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.Rules;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests;
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator;
 
 [TestClass]
 public class RuleHelpXamlBuilderTests

--- a/src/Education.UnitTests/XamlGenerator/RuleHelpXamlTranslatorTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/RuleHelpXamlTranslatorTests.cs
@@ -25,7 +25,7 @@ using Moq;
 using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator
 {
     [TestClass]
     public class RuleHelpXamlTranslatorTests

--- a/src/Education.UnitTests/XamlGenerator/SimpleRuleHelpXamlBuilderTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/SimpleRuleHelpXamlBuilderTests.cs
@@ -32,7 +32,7 @@ using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.Rules;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator
 {
     [TestClass]
     public class SimpleRuleHelpXamlBuilderTests

--- a/src/Education.UnitTests/XamlGenerator/StaticXamlStorageTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/StaticXamlStorageTests.cs
@@ -25,7 +25,7 @@ using Moq;
 using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator
 {
     [TestClass]
     public class StaticXamlStorageTests

--- a/src/Education.UnitTests/XamlGenerator/XamlGeneratorHelperTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/XamlGeneratorHelperTests.cs
@@ -27,7 +27,7 @@ using Moq;
 using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.Rules;
 
-namespace SonarLint.VisualStudio.Education.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator
 {
     [TestClass]
     public class XamlGeneratorHelperTests

--- a/src/Education.UnitTests/XamlGenerator/XamlWriterFactoryTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/XamlWriterFactoryTests.cs
@@ -24,7 +24,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests;
+namespace SonarLint.VisualStudio.Education.UnitTests.XamlGenerator;
 
 [TestClass]
 public class XamlWriterFactoryTests


### PR DESCRIPTION
Fixed up namespaces
No product or test code changes