### PR TITLE
Change SLCoreInstanceHandle & SLCoreConstantsProvider to disable telemetry as part of initialization

### DIFF
--- a/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
+++ b/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
@@ -63,7 +63,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SLCore
         [TestMethod]
         public void FeatureFlags_ShouldBeExpected()
         {
-            var expectedFeatureFlags = new FeatureFlagsDto(true, true, false, true, false, false, true);
+            var expectedFeatureFlags = new FeatureFlagsDto(true, true, false, true, false, false, true, false);
             var result = testSubject.FeatureFlags;
 
             result.Should().BeEquivalentTo(expectedFeatureFlags);

--- a/src/Integration/SLCore/SLCoreConstantsProvider.cs
+++ b/src/Integration/SLCore/SLCoreConstantsProvider.cs
@@ -31,7 +31,7 @@ namespace SonarLint.VisualStudio.Integration.SLCore
     {
         public ClientConstantsDto ClientConstants => new ClientConstantsDto("SonarLint for Visual Studio", $"SonarLint Visual Studio/{VersionHelper.SonarLintVersion}");
 
-        public FeatureFlagsDto FeatureFlags => new FeatureFlagsDto(true, true, false, true, false, false, true);
+        public FeatureFlagsDto FeatureFlags => new FeatureFlagsDto(true, true, false, true, false, false, true, false);
 
         //We do not support telemetry now
         public TelemetryClientConstantAttributesDto TelemetryConstants => new TelemetryClientConstantAttributesDto("SLVS_SHOULD_NOT_SEND_TELEMETRY", default, default, default, default);

--- a/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
+++ b/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
@@ -82,7 +82,7 @@ public sealed class SLCoreTestRunner : IDisposable
             var constantsProvider = Substitute.For<ISLCoreConstantsProvider>();
             constantsProvider.ClientConstants.Returns(new ClientConstantsDto("SLVS_Integration_Tests",
                 $"SLVS_Integration_Tests/{VersionHelper.SonarLintVersion}"));
-            constantsProvider.FeatureFlags.Returns(new FeatureFlagsDto(true, true, false, true, false, false, true));
+            constantsProvider.FeatureFlags.Returns(new FeatureFlagsDto(true, true, false, true, false, false, true, false));
             constantsProvider.TelemetryConstants.Returns(new TelemetryClientConstantAttributesDto("slvs_integration_tests", "SLVS Integration Tests",
                 VersionHelper.SonarLintVersion, "16.0", new()));
 

--- a/src/SLCore.UnitTests/Service/Lifecycle/InitializeParamsTests.cs
+++ b/src/SLCore.UnitTests/Service/Lifecycle/InitializeParamsTests.cs
@@ -37,7 +37,7 @@ public class InitializeParamsTests
         var testSubject = new InitializeParams(
             new ClientConstantsDto("TESTname", "TESTagent"),
             new HttpConfigurationDto(new SslConfigurationDto()),
-            new FeatureFlagsDto(false, true, false, true, false, true, false),
+            new FeatureFlagsDto(false, true, false, true, false, true, false, false),
             "storageRoot",
             "workDir",
             new List<string> { "myplugin1", "myplugin2" },
@@ -73,7 +73,8 @@ public class InitializeParamsTests
                                     "enableSecurityHotspots": true,
                                     "shouldManageServerSentEvents": false,
                                     "enableDataflowBugDetection": true,
-                                    "shouldManageFullSynchronization": false
+                                    "shouldManageFullSynchronization": false,
+                                    "enableTelemetry": false
                                   },
                                   "storageRoot": "storageRoot",
                                   "workDir": "workDir",

--- a/src/SLCore/ISLCoreInstanceHandle.cs
+++ b/src/SLCore/ISLCoreInstanceHandle.cs
@@ -76,8 +76,7 @@ internal sealed class SLCoreInstanceHandle : ISLCoreInstanceHandle
 
         SLCoreRpc = slCoreRpcFactory.StartNewRpcInstance();
 
-        if (!SLCoreRpc.ServiceProvider.TryGetTransientService(out ILifecycleManagementSLCoreService lifecycleManagementSlCoreService) ||
-            !SLCoreRpc.ServiceProvider.TryGetTransientService(out ITelemetrySLCoreService telemetrySlCoreService))
+        if (!SLCoreRpc.ServiceProvider.TryGetTransientService(out ILifecycleManagementSLCoreService lifecycleManagementSlCoreService))
         {
             throw new InvalidOperationException(SLCoreStrings.ServiceProviderNotInitialized);
         }
@@ -112,8 +111,6 @@ internal sealed class SLCoreInstanceHandle : ISLCoreInstanceHandle
             isFocusOnNewCode: false,
             constantsProvider.TelemetryConstants,
             null));
-
-        telemetrySlCoreService.DisableTelemetry();
 
         configScopeUpdater.UpdateConfigScopeForCurrentSolution(activeSolutionBoundTracker.CurrentConfiguration.Project);
     }

--- a/src/SLCore/Service/Lifecycle/Models/FeatureFlagsDto.cs
+++ b/src/SLCore/Service/Lifecycle/Models/FeatureFlagsDto.cs
@@ -27,5 +27,6 @@ namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models
         bool enableSecurityHotspots,
         bool shouldManageServerSentEvents,
         bool enableDataflowBugDetection,
-        bool shouldManageFullSynchronization);
+        bool shouldManageFullSynchronization,
+        bool enableTelemetry);
 }

--- a/src/SLCore/Service/Telemetry/ITelemetrySLCoreService.cs
+++ b/src/SLCore/Service/Telemetry/ITelemetrySLCoreService.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.SLCore.Core;
 using SonarLint.VisualStudio.SLCore.Protocol;
 


### PR DESCRIPTION
Fixes #5264
