### PR TITLE
[CAYC] Remove obsolete unused method from IThreadHandling

### DIFF
--- a/src/ConnectedMode/Migration/Wizard/MigrationWizardWindow.xaml.cs
+++ b/src/ConnectedMode/Migration/Wizard/MigrationWizardWindow.xaml.cs
@@ -130,7 +130,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Migration.Wizard
             var elapsed = DateTime.UtcNow - startTime;
             var displayText = elapsed.ToString("mm\\:ss");
 
-            threadHandling.RunOnUIThread2(
+            threadHandling.RunOnUIThread(
                 () => txtStopwatchTime.Text = displayText);
         }
 
@@ -187,7 +187,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Migration.Wizard
 
         void IProgress<MigrationProgress>.Report(MigrationProgress value)
         {
-            threadHandling.RunOnUIThread2(() =>
+            threadHandling.RunOnUIThread(() =>
             {
                 ListBoxItem item = new ListBoxItem();
                 if (value.IsWarning)

--- a/src/Core/IThreadHandling.cs
+++ b/src/Core/IThreadHandling.cs
@@ -53,18 +53,6 @@ namespace SonarLint.VisualStudio.Core
         /// </summary>
         Task RunOnUIThreadAsync(Action op);
 
-        // TODO: renaming async methods to end with "Async", then rename this method to "RunOnUIThread"
-        // See https://github.com/SonarSource/sonarlint-visualstudio/issues/4180
-        /// <summary>
-        /// Executes the operation synchronously on the main thread.
-        /// If the caller is on the main thread already then the operation is executed directly.
-        /// If the caller is not on the main thread then the method will switch to the main thread,
-        /// then resume on the caller's thread when then the operation completes.
-        /// </summary>
-        [Obsolete("This method does not work correctly. Use RunOnUIThread2 instead.")]
-        // See https://github.com/SonarSource/sonarlint-visualstudio/issues/4179 for more info.
-        void RunOnUIThread(Action op);
-
         /// <summary>
         /// Executes the operation asynchronously on the main thread. While synchronously blocking 
         /// synchronously the calling thread.

--- a/src/Core/IThreadHandling.cs
+++ b/src/Core/IThreadHandling.cs
@@ -60,7 +60,7 @@ namespace SonarLint.VisualStudio.Core
         /// If the caller is not on the main thread then the method will switch to the main thread,
         /// then resume on the caller's thread when then the operation completes.
         /// </summary>
-        void RunOnUIThread2(Action op);
+        void RunOnUIThread(Action op);
 
         /// <summary>
         /// Executes the operation asynchronously on the background thread.

--- a/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
+++ b/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
@@ -174,7 +174,7 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
             var serviceProvider = CreateServiceProviderWithSolution(solution.Object, () => calls.Add("GetService"));
 
             var threadHandling = new Mock<IThreadHandling>();
-            threadHandling.Setup(x => x.RunOnUIThread2(It.IsAny<Action>()))
+            threadHandling.Setup(x => x.RunOnUIThread(It.IsAny<Action>()))
                 .Callback<Action>(productOperation =>
                 {
                     calls.Add("switch to UI thread");
@@ -197,7 +197,7 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
             var serviceProvider = CreateServiceProviderWithSolution(solution.Object, () => calls.Add("GetService"));
 
             var threadHandling = new Mock<IThreadHandling>();
-            threadHandling.Setup(x => x.RunOnUIThread2(It.IsAny<Action>()))
+            threadHandling.Setup(x => x.RunOnUIThread(It.IsAny<Action>()))
                 .Callback<Action>(productOperation =>
                 {
                     calls.Add("switch to UI thread");

--- a/src/Infrastructure.VS/SolutionInfoProvider.cs
+++ b/src/Infrastructure.VS/SolutionInfoProvider.cs
@@ -69,7 +69,7 @@ namespace SonarLint.VisualStudio.Infrastructure.VS
         public string GetFullSolutionFilePath()
         {
             string fullSolutionName = null;
-            threadHandling.RunOnUIThread2(() => fullSolutionName = GetSolutionFilePath());
+            threadHandling.RunOnUIThread(() => fullSolutionName = GetSolutionFilePath());
             return fullSolutionName;
         }
 

--- a/src/Infrastructure.VS/ThreadHandling.cs
+++ b/src/Infrastructure.VS/ThreadHandling.cs
@@ -49,10 +49,6 @@ namespace SonarLint.VisualStudio.Infrastructure.VS
 
         public async Task RunOnUIThreadAsync(Action op) => await VS.RunOnUIThread.RunAsync(op);
 
-        // TODO: check the implementation of RunOnUIThread.Run is actually synchronous
-        // See https://github.com/SonarSource/sonarlint-visualstudio/issues/4179
-        public void RunOnUIThread(Action op) => VS.RunOnUIThread.Run(op);
-
         public void RunOnUIThread2(Action op)
         {
             if (ThreadHelper.CheckAccess())

--- a/src/Infrastructure.VS/ThreadHandling.cs
+++ b/src/Infrastructure.VS/ThreadHandling.cs
@@ -49,7 +49,7 @@ namespace SonarLint.VisualStudio.Infrastructure.VS
 
         public async Task RunOnUIThreadAsync(Action op) => await VS.RunOnUIThread.RunAsync(op);
 
-        public void RunOnUIThread2(Action op)
+        public void RunOnUIThread(Action op)
         {
             if (ThreadHelper.CheckAccess())
             {

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -224,7 +224,7 @@ namespace SonarLint.VisualStudio.Integration.Connection
         {
             SonarQubeOrganization organization = null;
 
-            threadHandling.RunOnUIThread2(() =>
+            threadHandling.RunOnUIThread(() =>
             {
                 var organizationDialog = new OrganizationSelectionWindow(organizations) { Owner = Application.Current.MainWindow };
                 var hasUserClickedOk = organizationDialog.ShowDialog().GetValueOrDefault();

--- a/src/Integration/State/StateManager.cs
+++ b/src/Integration/State/StateManager.cs
@@ -108,7 +108,7 @@ namespace SonarLint.VisualStudio.Integration.State
 
         public void SetProjects(ConnectionInformation connection, IEnumerable<SonarQubeProject> projects)
         {
-            threadHandling.RunOnUIThread2(() => SetProjectsUIThread(connection, projects));
+            threadHandling.RunOnUIThread(() => SetProjectsUIThread(connection, projects));
         }
 
         public void SetBoundProject(Uri serverUri, string organizationKey, string projectKey)

--- a/src/TestInfrastructure/NoOpThreadHandler.cs
+++ b/src/TestInfrastructure/NoOpThreadHandler.cs
@@ -44,7 +44,7 @@ namespace SonarLint.VisualStudio.TestInfrastructure
             return Task.CompletedTask;
         }
 
-        public void RunOnUIThread2(Action op) => op();
+        public void RunOnUIThread(Action op) => op();
 
         public Task<T> RunOnBackgroundThread<T>(Func<Task<T>> asyncMethod) => asyncMethod();
 

--- a/src/TestInfrastructure/NoOpThreadHandler.cs
+++ b/src/TestInfrastructure/NoOpThreadHandler.cs
@@ -44,8 +44,6 @@ namespace SonarLint.VisualStudio.TestInfrastructure
             return Task.CompletedTask;
         }
 
-        public void RunOnUIThread(Action op) => op();
-
         public void RunOnUIThread2(Action op) => op();
 
         public Task<T> RunOnBackgroundThread<T>(Func<Task<T>> asyncMethod) => asyncMethod();


### PR DESCRIPTION
Remove obsolete `RunOnUIThread` and rename `RunOnUIThread2` -> `RunOnUIThread`.