### PR TITLE
SLVS-1382 Manage Connections Dialog: User should be able to view the list of connections

### DIFF
--- a/src/ConnectedMode.UnitTests/UI/ManageConnections/ManageConnectionsViewModelTest.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageConnections/ManageConnectionsViewModelTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System.ComponentModel;
+using SonarLint.VisualStudio.ConnectedMode.UI;
 using SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI.ManageConnections;
@@ -28,6 +29,7 @@ public class ManageConnectionsViewModelTest
 {
     private ManageConnectionsViewModel testSubject;
     private IEnumerable<Connection> connections;
+    private IProgressReporterViewModel progressReporterViewModel;
 
     [TestInitialize]
     public void TestInitialize()
@@ -37,7 +39,8 @@ public class ManageConnectionsViewModelTest
             new Connection(new ConnectionInfo("http://localhost:9000", ConnectionServerType.SonarQube), true),
             new Connection(new ConnectionInfo("https://sonarcloud.io/myOrg", ConnectionServerType.SonarCloud), false)
         ];
-        testSubject = new ManageConnectionsViewModel();
+        progressReporterViewModel = Substitute.For<IProgressReporterViewModel>();
+        testSubject = new ManageConnectionsViewModel(progressReporterViewModel);
     }
 
     [TestMethod]

--- a/src/ConnectedMode.UnitTests/UI/ManageConnections/ManageConnectionsViewModelTest.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageConnections/ManageConnectionsViewModelTest.cs
@@ -30,7 +30,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI.ManageConnections;
 public class ManageConnectionsViewModelTest
 {
     private ManageConnectionsViewModel testSubject;
-    private IEnumerable<Connection> connections;
+    private List<Connection> connections;
     private IProgressReporterViewModel progressReporterViewModel;
     private IConnectedModeServices connectedModeServices;
     private IServerConnectionsRepositoryAdapter serverConnectionsRepositoryAdapter;
@@ -101,9 +101,8 @@ public class ManageConnectionsViewModelTest
 
         testSubject.AddConnection(connectionToAdd);
 
-        var viewModelsCount = testSubject.ConnectionViewModels.Count;
-        viewModelsCount.Should().Be(connections.Count() + 1);
-        testSubject.ConnectionViewModels[viewModelsCount - 1].Connection.Should().Be(connectionToAdd);
+        testSubject.ConnectionViewModels.Count.Should().Be( 1);
+        testSubject.ConnectionViewModels[0].Connection.Should().Be(connectionToAdd);
     }
 
     [TestMethod]

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml
@@ -1,12 +1,12 @@
 ﻿<Window x:Class="SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections.ManageConnectionsDialog"
                          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                         xmlns:vsShell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
-                         xmlns:ui="clr-namespace:SonarLint.VisualStudio.ConnectedMode.UI.Resources"
+                         xmlns:res="clr-namespace:SonarLint.VisualStudio.ConnectedMode.UI.Resources"
                          xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
                          xmlns:vsimagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
                          xmlns:wpf="clr-namespace:SonarLint.VisualStudio.Core.WPF;assembly=SonarLint.VisualStudio.Core"
-                         Title="{x:Static ui:UiResources.ManageConnectionsDialogTitle}" 
+                         xmlns:ui="clr-namespace:SonarLint.VisualStudio.ConnectedMode.UI"
+                         Title="{x:Static res:UiResources.ManageConnectionsDialogTitle}" 
                          WindowStartupLocation="CenterOwner"
                          Initialized="ManageConnectionsWindow_OnInitialized"
                          x:Name="This">
@@ -27,6 +27,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0">
@@ -44,8 +45,8 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Text="{x:Static ui:UiResources.ExistingConnectionsLabel}" Style="{StaticResource HeaderTextBlock}"/>
-                <Button Grid.Column="1" Content="{x:Static ui:UiResources.NewConnectionButton}" HorizontalAlignment="Right"
+                <TextBlock Grid.Column="0" Text="{x:Static res:UiResources.ExistingConnectionsLabel}" Style="{StaticResource HeaderTextBlock}"/>
+                <Button Grid.Column="1" Content="{x:Static res:UiResources.NewConnectionButton}" HorizontalAlignment="Right"
                         Click="NewConnection_Clicked"/>
             </Grid>
            <ListBox Grid.Row="1" ItemsSource="{Binding Path=ConnectionViewModels, Mode=OneWay}" Margin="0,10" 
@@ -80,7 +81,7 @@
                                </Grid.RowDefinitions>
 
                                <TextBlock Grid.Row="0" Text="{Binding Path=Name, Mode=OneWay}" VerticalAlignment="Center" />
-                               <CheckBox Grid.Row="1" Content="{x:Static ui:UiResources.SmartNotificationsCheckboxLabel}" IsChecked="{Binding Path=EnableSmartNotifications}"
+                               <CheckBox Grid.Row="1" Content="{x:Static res:UiResources.SmartNotificationsCheckboxLabel}" IsChecked="{Binding Path=EnableSmartNotifications}"
                                          VerticalContentAlignment="Center"/>
                             </Grid>
 
@@ -90,11 +91,11 @@
                                    <ColumnDefinition Width="Auto"/>
                                </Grid.ColumnDefinitions>
 
-                               <Button Grid.Column="0" Style="{StaticResource IconButtonStyle}" ToolTip="{x:Static ui:UiResources.EditConnectionToolTip}" Click="EditConnection_Clicked">
+                               <Button Grid.Column="0" Style="{StaticResource IconButtonStyle}" ToolTip="{x:Static res:UiResources.EditConnectionToolTip}" Click="EditConnection_Clicked">
                                    <imaging:CrispImage Width="20" Height="20" VerticalAlignment="Center" Cursor="Hand" Moniker="{x:Static vsimagecatalog:KnownMonikers.Settings}"
                                                        Margin="10,0" />
                                 </Button>
-                                <Button Grid.Column="1" Style="{StaticResource IconButtonStyle}" ToolTip="{x:Static ui:UiResources.RemoveConnectionToolTip}" Click="RemoveConnectionButton_OnClick">
+                                <Button Grid.Column="1" Style="{StaticResource IconButtonStyle}" ToolTip="{x:Static res:UiResources.RemoveConnectionToolTip}" Click="RemoveConnectionButton_OnClick">
                                     <imaging:CrispImage Width="20" Height="20" VerticalAlignment="Center" Cursor="Hand" Moniker="{x:Static vsimagecatalog:KnownMonikers.Close}"/>
                                 </Button>
                             </Grid>
@@ -103,12 +104,16 @@
                 </ListBox.ItemTemplate>
            </ListBox>
 
-            <TextBlock Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{x:Static ui:UiResources.NoConnectionExistsLabel}" 
+            <TextBlock Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{x:Static res:UiResources.NoConnectionExistsLabel}" 
                        Visibility="{Binding Path=NoConnectionExists, Converter={StaticResource TrueToVisibleConverter}}"/>
         </Grid>
 
-        <Grid HorizontalAlignment="Right" Grid.Row="1" Margin="10">
-            <Button Content="{x:Static ui:UiResources.OkButton}" IsCancel="True" IsDefault="True"/>
+        <Grid Grid.Row="1">
+            <ui:ProgressAndErrorHandlerComponent ProgressReporterViewModel="{Binding Path=ProgressReporterViewModel}" />
+        </Grid>
+
+        <Grid HorizontalAlignment="Right" Grid.Row="2" Margin="10">
+            <Button Content="{x:Static res:UiResources.OkButton}" IsCancel="True" IsDefault="True"/>
         </Grid>
     </Grid>
 </Window>

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
@@ -34,11 +34,12 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
     {
         private readonly IConnectedModeServices connectedModeServices;
 
-        public ManageConnectionsViewModel ViewModel { get; } = new();
+        public ManageConnectionsViewModel ViewModel { get; }
 
         public ManageConnectionsDialog(IConnectedModeServices connectedModeServices)
         {
             this.connectedModeServices = connectedModeServices;
+            ViewModel = new ManageConnectionsViewModel(new ProgressReporterViewModel());
             InitializeComponent();
         }
 

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
@@ -39,7 +39,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
         public ManageConnectionsDialog(IConnectedModeServices connectedModeServices)
         {
             this.connectedModeServices = connectedModeServices;
-            ViewModel = new ManageConnectionsViewModel(new ProgressReporterViewModel());
+            ViewModel = new ManageConnectionsViewModel(connectedModeServices, new ProgressReporterViewModel());
             InitializeComponent();
         }
 
@@ -96,9 +96,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             return organizationSelectionDialog.ShowDialog(this) == true ? organizationSelectionDialog.ViewModel.FinalConnectionInfo : null;
         }
 
-        private void ManageConnectionsWindow_OnInitialized(object sender, EventArgs e)
+        private async void ManageConnectionsWindow_OnInitialized(object sender, EventArgs e)
         {
-            ViewModel.InitializeConnections([]);
+            await ViewModel.LoadConnectionsWithProgressAsync();
         }
 
         private void RemoveConnectionButton_OnClick(object sender, RoutedEventArgs e)

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
@@ -23,8 +23,9 @@ using SonarLint.VisualStudio.Core.WPF;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 {
-    public class ManageConnectionsViewModel : ViewModelBase
+    public class ManageConnectionsViewModel(IProgressReporterViewModel progressReporterViewModel) : ViewModelBase
     {
+        public IProgressReporterViewModel ProgressReporterViewModel { get; } = progressReporterViewModel;
         public ObservableCollection<ConnectionViewModel> ConnectionViewModels { get; } = [];
         public bool NoConnectionExists => ConnectionViewModels.Count == 0;
 

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
@@ -19,19 +19,42 @@
  */
 
 using System.Collections.ObjectModel;
+using SonarLint.VisualStudio.ConnectedMode.UI.Resources;
 using SonarLint.VisualStudio.Core.WPF;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 {
-    public class ManageConnectionsViewModel(IProgressReporterViewModel progressReporterViewModel) : ViewModelBase
+    public class ManageConnectionsViewModel(IConnectedModeServices connectedModeServices, IProgressReporterViewModel progressReporterViewModel) : ViewModelBase
     {
         public IProgressReporterViewModel ProgressReporterViewModel { get; } = progressReporterViewModel;
         public ObservableCollection<ConnectionViewModel> ConnectionViewModels { get; } = [];
         public bool NoConnectionExists => ConnectionViewModels.Count == 0;
 
-        public void InitializeConnections(IEnumerable<Connection> connections)
+        public async Task LoadConnectionsWithProgressAsync()
+        {
+            var validationParams = new TaskToPerformParams<AdapterResponse>(LoadConnectionsAsync, UiResources.LoadingConnectionsText, UiResources.LoadingConnectionsFailedText);
+            await ProgressReporterViewModel.ExecuteTaskWithProgressAsync(validationParams);
+        }
+
+        internal async Task<AdapterResponse> LoadConnectionsAsync()
+        {
+            try
+            {
+                await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(InitializeConnections);
+                return new AdapterResponse(true);
+            }
+            catch (Exception ex)
+            {
+                connectedModeServices.Logger.WriteLine(ex.Message);
+            }
+
+            return new AdapterResponse(false);
+        }
+
+        internal void InitializeConnections()
         {
             ConnectionViewModels.Clear();
+            var connections = connectedModeServices.ServerConnectionsRepositoryAdapter.GetAllConnections();
             connections.ToList().ForEach(AddConnection);
         }
 

--- a/src/Core/Binding/IServerConnectionsRepository.cs
+++ b/src/Core/Binding/IServerConnectionsRepository.cs
@@ -45,7 +45,7 @@ public class DummyServerConnectionsRepository : IServerConnectionsRepository
 
     public List<ServerConnection> GetAll()
     {
-        throw new NotImplementedException();
+        return [new ServerConnection.SonarCloud("a")];
     }
 
     public bool TryAdd(ServerConnection connection)


### PR DESCRIPTION
[SLVS-1382](https://sonarsource.atlassian.net/browse/SLVS-1382)

This PR is based on the [binding dialog PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/5649), because the ServerConnectionsRepositoryAdapter was needed to map the model used for the repository to the UI model.

[SLVS-1382]: https://sonarsource.atlassian.net/browse/SLVS-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ