### PR TITLE
Change vs22/vsixmanifest version to 8.0

### DIFF
--- a/src/Integration.Vsix/Manifests/VS2022/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2022/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
-        <Identity Id="SonarLint.0DE19254-1DCA-4479-8EAF-58E5D677FF4D" Version="7.8.0.0" Language="en-US" Publisher="SonarSource" />
+        <Identity Id="SonarLint.0DE19254-1DCA-4479-8EAF-58E5D677FF4D" Version="8.0.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarLint for Visual Studio 2022</DisplayName>
         <Preview>false</Preview>
       <Description xml:space="preserve">Linter to detect and fix coding issues locally in C#, VB.NET, C, C++, JS, TS and CSS code. Use with SonarQube and SonarCloud for optimal team performance.</Description>


### PR DESCRIPTION
Fixes a problem introduced by https://github.com/SonarSource/sonarlint-visualstudio/commit/a5c28455c4191a55c2958f6bf75b7505c2521265
