### PR TITLE
Revert "Convert SuppressedIssueMatcher to IssueMatcher, return SonarQubeIssue instead of boolean"

### DIFF
--- a/src/ConnectedMode.UnitTests/Suppressions/ClientSuppressionSynchronizerTests.cs
+++ b/src/ConnectedMode.UnitTests/Suppressions/ClientSuppressionSynchronizerTests.cs
@@ -21,13 +21,10 @@
 using System;
 using System.Collections.Generic;
 using SonarLint.VisualStudio.ConnectedMode.Suppressions;
-using SonarLint.VisualStudio.ConnectedMode.Synchronization;
-using SonarLint.VisualStudio.ConnectedMode.UnitTests.Helpers;
 using SonarLint.VisualStudio.Core.Suppressions;
 using SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.TestInfrastructure;
-using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
 {
@@ -39,7 +36,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
         {
             MefTestHelpers.CheckTypeCanBeImported<ClientSuppressionSynchronizer, IClientSuppressionSynchronizer>(
                 MefTestHelpers.CreateExport<IIssueLocationStoreAggregator>(),
-                MefTestHelpers.CreateExport<IIssueMatcher>());
+                MefTestHelpers.CreateExport<ISuppressedIssueMatcher>());
         }
 
         [TestMethod]
@@ -187,26 +184,13 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Suppressions
             return issuesStore.Object;
         }
 
-        private static IIssueMatcher CreateSuppressedIssueMatcher(params IFilterableIssue[] matches)
+        private static ISuppressedIssueMatcher CreateSuppressedIssueMatcher(params IFilterableIssue[] matches)
         {
-            var suppressedIssuesMatcher = new Mock<IIssueMatcher>();
+            var suppressedIssuesMatcher = new Mock<ISuppressedIssueMatcher>();
 
             foreach (var match in matches)
             {
-                suppressedIssuesMatcher
-                    .Setup(x => x.Match(match))
-                    .Returns(new SonarQubeIssue(default, 
-                        default, 
-                        default, 
-                        default, 
-                        default, 
-                        default, 
-                        true, // suppressed issue
-                        default,
-                        default,
-                        default,
-                        default,
-                        default));
+                suppressedIssuesMatcher.Setup(x => x.SuppressionExists(match)).Returns(true);
             }
 
             return suppressedIssuesMatcher.Object;

--- a/src/ConnectedMode/Suppressions/ClientSuppressionSynchronizer.cs
+++ b/src/ConnectedMode/Suppressions/ClientSuppressionSynchronizer.cs
@@ -23,7 +23,6 @@ using SonarLint.VisualStudio.Core.Suppressions;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using System.Collections.Generic;
 using System;
-using SonarLint.VisualStudio.ConnectedMode.Synchronization;
 using SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging;
 
 namespace SonarLint.VisualStudio.ConnectedMode.Suppressions
@@ -33,15 +32,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.Suppressions
     internal class ClientSuppressionSynchronizer : IClientSuppressionSynchronizer
     {
         private readonly IIssueLocationStoreAggregator issuesStore;
-        private readonly IIssueMatcher issueMatcher;
+        private readonly ISuppressedIssueMatcher suppressedIssueMatcher;
 
         public event EventHandler<LocalSuppressionsChangedEventArgs> LocalSuppressionsChanged;
 
         [ImportingConstructor]
-        public ClientSuppressionSynchronizer(IIssueLocationStoreAggregator issuesStore, IIssueMatcher issueMatcher)
+        public ClientSuppressionSynchronizer(IIssueLocationStoreAggregator issuesStore, ISuppressedIssueMatcher suppressedIssueMatcher)
         {
             this.issuesStore = issuesStore;
-            this.issueMatcher = issueMatcher;
+            this.suppressedIssueMatcher = suppressedIssueMatcher;
         }
 
         public void SynchronizeSuppressedIssues()
@@ -55,7 +54,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Suppressions
                 var issueViz = issue as IAnalysisIssueVisualization;
 
                 // If the object was matched then it is suppressed on the server
-                var newIsSuppressedValue = issueMatcher.Match(issueViz)?.IsResolved ?? false;
+                var newIsSuppressedValue = suppressedIssueMatcher.SuppressionExists(issueViz);
 
                 if (issueViz.IsSuppressed != newIsSuppressedValue)
                 {

--- a/src/Integration.Vsix.UnitTests/Analysis/IssueConsumerFactoryTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/IssueConsumerFactoryTests.cs
@@ -25,7 +25,6 @@ using Microsoft.VisualStudio.Text;
 using Moq;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.ConnectedMode.Suppressions;
-using SonarLint.VisualStudio.ConnectedMode.Synchronization;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using SonarLint.VisualStudio.IssueVisualization.Models;
@@ -41,7 +40,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Analysis
         public void MefCtor_CheckIsExported()
         {
             MefTestHelpers.CheckTypeCanBeImported<IssueConsumerFactory, IIssueConsumerFactory>(
-                MefTestHelpers.CreateExport<IIssueMatcher>(),
+                MefTestHelpers.CreateExport<ISuppressedIssueMatcher>(),
                 MefTestHelpers.CreateExport<IAnalysisIssueVisualizationConverter>(),
                 MefTestHelpers.CreateExport<ILocalHotspotsStoreUpdater>());
         }
@@ -49,7 +48,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Analysis
         [TestMethod]
         public void Create_InitializedIssueConsumerReturned()
         {
-            var testSubject = new IssueConsumerFactory(Mock.Of<IIssueMatcher>(), Mock.Of<IAnalysisIssueVisualizationConverter>(), Mock.Of<ILocalHotspotsStoreUpdater>());
+            var testSubject = new IssueConsumerFactory(Mock.Of<ISuppressedIssueMatcher>(), Mock.Of<IAnalysisIssueVisualizationConverter>(), Mock.Of<ILocalHotspotsStoreUpdater>());
 
             IIssuesSnapshot publishedSnaphot = null;
             var consumer = testSubject.Create(CreateValidTextDocument("file.txt"), "project name", Guid.NewGuid(), x => { publishedSnaphot = x; });

--- a/src/Integration.Vsix/Analysis/IssueConsumerFactory.cs
+++ b/src/Integration.Vsix/Analysis/IssueConsumerFactory.cs
@@ -21,7 +21,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.ConnectedMode.Synchronization;
+using SonarLint.VisualStudio.ConnectedMode.Suppressions;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
@@ -50,12 +50,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal partial class IssueConsumerFactory : IIssueConsumerFactory
     {
-        private readonly IIssueMatcher suppressedIssueMatcher;
+        private readonly ISuppressedIssueMatcher suppressedIssueMatcher;
         private readonly IAnalysisIssueVisualizationConverter converter;
         private readonly ILocalHotspotsStoreUpdater localHotspotsStore;
 
         [ImportingConstructor]
-        internal IssueConsumerFactory(IIssueMatcher suppressedIssueMatcher, IAnalysisIssueVisualizationConverter converter, ILocalHotspotsStoreUpdater localHotspotsStore)
+        internal IssueConsumerFactory(ISuppressedIssueMatcher suppressedIssueMatcher, IAnalysisIssueVisualizationConverter converter, ILocalHotspotsStoreUpdater localHotspotsStore)
         {
             this.suppressedIssueMatcher = suppressedIssueMatcher;
             this.converter = converter;

--- a/src/Integration.Vsix/Analysis/IssueConsumerFactory_IssueHandler.cs
+++ b/src/Integration.Vsix/Analysis/IssueConsumerFactory_IssueHandler.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
-using SonarLint.VisualStudio.ConnectedMode.Synchronization;
+using SonarLint.VisualStudio.ConnectedMode.Suppressions;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
@@ -41,7 +41,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             private readonly ITextDocument textDocument;
             private readonly string projectName;
             private readonly Guid projectGuid;
-            private readonly IIssueMatcher suppressedIssueMatcher;
+            private readonly ISuppressedIssueMatcher suppressedIssueMatcher;
             private readonly SnapshotChangedHandler onSnapshotChanged;
             private readonly ILocalHotspotsStoreUpdater localHotspotsStore;
 
@@ -50,7 +50,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             public IssueHandler(ITextDocument textDocument,
                 string projectName,
                 Guid projectGuid,
-                IIssueMatcher suppressedIssueMatcher,
+                ISuppressedIssueMatcher suppressedIssueMatcher,
                 SnapshotChangedHandler onSnapshotChanged,
                 ILocalHotspotsStoreUpdater localHotspotsStore)
                 : this (textDocument, projectName, projectGuid, suppressedIssueMatcher, onSnapshotChanged, localHotspotsStore, DoTranslateSpans)
@@ -60,7 +60,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             internal /* for testing */ IssueHandler(ITextDocument textDocument,
                 string projectName,
                 Guid projectGuid,
-                IIssueMatcher suppressedIssueMatcher,
+                ISuppressedIssueMatcher suppressedIssueMatcher,
                 SnapshotChangedHandler onSnapshotChanged,
                 ILocalHotspotsStoreUpdater localHotspotsStore,
                 TranslateSpans translateSpans)
@@ -77,7 +77,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
 
             internal /* for testing */ void HandleNewIssues(IEnumerable<IAnalysisIssueVisualization> issues)
             {
-                MatchServerIssues(issues);
+                MarkSuppressedIssues(issues);
 
                 // The text buffer might have changed since the analysis was triggered, so translate
                 // all issues to the current snapshot.
@@ -99,11 +99,11 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
                 onSnapshotChanged(newSnapshot);
             }
 
-            private void MatchServerIssues(IEnumerable<IAnalysisIssueVisualization> issues)
+            private void MarkSuppressedIssues(IEnumerable<IAnalysisIssueVisualization> issues)
             {
                 foreach (var issue in issues)
                 {
-                    issue.IsSuppressed = suppressedIssueMatcher.Match(issue)?.IsResolved ?? false;
+                    issue.IsSuppressed = suppressedIssueMatcher.SuppressionExists(issue);
                 }
             }
 


### PR DESCRIPTION
Not needed anymore, we went in a different direction with issue fetching for muting