### PR TITLE
CaYC: SLCoreRuleMetaDataProvider & ModelExtensions

### DIFF
--- a/src/Education/Rule/SLCoreRuleMetaDataProvider.cs
+++ b/src/Education/Rule/SLCoreRuleMetaDataProvider.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.SLCore.Common.Helpers;
 using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Core;
 using SonarLint.VisualStudio.SLCore.Service.Rules;
@@ -84,7 +85,7 @@ internal class SLCoreRuleMetaDataProvider : IRuleMetaDataProvider
             Convert(effectiveRuleDetailsAsync.defaultImpacts));
 
     private static Dictionary<SoftwareQuality, SoftwareQualitySeverity> Convert(List<ImpactDto> cleanCodeAttribute) => 
-        cleanCodeAttribute?.ToDictionary(x => Convert(x.softwareQuality), x => Convert(x.impactSeverity));
+        cleanCodeAttribute?.ToDictionary(x => Convert(x.softwareQuality), x => x.impactSeverity.ToSoftwareQualitySeverity());
 
 
     private static RuleIssueSeverity Convert(IssueSeverity issueSeverity) =>
@@ -115,15 +116,6 @@ internal class SLCoreRuleMetaDataProvider : IRuleMetaDataProvider
             SLCore.Common.Models.SoftwareQuality.RELIABILITY => SoftwareQuality.Reliability,
             SLCore.Common.Models.SoftwareQuality.SECURITY => SoftwareQuality.Security,
             _ => throw new ArgumentOutOfRangeException(nameof(argSoftwareQuality), argSoftwareQuality, null)
-        };
-
-    private static SoftwareQualitySeverity Convert(ImpactSeverity cleanCodeAttribute) =>
-        cleanCodeAttribute switch
-        {
-            ImpactSeverity.LOW => SoftwareQualitySeverity.Low,
-            ImpactSeverity.MEDIUM => SoftwareQualitySeverity.Medium,
-            ImpactSeverity.HIGH => SoftwareQualitySeverity.High,
-            _ => throw new ArgumentOutOfRangeException(nameof(cleanCodeAttribute), cleanCodeAttribute, null)
         };
 
     private static CleanCodeAttribute? Convert(SLCore.Common.Models.CleanCodeAttribute? cleanCodeAttribute) =>

--- a/src/SLCore.UnitTests/Common/Helpers/ModelConversionExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/ModelConversionExtensionsTests.cs
@@ -25,7 +25,7 @@ using SonarLint.VisualStudio.SLCore.Common.Models;
 namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
 {
     [TestClass]
-    public class ModelExtensionsTests
+    public class ModelConversionExtensionsTests
     {
         [DataRow(IssueSeverity.BLOCKER, AnalysisIssueSeverity.Blocker)]
         [DataRow(IssueSeverity.CRITICAL, AnalysisIssueSeverity.Critical)]
@@ -46,6 +46,17 @@ namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
                 _ = ((IssueSeverity)issueSeverity).ToAnalysisIssueSeverity();
             }
         }
+        
+        [TestMethod]
+        public void ToAnalysisIssueSeverity_ValueOutOfRange_Throws()
+        {
+            var act = () => ((IssueSeverity)1000).ToAnalysisIssueSeverity();
+            act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("""
+                                                                          Unexpected enum value
+                                                                          Parameter name: issueSeverity
+                                                                          Actual value was 1000.
+                                                                          """);
+        }
 
         [DataRow(RuleType.BUG, AnalysisIssueType.Bug)]
         [DataRow(RuleType.CODE_SMELL, AnalysisIssueType.CodeSmell)]
@@ -65,6 +76,17 @@ namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
                 _ = ((RuleType)ruleType).ToAnalysisIssueType();
             }
         }
+        
+        [TestMethod]
+        public void ToAnalysisIssueType_ValueOutOfRange_Throws()
+        {
+            var act = () => ((RuleType)1000).ToAnalysisIssueType();
+            act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("""
+                                                                          Unexpected enum value
+                                                                          Parameter name: ruleType
+                                                                          Actual value was 1000.
+                                                                          """);
+        }
 
         [DataRow(ImpactSeverity.LOW, SoftwareQualitySeverity.Low)]
         [DataRow(ImpactSeverity.MEDIUM, SoftwareQualitySeverity.Medium)]
@@ -82,6 +104,17 @@ namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
             {
                 _ = ((ImpactSeverity)impactSeverity).ToSoftwareQualitySeverity();
             }
+        }
+        
+        [TestMethod]
+        public void ToSoftwareQualitySeverity_ValueOutOfRange_Throws()
+        {
+            var act = () => ((ImpactSeverity)1000).ToSoftwareQualitySeverity();
+            act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("""
+                                                                          Unexpected enum value
+                                                                          Parameter name: impactSeverity
+                                                                          Actual value was 1000.
+                                                                          """);
         }
     }
 }

--- a/src/SLCore.UnitTests/Common/Helpers/ModelConversionExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/ModelConversionExtensionsTests.cs
@@ -43,7 +43,8 @@ namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
         {
             foreach (var issueSeverity in Enum.GetValues(typeof(IssueSeverity)))
             {
-                _ = ((IssueSeverity)issueSeverity).ToAnalysisIssueSeverity();
+                var act = () => ((IssueSeverity)issueSeverity).ToAnalysisIssueSeverity();
+                act.Should().NotThrow();
             }
         }
         
@@ -73,7 +74,8 @@ namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
         {
             foreach (var ruleType in Enum.GetValues(typeof(RuleType)))
             {
-                _ = ((RuleType)ruleType).ToAnalysisIssueType();
+                var act = () => ((RuleType)ruleType).ToAnalysisIssueType();
+                act.Should().NotThrow();
             }
         }
         
@@ -102,7 +104,8 @@ namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers
         {
             foreach (var impactSeverity in Enum.GetValues(typeof(ImpactSeverity)))
             {
-                _ = ((ImpactSeverity)impactSeverity).ToSoftwareQualitySeverity();
+                var act = () => ((ImpactSeverity)impactSeverity).ToSoftwareQualitySeverity();
+                act.Should().NotThrow();
             }
         }
         

--- a/src/SLCore/Common/Helpers/ModelConversionExtensions.cs
+++ b/src/SLCore/Common/Helpers/ModelConversionExtensions.cs
@@ -23,7 +23,7 @@ using SonarLint.VisualStudio.SLCore.Common.Models;
 
 namespace SonarLint.VisualStudio.SLCore.Common.Helpers
 {
-    public static class ModelExtensions
+    public static class ModelConversionExtensions
     {
         public static AnalysisIssueSeverity ToAnalysisIssueSeverity(this IssueSeverity issueSeverity)
         {
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.SLCore.Common.Helpers
                 IssueSeverity.MAJOR => AnalysisIssueSeverity.Major,
                 IssueSeverity.MINOR => AnalysisIssueSeverity.Minor,
                 IssueSeverity.INFO => AnalysisIssueSeverity.Info,
-                _ => throw new ArgumentException(SLCoreStrings.ModelExtensions_UnexpectedValue, nameof(issueSeverity)),
+                _ => throw new ArgumentOutOfRangeException(nameof(issueSeverity), issueSeverity, SLCoreStrings.ModelExtensions_UnexpectedValue),
             };
         }
 
@@ -46,7 +46,7 @@ namespace SonarLint.VisualStudio.SLCore.Common.Helpers
                 RuleType.BUG => AnalysisIssueType.Bug,
                 RuleType.VULNERABILITY => AnalysisIssueType.Vulnerability,
                 RuleType.SECURITY_HOTSPOT => AnalysisIssueType.SecurityHotspot,
-                _ => throw new ArgumentException(SLCoreStrings.ModelExtensions_UnexpectedValue, nameof(ruleType)),
+                _ => throw new ArgumentOutOfRangeException(nameof(ruleType), ruleType, SLCoreStrings.ModelExtensions_UnexpectedValue),
             };
         }
 
@@ -57,7 +57,7 @@ namespace SonarLint.VisualStudio.SLCore.Common.Helpers
                 ImpactSeverity.LOW => SoftwareQualitySeverity.Low,
                 ImpactSeverity.MEDIUM => SoftwareQualitySeverity.Medium,
                 ImpactSeverity.HIGH => SoftwareQualitySeverity.High,
-                _ => throw new ArgumentException(SLCoreStrings.ModelExtensions_UnexpectedValue, nameof(impactSeverity)),
+                _ => throw new ArgumentOutOfRangeException(nameof(impactSeverity), impactSeverity, SLCoreStrings.ModelExtensions_UnexpectedValue),
             };
         }
     }


### PR DESCRIPTION
Fixes missed bits from https://github.com/SonarSource/sonarlint-visualstudio/pull/5482
