### PR TITLE
Convert SuppressedIssueMatcher to IssueMatcher, return SonarQubeIssue instead of boolean

### DIFF
--- a/src/ConnectedMode.UnitTests/Suppressions/ClientSuppressionSynchronizerTests.cs
+++ b/src/ConnectedMode.UnitTests/Suppressions/ClientSuppressionSynchronizerTests.cs
@@ -21,10 +21,13 @@
 using System;
 using System.Collections.Generic;
 using SonarLint.VisualStudio.ConnectedMode.Suppressions;
+using SonarLint.VisualStudio.ConnectedMode.Synchronization;
+using SonarLint.VisualStudio.ConnectedMode.UnitTests.Helpers;
 using SonarLint.VisualStudio.Core.Suppressions;
 using SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.TestInfrastructure;
+using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
 {
@@ -36,7 +39,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
         {
             MefTestHelpers.CheckTypeCanBeImported<ClientSuppressionSynchronizer, IClientSuppressionSynchronizer>(
                 MefTestHelpers.CreateExport<IIssueLocationStoreAggregator>(),
-                MefTestHelpers.CreateExport<ISuppressedIssueMatcher>());
+                MefTestHelpers.CreateExport<IIssueMatcher>());
         }
 
         [TestMethod]
@@ -184,13 +187,26 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
             return issuesStore.Object;
         }
 
-        private static ISuppressedIssueMatcher CreateSuppressedIssueMatcher(params IFilterableIssue[] matches)
+        private static IIssueMatcher CreateSuppressedIssueMatcher(params IFilterableIssue[] matches)
         {
-            var suppressedIssuesMatcher = new Mock<ISuppressedIssueMatcher>();
+            var suppressedIssuesMatcher = new Mock<IIssueMatcher>();
 
             foreach (var match in matches)
             {
-                suppressedIssuesMatcher.Setup(x => x.SuppressionExists(match)).Returns(true);
+                suppressedIssuesMatcher
+                    .Setup(x => x.Match(match))
+                    .Returns(new SonarQubeIssue(default, 
+                        default, 
+                        default, 
+                        default, 
+                        default, 
+                        default, 
+                        true, // suppressed issue
+                        default,
+                        default,
+                        default,
+                        default,
+                        default));
             }
 
             return suppressedIssuesMatcher.Object;

--- a/src/ConnectedMode/Suppressions/ClientSuppressionSynchronizer.cs
+++ b/src/ConnectedMode/Suppressions/ClientSuppressionSynchronizer.cs
@@ -23,6 +23,7 @@ using SonarLint.VisualStudio.Core.Suppressions;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using System.Collections.Generic;
 using System;
+using SonarLint.VisualStudio.ConnectedMode.Synchronization;
 using SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging;
 
 namespace SonarLint.VisualStudio.ConnectedMode.Suppressions
@@ -32,15 +33,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.Suppressions
     internal class ClientSuppressionSynchronizer : IClientSuppressionSynchronizer
     {
         private readonly IIssueLocationStoreAggregator issuesStore;
-        private readonly ISuppressedIssueMatcher suppressedIssueMatcher;
+        private readonly IIssueMatcher issueMatcher;
 
         public event EventHandler<LocalSuppressionsChangedEventArgs> LocalSuppressionsChanged;
 
         [ImportingConstructor]
-        public ClientSuppressionSynchronizer(IIssueLocationStoreAggregator issuesStore, ISuppressedIssueMatcher suppressedIssueMatcher)
+        public ClientSuppressionSynchronizer(IIssueLocationStoreAggregator issuesStore, IIssueMatcher issueMatcher)
         {
             this.issuesStore = issuesStore;
-            this.suppressedIssueMatcher = suppressedIssueMatcher;
+            this.issueMatcher = issueMatcher;
         }
 
         public void SynchronizeSuppressedIssues()
@@ -54,7 +55,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Suppressions
                 var issueViz = issue as IAnalysisIssueVisualization;
 
                 // If the object was matched then it is suppressed on the server
-                var newIsSuppressedValue = suppressedIssueMatcher.SuppressionExists(issueViz);
+                var newIsSuppressedValue = issueMatcher.Match(issueViz)?.IsResolved ?? false;
 
                 if (issueViz.IsSuppressed != newIsSuppressedValue)
                 {

--- a/src/Integration.Vsix.UnitTests/Analysis/IssueConsumerFactoryTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/IssueConsumerFactoryTests.cs
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.Text;
 using Moq;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.ConnectedMode.Suppressions;
+using SonarLint.VisualStudio.ConnectedMode.Synchronization;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using SonarLint.VisualStudio.IssueVisualization.Models;
@@ -40,7 +41,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Analysis
         public void MefCtor_CheckIsExported()
         {
             MefTestHelpers.CheckTypeCanBeImported<IssueConsumerFactory, IIssueConsumerFactory>(
-                MefTestHelpers.CreateExport<ISuppressedIssueMatcher>(),
+                MefTestHelpers.CreateExport<IIssueMatcher>(),
                 MefTestHelpers.CreateExport<IAnalysisIssueVisualizationConverter>(),
                 MefTestHelpers.CreateExport<ILocalHotspotsStoreUpdater>());
         }
@@ -48,7 +49,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Analysis
         [TestMethod]
         public void Create_InitializedIssueConsumerReturned()
         {
-            var testSubject = new IssueConsumerFactory(Mock.Of<ISuppressedIssueMatcher>(), Mock.Of<IAnalysisIssueVisualizationConverter>(), Mock.Of<ILocalHotspotsStoreUpdater>());
+            var testSubject = new IssueConsumerFactory(Mock.Of<IIssueMatcher>(), Mock.Of<IAnalysisIssueVisualizationConverter>(), Mock.Of<ILocalHotspotsStoreUpdater>());
 
             IIssuesSnapshot publishedSnaphot = null;
             var consumer = testSubject.Create(CreateValidTextDocument("file.txt"), "project name", Guid.NewGuid(), x => { publishedSnaphot = x; });

--- a/src/Integration.Vsix/Analysis/IssueConsumerFactory.cs
+++ b/src/Integration.Vsix/Analysis/IssueConsumerFactory.cs
@@ -21,7 +21,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.ConnectedMode.Suppressions;
+using SonarLint.VisualStudio.ConnectedMode.Synchronization;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
@@ -50,12 +50,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal partial class IssueConsumerFactory : IIssueConsumerFactory
     {
-        private readonly ISuppressedIssueMatcher suppressedIssueMatcher;
+        private readonly IIssueMatcher suppressedIssueMatcher;
         private readonly IAnalysisIssueVisualizationConverter converter;
         private readonly ILocalHotspotsStoreUpdater localHotspotsStore;
 
         [ImportingConstructor]
-        internal IssueConsumerFactory(ISuppressedIssueMatcher suppressedIssueMatcher, IAnalysisIssueVisualizationConverter converter, ILocalHotspotsStoreUpdater localHotspotsStore)
+        internal IssueConsumerFactory(IIssueMatcher suppressedIssueMatcher, IAnalysisIssueVisualizationConverter converter, ILocalHotspotsStoreUpdater localHotspotsStore)
         {
             this.suppressedIssueMatcher = suppressedIssueMatcher;
             this.converter = converter;


### PR DESCRIPTION
Fixes #5042 
Part of #5040
