### PR TITLE
 Move common, test and product, global usings to Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,4 +21,13 @@
     </AdditionalFiles>
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Diagnostics" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+
 </Project>

--- a/src/SonarLint.Product.props
+++ b/src/SonarLint.Product.props
@@ -7,14 +7,5 @@
     <RequiresSigning>true</RequiresSigning>
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Using Include="System" />
-    <Using Include="System.Collections.Generic" />
-    <Using Include="System.Diagnostics" />
-    <Using Include="System.Linq" />
-    <Using Include="System.Threading" />
-    <Using Include="System.Threading.Tasks" />
-  </ItemGroup>
   
 </Project>

--- a/src/SonarLint.Test.props
+++ b/src/SonarLint.Test.props
@@ -28,12 +28,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Using Include="System" />
-    <Using Include="System.Collections.Generic" />
-    <Using Include="System.Diagnostics" />
-    <Using Include="System.Linq" />
-    <Using Include="System.Threading" />
-    <Using Include="System.Threading.Tasks" />
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
     <Using Include="NSubstitute" />


### PR DESCRIPTION
Fixes #5426

Based on:
https://github.com/SonarSource/sonarlint-visualstudio/pull/5432#discussion_r1603237273
