### PR TITLE
Add IsFolderWorkerSpace wrapper to ISolutionInfoProvider

### DIFF
--- a/src/Core/ISolutionInfoProvider.cs
+++ b/src/Core/ISolutionInfoProvider.cs
@@ -70,14 +70,12 @@ namespace SonarLint.VisualStudio.Core
         /// <summary>
         /// Returns true/false if the workspace is in Open-As-Folder mode
         /// </summary>
-        /// <remarks>Will always return false in VS2015 as that mode is not supported in 2015.</remarks>
         Task<bool> IsFolderWorkspaceAsync();
 
         /// <summary>
         /// Returns true/false if the workspace is in Open-As-Folder mode
         /// </summary>
-        /// <remarks>Will always return false in VS2015 as that mode is not supported in 2015.</remarks>
-        /// to be used only by existing non-thread-aware code that cannot easily be refactored.</remarks>
+        /// <remarks>to be used only by existing non-thread-aware code that cannot easily be refactored.</remarks>
         bool IsFolderWorkspace();
     }
 }

--- a/src/Core/ISolutionInfoProvider.cs
+++ b/src/Core/ISolutionInfoProvider.cs
@@ -66,5 +66,18 @@ namespace SonarLint.VisualStudio.Core
         ///  <remarks>If possible, use the asynchronous version of this method. This synchronous version was added
         /// to be used only by existing non-thread-aware code that cannot easily be refactored.</remarks>
         bool IsSolutionFullyOpened();
+
+        /// <summary>
+        /// Returns true/false if the workspace is in Open-As-Folder mode
+        /// </summary>
+        /// <remarks>Will always return false in VS2015 as that mode is not supported in 2015.</remarks>
+        Task<bool> IsFolderWorkspaceAsync();
+
+        /// <summary>
+        /// Returns true/false if the workspace is in Open-As-Folder mode
+        /// </summary>
+        /// <remarks>Will always return false in VS2015 as that mode is not supported in 2015.</remarks>
+        /// to be used only by existing non-thread-aware code that cannot easily be refactored.</remarks>
+        bool IsFolderWorkspace();
     }
 }

--- a/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
+++ b/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
@@ -147,6 +147,36 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
         }
 
         [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataRow(null)]
+        public void GetIsFolderWorkspaceAsync_ReturnsExpectedValue(bool? isOpenAsFolder)
+        {
+            var solution = CreateIVsSolutionWithIsFolderWorkspace(isOpenAsFolder);
+            var serviceProvider = CreateServiceProviderWithSolution(solution.Object);
+
+            var testSubject = CreateTestSubject(serviceProvider.Object);
+
+            var actual = testSubject.IsSolutionFullyOpened();
+            actual.Should().Be((bool)isOpenAsFolder);
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        [DataRow(null)]
+        public void GetIsFolderWorkspace_ReturnsExpectedValue(bool? isOpenAsFolder)
+        {
+            var solution = CreateIVsSolutionWithIsFolderWorkspace(isOpenAsFolder);
+            var serviceProvider = CreateServiceProviderWithSolution(solution.Object);
+
+            var testSubject = CreateTestSubject(serviceProvider.Object);
+
+            var actual = testSubject.IsSolutionFullyOpened();
+            actual.Should().Be((bool)isOpenAsFolder);
+        }
+
+        [TestMethod]
         [DataRow(true, 0)]
         [DataRow(false, 0)]
         [DataRow(true, -1)]
@@ -215,6 +245,29 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
             var calls = new List<string>();
 
             var solution = CreateIVsSolutionWithIsFullyOpened(true, callback:() => calls.Add("GetSolutionIsFullyOpen"));
+            var serviceProvider = CreateServiceProviderWithSolution(solution.Object, () => calls.Add("GetService"));
+
+            var threadHandling = new Mock<IThreadHandling>();
+            threadHandling.Setup(x => x.RunOnUIThreadAsync(It.IsAny<Action>()))
+                .Callback<Action>(productOperation =>
+                {
+                    calls.Add("switch to UI thread");
+                    productOperation.Invoke();
+                });
+
+            var testSubject = CreateTestSubject(serviceProvider.Object, threadHandling.Object);
+
+            var actual = await testSubject.IsSolutionFullyOpenedAsync();
+
+            calls.Should().ContainInOrder("switch to UI thread", "GetService", "GetSolutionIsFullyOpen");
+        }
+
+        [TestMethod]
+        public async Task IsSolutionFullyOpenAsync_ServiceCalledOnUIThread()
+        {
+            var calls = new List<string>();
+
+            var solution = CreateIVsSolutionWithIsFullyOpened(true, callback: () => calls.Add("GetSolutionIsFullyOpen"));
             var serviceProvider = CreateServiceProviderWithSolution(solution.Object, () => calls.Add("GetService"));
 
             var threadHandling = new Mock<IThreadHandling>();
@@ -344,6 +397,19 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
                 .Returns(hresult);
 
             return solution;
+        }
+
+        private static Mock<IVsSolution> CreateIVsSolutionWithIsFolderWorkspace(bool? isOpenAsFolder)
+        {
+            object result = isOpenAsFolder;
+            var VSPROPID_IsInOpenFolderMode = -8044;
+            var vsSolution = new Mock<IVsSolution>();
+
+            vsSolution
+                .Setup(x => x.GetProperty(VSPROPID_IsInOpenFolderMode, out result))
+                .Returns(VSConstants.S_OK);
+
+            return vsSolution;
         }
 
         private static Mock<IThreadHandling> CreateThreadHandlingWithRunOnUICallback(Action testOperation)

--- a/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
+++ b/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
@@ -150,15 +150,15 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
         [DataRow(true)]
         [DataRow(false)]
         [DataRow(null)]
-        public void GetIsFolderWorkspaceAsync_ReturnsExpectedValue(bool? isOpenAsFolder)
+        public async Task GetIsFolderWorkspaceAsync_ReturnsExpectedValue(bool? isOpenAsFolder)
         {
             var solution = CreateIVsSolutionWithIsFolderWorkspace(isOpenAsFolder);
             var serviceProvider = CreateServiceProviderWithSolution(solution.Object);
 
             var testSubject = CreateTestSubject(serviceProvider.Object);
 
-            var actual = testSubject.IsSolutionFullyOpened();
-            actual.Should().Be((bool)isOpenAsFolder);
+            var actual = await testSubject.IsFolderWorkspaceAsync();
+            actual.Should().Be(isOpenAsFolder == true);
         }
 
         [TestMethod]
@@ -172,8 +172,8 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
 
             var testSubject = CreateTestSubject(serviceProvider.Object);
 
-            var actual = testSubject.IsSolutionFullyOpened();
-            actual.Should().Be((bool)isOpenAsFolder);
+            var actual = testSubject.IsFolderWorkspace();
+            actual.Should().Be(isOpenAsFolder == true);
         }
 
         [TestMethod]

--- a/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
+++ b/src/Infrastructure.VS.UnitTests/SolutionInfoProviderTests.cs
@@ -263,11 +263,11 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
         }
 
         [TestMethod]
-        public async Task IsSolutionFullyOpenAsync_ServiceCalledOnUIThread()
+        public async Task IsFolderWorkspaceAsync_ServiceCalledOnUIThread()
         {
             var calls = new List<string>();
 
-            var solution = CreateIVsSolutionWithIsFullyOpened(true, callback: () => calls.Add("GetSolutionIsFullyOpen"));
+            var solution = CreateIVsSolutionWithIsFullyOpened(true, callback: () => calls.Add("GetIsFolderWorkspace"));
             var serviceProvider = CreateServiceProviderWithSolution(solution.Object, () => calls.Add("GetService"));
 
             var threadHandling = new Mock<IThreadHandling>();
@@ -282,7 +282,7 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
 
             var actual = await testSubject.IsSolutionFullyOpenedAsync();
 
-            calls.Should().ContainInOrder("switch to UI thread", "GetService", "GetSolutionIsFullyOpen");
+            calls.Should().ContainInOrder("switch to UI thread", "GetService", "GetIsFolderWorkspace");
         }
 
         [TestMethod]
@@ -352,6 +352,29 @@ namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
             var actual = await testSubject.IsSolutionFullyOpenedAsync();
 
             calls.Should().ContainInOrder("switch to UI thread", "GetService", "GetSolutionIsFullyOpen");
+        }
+
+        [TestMethod]
+        public async Task IsFolderWorkspacec_ServiceCalledOnUIThread()
+        {
+            var calls = new List<string>();
+
+            var solution = CreateIVsSolutionWithIsFullyOpened(true, callback: () => calls.Add("GetIsFolderWorkspace"));
+            var serviceProvider = CreateServiceProviderWithSolution(solution.Object, () => calls.Add("GetService"));
+
+            var threadHandling = new Mock<IThreadHandling>();
+            threadHandling.Setup(x => x.RunOnUIThreadAsync(It.IsAny<Action>()))
+                .Callback<Action>(productOperation =>
+                {
+                    calls.Add("switch to UI thread");
+                    productOperation.Invoke();
+                });
+
+            var testSubject = CreateTestSubject(serviceProvider.Object, threadHandling.Object);
+
+            var actual = await testSubject.IsSolutionFullyOpenedAsync();
+
+            calls.Should().ContainInOrder("switch to UI thread", "GetService", "GetIsFolderWorkspace");
         }
 
         private static SolutionInfoProvider CreateTestSubject(IServiceProvider serviceProvider,

--- a/src/Infrastructure.VS/FolderWorkspaceService.cs
+++ b/src/Infrastructure.VS/FolderWorkspaceService.cs
@@ -32,29 +32,17 @@ namespace SonarLint.VisualStudio.Infrastructure.VS
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal class FolderWorkspaceService : IFolderWorkspaceService
     {
-        /// <summary>
-        /// See https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.__vspropid7?view=visualstudiosdk-2019
-        /// The enum is not available in VS 2015 API.
-        /// </summary>
-        internal const int VSPROPID_IsInOpenFolderMode = -8044;
-
-        private readonly IVsSolution vsSolution;
         private readonly ISolutionInfoProvider solutionInfoProvider;
 
         [ImportingConstructor]
-        public FolderWorkspaceService([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider, ISolutionInfoProvider solutionInfoProvider)
+        public FolderWorkspaceService(ISolutionInfoProvider solutionInfoProvider)
         {
-            vsSolution = serviceProvider.GetService(typeof(SVsSolution)) as IVsSolution;
             this.solutionInfoProvider = solutionInfoProvider;
         }
 
         public bool IsFolderWorkspace()
         {
-            // "Open as Folder" was introduced in VS2017, so in VS2015 the hr result will be `E_NOTIMPL` and `isOpenAsFolder` will be null.
-            var hr = vsSolution.GetProperty(VSPROPID_IsInOpenFolderMode, out var isOpenAsFolder);
-            Debug.Assert(hr == VSConstants.S_OK, "Failed to retrieve VSPROPID_IsInOpenFolderMode");
-
-            return isOpenAsFolder != null && (bool)isOpenAsFolder;
+            return solutionInfoProvider.IsFolderWorkspace();
         }
 
         public string FindRootDirectory()


### PR DESCRIPTION
Remove calls to GetService from Importing Constructor.

part of https://github.com/SonarSource/sonarlint-visualstudio/issues/4842