### PR TITLE
EnsureHtmlIsXml column cleaner regexp mistakenly matches too much

### DIFF
--- a/src/Education.UnitTests/XamlGenerator/RuleXamlBuilderSmokeTest.cs
+++ b/src/Education.UnitTests/XamlGenerator/RuleXamlBuilderSmokeTest.cs
@@ -52,29 +52,21 @@ public class RuleXamlBuilderSmokeTest
         Console.WriteLine("Checking xaml creation. Count = " + resourceNames.Count());
 
         string[] failures;
-        using(new AssertIgnoreScope()) // the product code can assert if it encounters an unrecognised tag
+        using (new AssertIgnoreScope()) // the product code can assert if it encounters an unrecognised tag
         {
             failures = resourceNames.Where(x => !ProcessResource(x))
                 .ToArray();
         }
-        
+
         failures.Should().BeEquivalentTo(new[]
         {
             // introduced in sonar-cpp 6.48
             "SonarLint.VisualStudio.Rules.Embedded.cpp.S1232.json",
-            // introduced in dotnet analyzer 9.5
-            "SonarLint.VisualStudio.Rules.Embedded.csharpsquid.S4433.json",
-            // possible issues with EnsureHtmlIsXml regexp in rich rule description, need to investigate (same issue for all 5332 rules)
-            "SonarLint.VisualStudio.Rules.Embedded.cpp.S5332.json",
-            "SonarLint.VisualStudio.Rules.Embedded.c.S5332.json",
-            "SonarLint.VisualStudio.Rules.Embedded.csharpsquid.S5332.json",
-            "SonarLint.VisualStudio.Rules.Embedded.javascript.S5332.json",
-            "SonarLint.VisualStudio.Rules.Embedded.typescript.S5332.json",
             // some issue with diff highlighting
             "SonarLint.VisualStudio.Rules.Embedded.csharpsquid.S6640.json",
         });
     }
-    
+
     private static bool ProcessResource(string fullResourceName)
     {
         var xamlWriterFactory = new XamlWriterFactory();
@@ -82,14 +74,14 @@ public class RuleXamlBuilderSmokeTest
         var xamlGeneratorHelperFactory = new XamlGeneratorHelperFactory(ruleHelpXamlTranslatorFactory);
         var ruleInfoTranslator = new RuleInfoTranslator(ruleHelpXamlTranslatorFactory, new TestLogger());
         var staticXamlStorage = new StaticXamlStorage(ruleHelpXamlTranslatorFactory);
-        
+
         var simpleXamlBuilder = new SimpleRuleHelpXamlBuilder(ruleHelpXamlTranslatorFactory, xamlGeneratorHelperFactory, xamlWriterFactory);
         var richXamlBuilder = new RichRuleHelpXamlBuilder(ruleInfoTranslator, xamlGeneratorHelperFactory, staticXamlStorage, xamlWriterFactory);
-        
+
         try
         {
             bool res = false;
-            
+
             var data = ReadResource(fullResourceName);
             var jsonRuleInfo = LocalRuleMetadataProvider.RuleInfoJsonDeserializer.Deserialize(data);
 
@@ -104,7 +96,7 @@ public class RuleXamlBuilderSmokeTest
                 Res(richXamlBuilder.Create(jsonRuleInfo, null));
                 res = true;
             }
-            
+
             return res; // simple || rich should be true
         }
         catch (Exception ex)

--- a/src/Rules.UnitTests/HtmlXmlCompatibilityHelperTests.cs
+++ b/src/Rules.UnitTests/HtmlXmlCompatibilityHelperTests.cs
@@ -29,15 +29,31 @@ namespace SonarLint.VisualStudio.Rules.UnitTests
         [TestMethod]
         public void EnsureHtmlIsXml_ClosesBr()
         {
-            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<br> < br >Hi").Should().BeEquivalentTo("Lalala<br/> < br />Hi");
+            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<br> < br >Hi <br>").Should().BeEquivalentTo("Lalala<br/> < br />Hi");
+        }
+
+        [TestMethod]
+        public void EnsureHtmlIsXml_ShouldNotMatchBrInText()
+        {
+            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("<p>some text with br in it <em>SASL</em>")
+                .Should()
+                .BeEquivalentTo("<p>some text with br in it <em>SASL</em>");
         }
 
         [TestMethod]
         public void EnsureHtmlIsXml_ClosesCol()
         {
-            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<col span=\"2\" style=\"background-color:red\">Hi")
+            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<col span=\"2\" style=\"background-color:red\">Hi <  col > hello")
                 .Should()
-                .BeEquivalentTo("Lalala<col span=\"2\" style=\"background-color:red\"/>Hi");
+                .BeEquivalentTo("Lalala<col span=\"2\" style=\"background-color:red\"/>Hi <  col /> hello <col/>");
+        }
+
+        [TestMethod]
+        public void EnsureHtmlIsXml_ShouldNotMatchColInText()
+        {
+            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("<p>Lightweight Directory Access Protocol (LDAP) servers provide two main authentication methods: the <em>SASL</em>")
+                .Should()
+                .BeEquivalentTo("<p>Lightweight Directory Access Protocol (LDAP) servers provide two main authentication methods: the <em>SASL</em>");
         }
 
         [TestMethod]

--- a/src/Rules.UnitTests/HtmlXmlCompatibilityHelperTests.cs
+++ b/src/Rules.UnitTests/HtmlXmlCompatibilityHelperTests.cs
@@ -29,7 +29,7 @@ namespace SonarLint.VisualStudio.Rules.UnitTests
         [TestMethod]
         public void EnsureHtmlIsXml_ClosesBr()
         {
-            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<br> < br >Hi <br>").Should().BeEquivalentTo("Lalala<br/> < br />Hi");
+            HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<br> < br >Hi").Should().BeEquivalentTo("Lalala<br/> < br />Hi");
         }
 
         [TestMethod]
@@ -45,7 +45,7 @@ namespace SonarLint.VisualStudio.Rules.UnitTests
         {
             HtmlXmlCompatibilityHelper.EnsureHtmlIsXml("Lalala<col span=\"2\" style=\"background-color:red\">Hi <  col > hello")
                 .Should()
-                .BeEquivalentTo("Lalala<col span=\"2\" style=\"background-color:red\"/>Hi <  col /> hello <col/>");
+                .BeEquivalentTo("Lalala<col span=\"2\" style=\"background-color:red\"/>Hi <  col /> hello");
         }
 
         [TestMethod]

--- a/src/Rules/HtmlXmlCompatibilityHelper.cs
+++ b/src/Rules/HtmlXmlCompatibilityHelper.cs
@@ -30,11 +30,11 @@ namespace SonarLint.VisualStudio.Rules
         // the empty elements and replace them with elements with closing tags
         // e.g. <br>  =>  <br/>
         // e.g. <col span="123">  =>  <col span="123"/>
-        private static readonly Regex CleanCol = new Regex("(?<element>(<col\\s*)|(col\\s+[^/^>]*))>",
+        private static readonly Regex CleanCol = new Regex("(?<element>(<\\s*col\\s*)|(<\\s*col\\s+[^/^>]*))>",
             RegexOptions.Compiled,
             Core.RegexConstants.DefaultTimeout);
 
-        private static readonly Regex CleanBr = new Regex("(?<element>(<br\\s*)|(br\\s+[^/^>]*))>",
+        private static readonly Regex CleanBr = new Regex("(?<element>(<\\s*br\\s*)|(<\\s*br\\s+[^/^>]*))>",
             RegexOptions.Compiled,
             Core.RegexConstants.DefaultTimeout);
 


### PR DESCRIPTION
Fixes #4605
