### PR TITLE
SLVS-1356 Publish artifacts on repox instead of azure

### DIFF
--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
 - name: buildName
   value: 'sonarlint-visualstudio-2022'
 - name: vsixPath
-  value: '$(Build.ArtifactStagingDirectory)'
+  value: '$(Build.ArtifactStagingDirectory)/(*)'
 
 name: $(Build.BuildId)
 
@@ -185,7 +185,7 @@ jobs:
   - task: PowerShell@2
     displayName: Sign Vsix file
     env:
-      PACKAGE_PATH: $(vsixPath)
+      PACKAGE_PATH: '$(Build.SourcesDirectory)\binaries\SonarLint.VSIX-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-$(vsTargetVersion).vsix'
       SM_HOST: $(SM_HOST)
       SM_API_KEY: $(SM_API_KEY)
       SM_CLIENT_CERT_PASSWORD: $(SM_CLIENT_CERT_PASSWORD)

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -313,18 +313,14 @@ jobs:
         --build-name $(buildName)
         --build-number $(Build.BuildId)
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
-
-  - task: JfrogCliV2@1
-    displayName: 'Add dependencies to Build Info'
-    inputs:
-      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
-      command: 'jf rt build-add-dependencies $(buildName) $(Build.BuildId)' .
   
   - task: JfrogCliV2@1
     displayName: 'Publish Build Info on repox'
     inputs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
-      command: 'jf rt bp $(buildName) $(Build.BuildId)'
+      command: |
+        jf rt build-add-dependencies $(buildName) $(Build.BuildId) .
+        jf rt bp $(buildName) $(Build.BuildId)
 
   - task: VSTest@2
     displayName: VsTest - testAssemblies

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
 - name: buildName
   value: 'sonarlint-visualstudio-2022'
 - name: vsixPath
-  value: '$(Build.ArtifactStagingDirectory)/(*)'
+  value: '$(Build.ArtifactStagingDirectory)\(*)'
 
 name: $(Build.BuildId)
 
@@ -308,7 +308,7 @@ jobs:
       command:
         jf rt upload
         $(vsixPath)
-        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/
+        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/{1}
         --flat
         --build-name $(buildName)
         --build-number $(Build.BuildId)

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -47,6 +47,16 @@ jobs:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)\pipeline\scripts\should-sign-vsix.ps1
 
+  - task: PowerShell@2
+    displayName: 'Install JFrog CLI'
+    env:
+      JFROG_CLI_BUILD_NAME: $(buildName)
+      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
+    inputs:
+      targetType: 'inline'
+      script: |
+        Invoke-WebRequest -Uri https://getcli.jfrog.io -OutFile jfrog.exe
+
   - task: NuGetToolInstaller@0
     displayName: Use NuGet 6.3.x
     inputs:
@@ -65,6 +75,16 @@ jobs:
       includeNuGetOrg: false
       nugetConfigPath: nuget.config
       arguments: restore -LockedMode -Verbosity detailed
+
+  - task: PowerShell@2
+    displayName: 'Add Dependencies to Build Info'
+    env:
+      JFROG_CLI_BUILD_NAME: $(buildName)
+      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
+    inputs:
+      targetType: 'inline'
+      script: |
+        .\jfrog.exe rt build-add-dependencies "**/*.nupkg"
 
   - task: PowerShell@2
     displayName: 'Read Sonar project version from the versions.props file '

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -302,7 +302,7 @@ jobs:
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
     
   - task: JfrogCliV2@1
-    displayName: 'Publish vsix on repox'
+    displayName: 'Publish Artifact vsix on repox'
     inputs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       command:

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -308,7 +308,7 @@ jobs:
       command:
         jf rt upload
         $(vsixPath)
-        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/{1}
+        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/$(buildName)/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/{1}
         --flat
         --build-name $(buildName)
         --build-number $(Build.BuildId)
@@ -319,7 +319,6 @@ jobs:
     inputs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       command: |
-        jf rt build-add-dependencies $(buildName) $(Build.BuildId) .
         jf rt bp $(buildName) $(Build.BuildId)
 
   - task: VSTest@2
@@ -342,6 +341,14 @@ jobs:
   - task: SonarCloudPublish@2
     displayName: Publish Quality Gate Result (VS2022 only)
     condition: and(succeeded(), eq(variables['vsTargetVersion'], '2022'))
+
+  - task: JFrogBuildPromotion@1
+    inputs:
+      artifactoryConnection: 'repox_promoter_token'
+      buildName: '$(buildName)'
+      buildNumber: '$(Build.BuildId)'
+      targetRepo: 'sonarsource-public-builds'
+      status: 'it-passed'
 
   - task: PowerShell@2
     displayName: Set trigger dogfood VSIX build tag (VS2022 only)

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -309,6 +309,7 @@ jobs:
         jf rt upload
         $(vsixPath)
         sonarsource-public-builds/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/
+        --flat
         --build-name $(buildName)
         --build-number $(Build.BuildId)
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -47,15 +47,15 @@ jobs:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)\pipeline\scripts\should-sign-vsix.ps1
 
-  - task: PowerShell@2
-    displayName: 'Install JFrog CLI'
-    env:
-      JFROG_CLI_BUILD_NAME: $(buildName)
-      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
-    inputs:
-      targetType: 'inline'
-      script: |
-        Invoke-WebRequest -Uri https://getcli.jfrog.io -OutFile jfrog.exe
+#  - task: PowerShell@2
+#    displayName: 'Install JFrog CLI'
+#    env:
+#      JFROG_CLI_BUILD_NAME: $(buildName)
+#      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
+#    inputs:
+#      targetType: 'inline'
+#      script: |
+#        Invoke-WebRequest -Uri https://getcli.jfrog.io -OutFile jfrog.exe
 
   - task: NuGetToolInstaller@0
     displayName: Use NuGet 6.3.x
@@ -76,15 +76,22 @@ jobs:
       nugetConfigPath: nuget.config
       arguments: restore -LockedMode -Verbosity detailed
 
-  - task: PowerShell@2
-    displayName: 'Add Dependencies to Build Info'
-    env:
-      JFROG_CLI_BUILD_NAME: $(buildName)
-      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
+  - task: JfrogCliV2@1
+    displayName: 'Publish Artifact vsix on repox'
     inputs:
-      targetType: 'inline'
-      script: |
-        .\jfrog.exe rt build-add-dependencies "**/*.nupkg"
+      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
+      command:
+        jf rt build-add-dependencies "**/*.nupkg"
+  
+#  - task: PowerShell@2
+#    displayName: 'Add Dependencies to Build Info'
+#    env:
+#      JFROG_CLI_BUILD_NAME: $(buildName)
+#      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
+#    inputs:
+#      targetType: 'inline'
+#      script: |
+#        .\jfrog.exe rt build-add-dependencies "**/*.nupkg"
 
   - task: PowerShell@2
     displayName: 'Read Sonar project version from the versions.props file '
@@ -334,6 +341,12 @@ jobs:
         --build-number $(Build.BuildId)
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
     
+  - task: JfrogCliV2@1
+    displayName: 'Publish Build Info on repox'
+    inputs:
+      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
+      command: 'jf rt bp $(buildName) $(Build.BuildId)'
+
 #  - task: JFrogPublishBuildInfo@1
 #    displayName: 'Publish build info'
 #    inputs:

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -47,16 +47,6 @@ jobs:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)\pipeline\scripts\should-sign-vsix.ps1
 
-#  - task: PowerShell@2
-#    displayName: 'Install JFrog CLI'
-#    env:
-#      JFROG_CLI_BUILD_NAME: $(buildName)
-#      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
-#    inputs:
-#      targetType: 'inline'
-#      script: |
-#        Invoke-WebRequest -Uri https://getcli.jfrog.io -OutFile jfrog.exe
-
   - task: NuGetToolInstaller@0
     displayName: Use NuGet 6.3.x
     inputs:
@@ -75,23 +65,6 @@ jobs:
       includeNuGetOrg: false
       nugetConfigPath: nuget.config
       arguments: restore -LockedMode -Verbosity detailed
-
-  - task: JfrogCliV2@1
-    displayName: 'Publish Artifact vsix on repox'
-    inputs:
-      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
-      command:
-        jf rt build-add-dependencies "**/*.nupkg"
-  
-#  - task: PowerShell@2
-#    displayName: 'Add Dependencies to Build Info'
-#    env:
-#      JFROG_CLI_BUILD_NAME: $(buildName)
-#      JFROG_CLI_BUILD_NUMBER: $(Build.BuildId)
-#    inputs:
-#      targetType: 'inline'
-#      script: |
-#        .\jfrog.exe rt build-add-dependencies "**/*.nupkg"
 
   - task: PowerShell@2
     displayName: 'Read Sonar project version from the versions.props file '
@@ -340,22 +313,19 @@ jobs:
         --build-name $(buildName)
         --build-number $(Build.BuildId)
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
-    
+
+  - task: JfrogCliV2@1
+    displayName: 'Add dependencies to Build Info'
+    inputs:
+      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
+      command: 'jf rt build-add-dependencies $(buildName) $(Build.BuildId)' .
+  
   - task: JfrogCliV2@1
     displayName: 'Publish Build Info on repox'
     inputs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       command: 'jf rt bp $(buildName) $(Build.BuildId)'
 
-#  - task: JFrogPublishBuildInfo@1
-#    displayName: 'Publish build info'
-#    inputs:
-#      artifactoryConnection: $(ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN)
-#      buildName: '$(buildName)'
-#      buildNumber: '$(Build.BuildId)'
-#      excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'
-#    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
-    
   - task: VSTest@2
     displayName: VsTest - testAssemblies
     inputs:

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
 - name: buildName
   value: 'sonarlint-visualstudio-2022'
 - name: vsixPath
-  value: '$(Build.SourcesDirectory)\binaries\SonarLint.VSIX-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-$(vsTargetVersion).vsix'
+  value: '$(Build.ArtifactStagingDirectory)'
 
 name: $(Build.BuildId)
 
@@ -308,20 +308,20 @@ jobs:
       command:
         jf rt upload
         $(vsixPath)
-        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/
+        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/
         --flat
         --build-name $(buildName)
         --build-number $(Build.BuildId)
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
     
-  - task: JFrogPublishBuildInfo@1
-    displayName: 'Publish build info'
-    inputs:
-      artifactoryConnection: $(ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN)
-      buildName: '$(buildName)'
-      buildNumber: '$(Build.BuildId)'
-      excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'
-    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
+#  - task: JFrogPublishBuildInfo@1
+#    displayName: 'Publish build info'
+#    inputs:
+#      artifactoryConnection: $(ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN)
+#      buildName: '$(buildName)'
+#      buildNumber: '$(Build.BuildId)'
+#      excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'
+#    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
     
   - task: VSTest@2
     displayName: VsTest - testAssemblies

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -316,7 +316,7 @@ jobs:
     
   - task: JFrogPublishBuildInfo@1
     inputs:
-      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
+      artifactoryConnection: '$(ARTIFACTORY_DEPLOY_TOKEN)'
       buildName: '$(buildName)'
       buildNumber: '$(Build.BuildId)'
       excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -317,7 +317,7 @@ jobs:
   - task: JFrogPublishBuildInfo@1
     displayName: 'Publish build info'
     inputs:
-      artifactoryConnection: 'repox_promoter_token'
+      artifactoryConnection: $(ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN)
       buildName: '$(buildName)'
       buildNumber: '$(Build.BuildId)'
       excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -316,7 +316,7 @@ jobs:
     
   - task: JFrogPublishBuildInfo@1
     inputs:
-      artifactoryConnection: '$(ARTIFACTORY_DEPLOY_TOKEN)'
+      artifactoryConnection: $(ARTIFACTORY_DEPLOY_TOKEN)
       buildName: '$(buildName)'
       buildNumber: '$(Build.BuildId)'
       excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -295,7 +295,7 @@ jobs:
     displayName: 'Publish Artifact: vsix'
     inputs:
       ArtifactName: vsix
-    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
+    condition: succeededOrFailed()  # always publish artifacts - helps with diagnosing failures
     
   - task: JfrogCliV2@1
     displayName: 'Publish Artifact vsix on repox'
@@ -308,7 +308,7 @@ jobs:
         --flat
         --build-name $(buildName)
         --build-number $(Build.BuildId)
-    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
+    condition: succeededOrFailed()  # always publish artifacts - helps with diagnosing failures
   
   - task: JfrogCliV2@1
     displayName: 'Publish Build Info on repox'
@@ -316,6 +316,7 @@ jobs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       command: |
         jf rt bp $(buildName) $(Build.BuildId)
+    condition: succeededOrFailed()  # always publish build info - helps with diagnosing failures
 
   - task: VSTest@2
     displayName: VsTest - testAssemblies

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -316,6 +316,7 @@ jobs:
     
   - task: JFrogPublishBuildInfo@1
     inputs:
+      artifactoryConnection: 'jfrog_platform_qa_deployer_access_token'
       buildName: '$(buildName)'
       buildNumber: '$(Build.BuildId)'
       excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -6,6 +6,12 @@ variables:
 - group: artifactory_access
 - name: BuildParameters.solution
   value: SonarLint.VisualStudio.Integration.sln
+- name: ARTIFACTORY_DEPLOY_TOKEN
+  value: $[variables.ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN]
+- name: buildName
+  value: 'sonarlint-visualstudio-2022'
+- name: vsixPath
+  value: '$(Build.SourcesDirectory)\binaries\SonarLint.VSIX-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-$(vsTargetVersion).vsix'
 
 name: $(Build.BuildId)
 
@@ -179,7 +185,7 @@ jobs:
   - task: PowerShell@2
     displayName: Sign Vsix file
     env:
-      PACKAGE_PATH: '$(Build.SourcesDirectory)\binaries\SonarLint.VSIX-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-$(vsTargetVersion).vsix'
+      PACKAGE_PATH: $(vsixPath)
       SM_HOST: $(SM_HOST)
       SM_API_KEY: $(SM_API_KEY)
       SM_CLIENT_CERT_PASSWORD: $(SM_CLIENT_CERT_PASSWORD)
@@ -294,7 +300,19 @@ jobs:
     inputs:
       ArtifactName: vsix
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
-  
+    
+  - task: JfrogCliV2@1
+    displayName: 'Publish vsix on repox'
+    inputs:
+      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
+      command:
+        jf rt upload
+        $(vsixPath)
+        sonarsource-public-builds/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/
+        --build-name $(buildName)
+        --build-number $(Build.BuildId)
+    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
+    
   - task: VSTest@2
     displayName: VsTest - testAssemblies
     inputs:

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -315,8 +315,9 @@ jobs:
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
     
   - task: JFrogPublishBuildInfo@1
+    displayName: 'Publish build info'
     inputs:
-      artifactoryConnection: $(ARTIFACTORY_DEPLOY_TOKEN)
+      artifactoryConnection: 'repox_promoter_token'
       buildName: '$(buildName)'
       buildNumber: '$(Build.BuildId)'
       excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -301,22 +301,10 @@ jobs:
     displayName: 'Publish Artifact vsix on repox'
     inputs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
-      command:
-        jf rt upload
-        '$(Build.ArtifactStagingDirectory)\(*)'
-        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/$(buildName)/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/{1}
-        --flat
-        --build-name $(buildName)
-        --build-number $(Build.BuildId)
-    condition: succeededOrFailed()  # always publish artifacts - helps with diagnosing failures
-  
-  - task: JfrogCliV2@1
-    displayName: 'Publish Build Info on repox'
-    inputs:
-      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       command: |
+        jf rt upload $(Build.ArtifactStagingDirectory)\(*) sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/$(buildName)/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/{1} --flat --build-name $(buildName) --build-number $(Build.BuildId)
         jf rt bp $(buildName) $(Build.BuildId)
-    condition: succeededOrFailed()  # always publish build info - helps with diagnosing failures
+    condition: succeededOrFailed()  # always publish artifacts - helps with diagnosing failures
 
   - task: VSTest@2
     displayName: VsTest - testAssemblies

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -6,12 +6,8 @@ variables:
 - group: artifactory_access
 - name: BuildParameters.solution
   value: SonarLint.VisualStudio.Integration.sln
-- name: ARTIFACTORY_DEPLOY_TOKEN
-  value: $[variables.ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN]
 - name: buildName
   value: 'sonarlint-visualstudio-2022'
-- name: vsixPath
-  value: '$(Build.ArtifactStagingDirectory)\(*)'
 
 name: $(Build.BuildId)
 
@@ -307,7 +303,7 @@ jobs:
       jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       command:
         jf rt upload
-        $(vsixPath)
+        '$(Build.ArtifactStagingDirectory)\(*)'
         sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/$(buildName)/$(SONAR_PROJECT_VERSION).$(Build.BuildId)/{1}
         --flat
         --build-name $(buildName)

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -316,7 +316,7 @@ jobs:
     
   - task: JFrogPublishBuildInfo@1
     inputs:
-      artifactoryConnection: 'jfrog_platform_qa_deployer_access_token'
+      jfrogPlatformConnection: 'jfrog_platform_qa_deployer_access_token'
       buildName: '$(buildName)'
       buildNumber: '$(Build.BuildId)'
       excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -308,7 +308,7 @@ jobs:
       command:
         jf rt upload
         $(vsixPath)
-        sonarsource-public-builds/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/
+        sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio/
         --flat
         --build-name $(buildName)
         --build-number $(Build.BuildId)

--- a/pipeline/azure-pipelines.yml
+++ b/pipeline/azure-pipelines.yml
@@ -314,6 +314,13 @@ jobs:
         --build-number $(Build.BuildId)
     condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
     
+  - task: JFrogPublishBuildInfo@1
+    inputs:
+      buildName: '$(buildName)'
+      buildNumber: '$(Build.BuildId)'
+      excludeEnvVars: '*password*;*psw*;*secret*;*key*;*token*;*auth*;'
+    condition: succeededOrFailed()  # always publish artefacts - helps with diagnosing failures
+    
   - task: VSTest@2
     displayName: VsTest - testAssemblies
     inputs:


### PR DESCRIPTION
This PR is
1. Publishing the artifacts to repox
    > https://repox.jfrog.io/ui/repos/tree/General/sonarsource-public-qa/org/sonarsource/sonarlint/visualstudio
    > the `sonarlint-visualstudio` has been replaced by `sonarlint-visualstudio-2022`. However, there is no such dir on repox at the moment as all the artifacts have been promoted to the `sonarsource-public-builds`.
2. Publishing the build info
    > https://repox.jfrog.io/ui/builds/sonarlint-visualstudio-2022/97475/1724053604929/published?buildRepo=artifactory-build-info
    > There are no dependencies reported on the build-info yet. Dependencies will be added when we migrate to Cirrus CI
3. Promoting the artifact on repox builds when tests pass
    > https://repox.jfrog.io/ui/repos/tree/General/sonarsource-public-builds/org/sonarsource/sonarlint/visualstudio/sonarlint-visualstudio-2022

