### PR TITLE
Disable rule command does not have CSS in the supported languages list

### DIFF
--- a/src/Integration.Vsix.UnitTests/Analysis/DisableRuleCommandTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/DisableRuleCommandTests.cs
@@ -18,18 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.ComponentModel.Design;
-using FluentAssertions;
 using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Secrets;
 using SonarLint.VisualStudio.Infrastructure.VS;
-using SonarLint.VisualStudio.TestInfrastructure;
 using SonarLint.VisualStudio.Integration.UnitTests;
 using ThreadHelper = SonarLint.VisualStudio.TestInfrastructure.ThreadHelper;
 
@@ -92,6 +86,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
         [DataRow("c:S222")]
         [DataRow("javascript:S333")]
         [DataRow("typescript:S444")]
+        [DataRow("css:S777")]
         [DataRow("secrets:S555")]
         public void CheckStatusAndExecute_SingleIssue_SupportedRepo_StandaloneMode_VisibleAndEnabled(string errorCode)
         {
@@ -126,6 +121,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
         [DataRow("javascript:S111", SonarLintMode.LegacyConnected, false)]
         [DataRow("typescript:S111", SonarLintMode.Connected, false)]
         [DataRow("typescript:S111", SonarLintMode.LegacyConnected, false)]
+        [DataRow("css:S111", SonarLintMode.Connected, false)]
+        [DataRow("css:S111", SonarLintMode.LegacyConnected, false)]
         public void CheckStatus_SingleIssue_SupportedRepo_ConnectedMode_HasExpectedEnabledStatus(string errorCode, SonarLintMode bindingMode,
             bool expectedEnabled)
         {

--- a/src/Integration.Vsix/Analysis/DisableRuleCommand.cs
+++ b/src/Integration.Vsix/Analysis/DisableRuleCommand.cs
@@ -152,6 +152,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             SonarRuleRepoKeys.Cpp,
             SonarRuleRepoKeys.JavaScript,
             SonarRuleRepoKeys.TypeScript,
+            SonarRuleRepoKeys.Css,
             SonarRuleRepoKeys.Secrets
         };
 

--- a/src/Integration.Vsix/Analysis/DisableRuleCommand.cs
+++ b/src/Integration.Vsix/Analysis/DisableRuleCommand.cs
@@ -17,10 +17,8 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-using System;
+
 using System.ComponentModel.Design;
-using System.Diagnostics;
-using System.Linq;
 using Microsoft.VisualStudio.Shell;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;


### PR DESCRIPTION
Fixes #5072

Wiki changes required:
* Add CSS to the table on `Define C, C++, JS, TS or secrets detection rules for local analysis` section
    https://docs.sonarsource.com/sonarlint/visual-studio/using-sonarlint/rules/

## Overview
On a standalone project with CSS files.

Before this PR:
![5434_before](https://github.com/SonarSource/sonarlint-visualstudio/assets/168648790/a2f293bf-5c02-4d16-a37f-92d0721c4666)

After this PR:
![5434_after](https://github.com/SonarSource/sonarlint-visualstudio/assets/168648790/3796cd58-2734-4f5a-ac09-be26b011f59c)
