### PR TITLE
SLVS-1399 Implement IServerConnectionRepository

### DIFF
--- a/src/ConnectedMode.UnitTests/Persistence/ServerConnectionsRepositoryTests.cs
+++ b/src/ConnectedMode.UnitTests/Persistence/ServerConnectionsRepositoryTests.cs
@@ -332,7 +332,7 @@ public class ServerConnectionsRepositoryTests
         var succeeded = testSubject.TryAdd(sonarCloudServerConnection);
 
         succeeded.Should().BeFalse();
-        logger.Received(1).WriteLine(exceptionMsg);
+        logger.Received(1).WriteLine($"Failed updating the {ServerConnectionsRepository.ConnectionsFileName}: {exceptionMsg}");
     }
 
     [TestMethod]
@@ -433,7 +433,7 @@ public class ServerConnectionsRepositoryTests
         var succeeded = testSubject.TryDelete(sonarCloud.Id);
 
         succeeded.Should().BeFalse();
-        logger.Received(1).WriteLine(exceptionMsg);
+        logger.Received(1).WriteLine($"Failed updating the {ServerConnectionsRepository.ConnectionsFileName}: {exceptionMsg}");
     }
 
     [TestMethod]
@@ -499,7 +499,7 @@ public class ServerConnectionsRepositoryTests
         var succeeded = testSubject.TryUpdateSettingsById(sonarCloud.Id, new ServerConnectionSettings(true));
 
         succeeded.Should().BeFalse();
-        logger.Received(1).WriteLine(exceptionMsg);
+        logger.Received(1).WriteLine($"Failed updating the {ServerConnectionsRepository.ConnectionsFileName}: {exceptionMsg}");
     }
 
     [TestMethod]
@@ -547,7 +547,7 @@ public class ServerConnectionsRepositoryTests
         var succeeded = testSubject.TryUpdateCredentialsById(connection.Id, Substitute.For<ICredentials>());
 
         succeeded.Should().BeFalse();
-        logger.Received(1).WriteLine(exceptionMsg);
+        logger.Received(1).WriteLine($"Failed updating credentials: {exceptionMsg}");
     }
 
     private SonarCloud MockFileWithOneSonarCloudConnection(bool isSmartNotificationsEnabled = true)

--- a/src/ConnectedMode.UnitTests/Persistence/ServerConnectionsRepositoryTests.cs
+++ b/src/ConnectedMode.UnitTests/Persistence/ServerConnectionsRepositoryTests.cs
@@ -1,0 +1,598 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using SonarLint.VisualStudio.ConnectedMode.Binding;
+using SonarLint.VisualStudio.ConnectedMode.Persistence;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Core.Persistence;
+using SonarLint.VisualStudio.TestInfrastructure;
+using static SonarLint.VisualStudio.Core.Binding.ServerConnection;
+
+namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Persistence;
+
+[TestClass]
+public class ServerConnectionsRepositoryTests
+{
+    private ServerConnectionsRepository testSubject;
+    private IJsonFileHandler jsonFileHandler;
+    private ILogger logger;
+    private IEnvironmentVariableProvider environmentVariableProvider;
+    private IServerConnectionModelMapper serverConnectionModelMapper;
+    private ISolutionBindingCredentialsLoader credentialsLoader;
+    private readonly SonarCloud sonarCloudServerConnection = new("myOrganization", new ServerConnectionSettings(true), Substitute.For<ICredentials>());
+    private readonly ServerConnection.SonarQube sonarQubeServerConnection = new(new Uri("http://localhost"), new ServerConnectionSettings(true), Substitute.For<ICredentials>());
+
+    [TestInitialize]
+    public void TestInitialize()
+    { 
+        jsonFileHandler = Substitute.For<IJsonFileHandler>();
+        serverConnectionModelMapper = Substitute.For<IServerConnectionModelMapper>();
+        credentialsLoader = Substitute.For<ISolutionBindingCredentialsLoader>();
+        environmentVariableProvider = Substitute.For<IEnvironmentVariableProvider>();
+        logger = Substitute.For<ILogger>();
+
+        testSubject = new ServerConnectionsRepository(jsonFileHandler, serverConnectionModelMapper, credentialsLoader, environmentVariableProvider, logger);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckExports()
+    {
+        MefTestHelpers.CheckTypeCanBeImported<ServerConnectionsRepository, IServerConnectionsRepository>(
+            MefTestHelpers.CreateExport<IJsonFileHandler>(),
+            MefTestHelpers.CreateExport<IServerConnectionModelMapper>(),
+            MefTestHelpers.CreateExport<ICredentialStoreService>(),
+            MefTestHelpers.CreateExport<ILogger>());
+    }
+
+    [TestMethod]
+    public void Mef_CheckIsSingleton()
+    {
+        MefTestHelpers.CheckIsSingletonMefComponent<ServerConnectionsRepository>();
+    }
+
+    [TestMethod]
+    public void TryGet_FileDoesNotExist_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>())).Do(x => throw new FileNotFoundException());
+
+        var succeeded = testSubject.TryGet("myId", out ServerConnection serverConnection);
+
+        succeeded.Should().BeFalse();
+        serverConnection.Should().BeNull();
+        jsonFileHandler.Received(1).ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>());
+    }
+
+    [TestMethod]
+    public void TryGet_FileCanNotBeRead_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>())).Do(x => throw new Exception());
+
+        var succeeded = testSubject.TryGet("myId", out ServerConnection serverConnection);
+
+        succeeded.Should().BeFalse();
+        serverConnection.Should().BeNull();
+        jsonFileHandler.Received(1).ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>());
+    }
+
+    [TestMethod]
+    public void TryGet_FileExistsAndConnectionDoesNotExist_ReturnsFalse()
+    {
+        MockFileWithOneSonarCloudConnection();
+
+        var succeeded = testSubject.TryGet("non-existing connectionId", out ServerConnection serverConnection);
+
+        succeeded.Should().BeFalse();
+        serverConnection.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TryGet_FileExistsAndConnectionIsSonarCloud_ReturnsSonarCloudConnection()
+    {
+        var sonarCloudModel = GetSonarCloudJsonModel("myOrg");
+        var expectedConnection = new SonarCloud(sonarCloudModel.Id);
+        MockReadingFile(new ServerConnectionsListJsonModel { ServerConnections = [sonarCloudModel] });
+        serverConnectionModelMapper.GetServerConnection(sonarCloudModel).Returns(expectedConnection);
+
+        var succeeded = testSubject.TryGet(sonarCloudModel.Id, out ServerConnection serverConnection);
+
+        succeeded.Should().BeTrue();
+        serverConnection.Should().Be(expectedConnection);
+    }
+
+    [TestMethod]
+    public void TryGet_FileExistsAndConnectionIsSonarCloud_FillsCredentials()
+    {
+        var expectedConnection = MockFileWithOneSonarCloudConnection();
+        var credentials = Substitute.For<ICredentials>();
+        credentialsLoader.Load(expectedConnection.CredentialsUri).Returns(credentials);
+
+        var succeeded = testSubject.TryGet(expectedConnection.Id, out ServerConnection serverConnection);
+
+        succeeded.Should().BeTrue();
+        serverConnection.Should().Be(expectedConnection);
+        serverConnection.Credentials.Should().Be(credentials);
+        credentialsLoader.Received(1).Load(expectedConnection.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryGet_FileExistsAndConnectionIsSonarQube_ReturnsSonarQubeConnection()
+    {
+        var sonarQubeModel = GetSonarQubeJsonModel(new Uri("http://localhost:9000"));
+        var expectedConnection = new ServerConnection.SonarQube(new Uri(sonarQubeModel.ServerUri));
+        MockReadingFile(new ServerConnectionsListJsonModel { ServerConnections = [sonarQubeModel] });
+        serverConnectionModelMapper.GetServerConnection(sonarQubeModel).Returns(expectedConnection);
+
+        var succeeded = testSubject.TryGet(sonarQubeModel.Id, out ServerConnection serverConnection);
+
+        succeeded.Should().BeTrue();
+        serverConnection.Should().Be(expectedConnection);
+    }
+
+    [TestMethod]
+    public void TryGet_FileExistsAndConnectionIsSonarQube_FillsCredentials()
+    {
+        var expectedConnection = MockFileWithOneSonarQubeConnection();
+        var credentials = Substitute.For<ICredentials>();
+        credentialsLoader.Load(expectedConnection.CredentialsUri).Returns(credentials);
+
+        var succeeded = testSubject.TryGet(expectedConnection.Id, out ServerConnection serverConnection);
+
+        succeeded.Should().BeTrue();
+        serverConnection.Should().Be(expectedConnection);
+        serverConnection.Credentials.Should().Be(credentials);
+        credentialsLoader.Received(1).Load(expectedConnection.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryGetAll_FileDoesNotExist_ReturnsEmptyList()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>())).Do(x => throw new FileNotFoundException());
+
+       testSubject.TryGetAll(out var connections);
+
+        connections.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TryGetAll_FileCouldNotBeRead_ThrowsException()
+    {
+        var exceptionMsg = "failed";
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>())).Do(x => throw new Exception(exceptionMsg));
+
+        var succeeded = testSubject.TryGetAll(out var connections);
+
+        succeeded.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryGetAll_FileExistsAndIsEmpty_ReturnsEmptyList()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+
+       testSubject.TryGetAll(out var connections);
+
+        connections.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TryGetAll_FileExistsAndHasConnection_MapsModel()
+    {
+        var cloudModel = GetSonarCloudJsonModel("myOrg");
+        MockReadingFile(new ServerConnectionsListJsonModel { ServerConnections = [cloudModel] });
+
+        testSubject.TryGetAll(out _);
+
+        serverConnectionModelMapper.Received(1).GetServerConnection(cloudModel);
+    }
+
+    [TestMethod]
+    public void TryGetAll_ConnectionsExist_DoesNotFillCredentials()
+    {
+        MockFileWithOneSonarCloudConnection();
+
+        testSubject.TryGetAll(out _);
+
+        credentialsLoader.DidNotReceive().Load(Arg.Any<Uri>());
+    }
+
+    [TestMethod]
+    public void TryAdd_FileCouldNotBeRead_DoesNotAddConnection()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+
+        var succeeded = testSubject.TryAdd(sonarCloudServerConnection);
+
+        succeeded.Should().BeFalse();
+        Received.InOrder(() =>
+        {
+            jsonFileHandler.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>());
+            serverConnectionModelMapper.GetServerConnectionsListJsonModel(Arg.Is<IEnumerable<ServerConnection>>(x => x.Contains(sonarCloudServerConnection)));
+            jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+        });
+    }
+
+    [TestMethod]
+    public void TryAdd_FileExistsAndConnectionIsNew_AddsConnection()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+
+        var succeeded = testSubject.TryAdd(sonarCloudServerConnection);
+
+        succeeded.Should().BeTrue();
+        Received.InOrder(() =>
+        {
+            jsonFileHandler.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>());
+            serverConnectionModelMapper.GetServerConnectionsListJsonModel(Arg.Is<IEnumerable<ServerConnection>>(x => x.Contains(sonarCloudServerConnection)));
+            jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+        });
+    }
+
+    [TestMethod]
+    public void TryAdd_SonarCloudConnectionIsAddedAndCredentialsAreNotNull_SavesCredentials()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+
+        var succeeded = testSubject.TryAdd(sonarCloudServerConnection);
+
+        succeeded.Should().BeTrue();
+        credentialsLoader.Received(1).Save(sonarCloudServerConnection.Credentials, sonarCloudServerConnection.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryAdd_SonarQubeConnectionIsAddedAndCredentialsAreNotNull_SavesCredentials()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+
+        var succeeded = testSubject.TryAdd(sonarQubeServerConnection);
+
+        succeeded.Should().BeTrue();
+        credentialsLoader.Received(1).Save(sonarQubeServerConnection.Credentials, sonarQubeServerConnection.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryAdd_ConnectionIsAddedAndCredentialsAreNull_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+        sonarCloudServerConnection.Credentials = null;
+
+        var succeeded = testSubject.TryAdd(sonarCloudServerConnection);
+
+        succeeded.Should().BeFalse();
+        credentialsLoader.DidNotReceive().Save(Arg.Any<ICredentials>(), Arg.Any<Uri>());
+    }
+
+    [TestMethod]
+    public void TryAdd_ConnectionIsNotAdded_DoesNotSaveCredentials()
+    {
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+
+        var succeeded = testSubject.TryAdd(sonarCloud);
+
+        succeeded.Should().BeFalse();
+        credentialsLoader.DidNotReceive().Save(Arg.Any<ICredentials>(), Arg.Any<Uri>());
+    }
+
+    [TestMethod]
+    public void TryAdd_FileExistsAndConnectionIsDuplicate_DoesNotAddConnection()
+    {
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+
+        var succeeded = testSubject.TryAdd(sonarCloud);
+
+        succeeded.Should().BeFalse();
+        jsonFileHandler.DidNotReceive().TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+    }
+
+    [TestMethod]
+    public void TryAdd_WritingToFileFails_DoesNotAddConnection()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(false);
+        var sonarCloud = new SonarCloud("myOrg");
+
+        var succeeded = testSubject.TryAdd(sonarCloud);
+
+        succeeded.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryAdd_WritingThrowsException_DoesNotUpdateConnectionAndWritesLog()
+    {
+        var exceptionMsg = "IO exception";
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>())).Do(x => throw new Exception(exceptionMsg));
+
+        var succeeded = testSubject.TryAdd(sonarCloudServerConnection);
+
+        succeeded.Should().BeFalse();
+        logger.Received(1).WriteLine(exceptionMsg);
+    }
+
+    [TestMethod]
+    public void TryDelete_FileCouldNotBeRead_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>())).Do(x => throw new Exception());
+
+        var succeeded = testSubject.TryDelete("myOrg");
+
+        succeeded.Should().BeFalse();
+        jsonFileHandler.DidNotReceive().TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+    }
+
+    [TestMethod]
+    public void TryDelete_FileExistsAndHasNoConnection_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+
+        var succeeded = testSubject.TryDelete("myOrg");
+
+        succeeded.Should().BeFalse();
+        jsonFileHandler.DidNotReceive().TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+    }
+
+    [TestMethod]
+    public void TryDelete_FileExistsAndConnectionExists_RemovesConnection()
+    {
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+
+        var succeeded = testSubject.TryDelete(sonarCloud.Id);
+
+        succeeded.Should().BeTrue();
+        Received.InOrder(() =>
+        {
+            jsonFileHandler.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>());
+            serverConnectionModelMapper.GetServerConnectionsListJsonModel(Arg.Is<IEnumerable<ServerConnection>>(x => !x.Any()));
+            jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+            credentialsLoader.DeleteCredentials(sonarCloud.CredentialsUri);
+        });
+    }
+
+    [TestMethod]
+    public void TryDelete_SonarCloudConnectionWasRemoved_RemovesCredentials()
+    {
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+
+        var succeeded = testSubject.TryDelete(sonarCloud.Id);
+
+        succeeded.Should().BeTrue();
+        credentialsLoader.Received(1).DeleteCredentials(sonarCloud.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryDelete_SonarQubeConnectionWasRemoved_RemovesCredentials()
+    {
+        var sonarQube = MockFileWithOneSonarQubeConnection();
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+
+        var succeeded = testSubject.TryDelete(sonarQube.Id);
+
+        succeeded.Should().BeTrue();
+        credentialsLoader.Received(1).DeleteCredentials(sonarQube.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryDelete_ConnectionWasNotRemoved_DoesNotRemoveCredentials()
+    {
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(false);
+
+        var succeeded = testSubject.TryDelete(sonarCloud.Id);
+
+        succeeded.Should().BeFalse();
+        credentialsLoader.DidNotReceive().DeleteCredentials(Arg.Any<Uri>());
+    }
+
+    [TestMethod]
+    public void TryDelete_WritingToFileFails_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(false);
+
+        var succeeded = testSubject.TryDelete("myOrg");
+
+        succeeded.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryDelete_WritingThrowsException_DoesNotUpdateConnectionAndWritesLog()
+    {
+        var exceptionMsg = "IO exception";
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+        jsonFileHandler.When(x => x.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>())).Do(x => throw new Exception(exceptionMsg));
+
+        var succeeded = testSubject.TryDelete(sonarCloud.Id);
+
+        succeeded.Should().BeFalse();
+        logger.Received(1).WriteLine(exceptionMsg);
+    }
+
+    [TestMethod]
+    public void TryUpdateSettingsById_FileCouldNotBeRead_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.When(x => x.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>())).Do(x => throw new Exception());
+
+        var succeeded = testSubject.TryUpdateSettingsById("myOrg", new ServerConnectionSettings(true));
+
+        succeeded.Should().BeFalse();
+        jsonFileHandler.DidNotReceive().TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+    }
+
+    [TestMethod]
+    public void TryUpdateSettingsById_FileExistsAndHasNoConnection_ReturnsFalse()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+
+        var succeeded = testSubject.TryUpdateSettingsById("myOrg", new ServerConnectionSettings(true));
+
+        succeeded.Should().BeFalse();
+        jsonFileHandler.DidNotReceive().TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+    }
+
+    [TestMethod]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    public void TryUpdateSettingsById_FileExistsAndConnectionExists_UpdatesSettings(bool oldSmartNotifications, bool newSmartNotifications)
+    {
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(true);
+        MockFileWithOneSonarCloudConnection(oldSmartNotifications);
+
+        var succeeded = testSubject.TryUpdateSettingsById("myOrg", new ServerConnectionSettings(newSmartNotifications));
+
+        succeeded.Should().BeTrue();
+        Received.InOrder(() =>
+        {
+            jsonFileHandler.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>());
+            serverConnectionModelMapper.GetServerConnectionsListJsonModel(Arg.Is<IEnumerable<ServerConnection>>(x => x.Count() == 1 && x.Single().Settings.IsSmartNotificationsEnabled == newSmartNotifications));
+            jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>());
+        });
+    }
+
+    [TestMethod]
+    public void TryUpdateSettingsById_WritingToFileFails_DoesNotUpdateConnection()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+        jsonFileHandler.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>()).Returns(false);
+
+        var succeeded = testSubject.TryUpdateSettingsById("myOrg", new ServerConnectionSettings(true));
+
+        succeeded.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryUpdateSettingsById_WritingThrowsException_DoesNotUpdateConnectionAndWritesLog()
+    {
+        var exceptionMsg = "IO exception";
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+        jsonFileHandler.When(x => x.TryWriteToFile(Arg.Any<string>(), Arg.Any<ServerConnectionsListJsonModel>())).Do(x => throw new Exception(exceptionMsg));
+
+        var succeeded = testSubject.TryUpdateSettingsById(sonarCloud.Id, new ServerConnectionSettings(true));
+
+        succeeded.Should().BeFalse();
+        logger.Received(1).WriteLine(exceptionMsg);
+    }
+
+    [TestMethod]
+    public void TryUpdateCredentialsById_ConnectionDoesNotExist_DoesNotUpdateCredentials()
+    {
+        MockReadingFile(new ServerConnectionsListJsonModel());
+
+        var succeeded = testSubject.TryUpdateCredentialsById("myConn", Substitute.For<ICredentials>());
+
+        succeeded.Should().BeFalse();
+        credentialsLoader.DidNotReceive().Save(Arg.Any<ICredentials>(), Arg.Any<Uri>());
+    }
+
+    [TestMethod]
+    public void TryUpdateCredentialsById_SonarCloudConnectionExists_UpdatesCredentials()
+    {
+        var sonarCloud = MockFileWithOneSonarCloudConnection();
+        var newCredentials = Substitute.For<ICredentials>();
+
+        var succeeded = testSubject.TryUpdateCredentialsById(sonarCloud.Id, newCredentials);
+
+        succeeded.Should().BeTrue();
+        credentialsLoader.Received(1).Save(newCredentials, sonarCloud.CredentialsUri);
+    }
+
+    [TestMethod]
+    public void TryUpdateCredentialsById_SonarQubeConnectionExists_UpdatesCredentials()
+    {
+        var sonarQube = MockFileWithOneSonarQubeConnection();
+        var newCredentials = Substitute.For<ICredentials>();
+
+        var succeeded = testSubject.TryUpdateCredentialsById(sonarQube.Id, newCredentials);
+
+        succeeded.Should().BeTrue();
+        credentialsLoader.Received(1).Save(newCredentials, sonarQube.ServerUri);
+    }
+
+    [TestMethod]
+    public void TryUpdateCredentialsById_SavingCredentialsThrows_ReturnsFalseAndLogs()
+    {
+        var exceptionMsg = "failed";
+        var connection = MockFileWithOneSonarCloudConnection();
+        credentialsLoader.When(x => x.Save(Arg.Any<ICredentials>(), Arg.Any<Uri>())).Do(x => throw new Exception(exceptionMsg));
+
+        var succeeded = testSubject.TryUpdateCredentialsById(connection.Id, Substitute.For<ICredentials>());
+
+        succeeded.Should().BeFalse();
+        logger.Received(1).WriteLine(exceptionMsg);
+    }
+
+    private SonarCloud MockFileWithOneSonarCloudConnection(bool isSmartNotificationsEnabled = true)
+    {
+        var sonarCloudModel = GetSonarCloudJsonModel("myOrg", isSmartNotificationsEnabled);
+        var sonarCloud = new SonarCloud(sonarCloudModel.Id, sonarCloudModel.Settings, Substitute.For<ICredentials>());
+        MockReadingFile(new ServerConnectionsListJsonModel { ServerConnections = [sonarCloudModel] });
+        serverConnectionModelMapper.GetServerConnection(sonarCloudModel).Returns(sonarCloud);
+        
+        return sonarCloud;
+    }
+
+    private ServerConnection.SonarQube MockFileWithOneSonarQubeConnection(bool isSmartNotificationsEnabled = true)
+    {
+        var sonarQubeModel = GetSonarQubeJsonModel(new Uri("http://localhost"), isSmartNotificationsEnabled);
+        var sonarQube = new ServerConnection.SonarQube(new Uri(sonarQubeModel.ServerUri), sonarQubeModel.Settings, Substitute.For<ICredentials>());
+        MockReadingFile(new ServerConnectionsListJsonModel { ServerConnections = [sonarQubeModel] });
+        serverConnectionModelMapper.GetServerConnection(sonarQubeModel).Returns(sonarQube);
+
+        return sonarQube;
+    }
+
+    private void MockReadingFile(ServerConnectionsListJsonModel modelToReturn)
+    {
+        jsonFileHandler.ReadFile<ServerConnectionsListJsonModel>(Arg.Any<string>()).Returns(modelToReturn);
+    }
+
+    private static ServerConnectionJsonModel GetSonarCloudJsonModel(string id, bool isSmartNotificationsEnabled = false)
+    {
+        return new ServerConnectionJsonModel
+        {
+            Id = id,
+            OrganizationKey = id,
+            Settings = new ServerConnectionSettings(isSmartNotificationsEnabled)
+        };
+    }
+
+    private static ServerConnectionJsonModel GetSonarQubeJsonModel(Uri id, bool isSmartNotificationsEnabled = false)
+    {
+        return new ServerConnectionJsonModel
+        {
+            Id = id.ToString(),
+            ServerUri = id.ToString(),
+            Settings = new ServerConnectionSettings(isSmartNotificationsEnabled)
+        };
+    }
+   
+}

--- a/src/ConnectedMode.UnitTests/ServerConnectionsRepositoryAdapterTests.cs
+++ b/src/ConnectedMode.UnitTests/ServerConnectionsRepositoryAdapterTests.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.TestInfrastructure;
 using static SonarLint.VisualStudio.Core.Binding.ServerConnection;
@@ -45,11 +44,11 @@ public class ServerConnectionsRepositoryAdapterTests
     [TestMethod]
     public void GetAllConnections_CallServerConnectionsRepository()
     {
-        serverConnectionsRepository.GetAll().Returns([]);
+        MockServerConnections([]);
 
         var connections = testSubject.GetAllConnections();
 
-        serverConnectionsRepository.Received(1).GetAll();
+        serverConnectionsRepository.Received(1).TryGetAll(out Arg.Any<IReadOnlyList<ServerConnection>>());
         connections.Should().BeEmpty();
     }
 
@@ -59,7 +58,7 @@ public class ServerConnectionsRepositoryAdapterTests
     public void GetAllConnections_HasOneSonarCloudConnection_ReturnsOneMappedConnection(bool isSmartNotificationsEnabled)
     {
         var sonarCloud = CreateSonarCloudServerConnection(isSmartNotificationsEnabled);
-        serverConnectionsRepository.GetAll().Returns([sonarCloud]);
+        MockServerConnections([sonarCloud]);
 
         var connections = testSubject.GetAllConnections();
 
@@ -72,7 +71,7 @@ public class ServerConnectionsRepositoryAdapterTests
     public void GetAllConnections_HasOneSonarQubeConnection_ReturnsOneMappedConnection(bool isSmartNotificationsEnabled)
     {
         var sonarQube = CreateSonarQubeServerConnection(isSmartNotificationsEnabled);
-        serverConnectionsRepository.GetAll().Returns([sonarQube]);
+        MockServerConnections([sonarQube]);
 
         var connections = testSubject.GetAllConnections();
 
@@ -82,11 +81,11 @@ public class ServerConnectionsRepositoryAdapterTests
     [TestMethod]
     public void GetAllConnectionsInfo_CallServerConnectionsRepository()
     {
-        serverConnectionsRepository.GetAll().Returns([]);
+        MockServerConnections([]);
 
         var connections = testSubject.GetAllConnectionsInfo();
 
-        serverConnectionsRepository.Received(1).GetAll();
+        serverConnectionsRepository.Received(1).TryGetAll(out Arg.Any<IReadOnlyList<ServerConnection>>());
         connections.Should().BeEmpty();
     }
 
@@ -94,7 +93,7 @@ public class ServerConnectionsRepositoryAdapterTests
     public void GetAllConnectionsInfo_HasOneSonarCloudConnection_ReturnsOneMappedConnection()
     {
         var sonarCloud = CreateSonarCloudServerConnection();
-        serverConnectionsRepository.GetAll().Returns([sonarCloud]);
+        MockServerConnections([sonarCloud]);
 
         var connections = testSubject.GetAllConnectionsInfo();
 
@@ -105,7 +104,7 @@ public class ServerConnectionsRepositoryAdapterTests
     public void GetAllConnectionsInfo_HasOneSonarQubeConnection_ReturnsOneMappedConnection()
     {
         var sonarQube = CreateSonarQubeServerConnection();
-        serverConnectionsRepository.GetAll().Returns([sonarQube]);
+        MockServerConnections([sonarQube]);
 
         var connections = testSubject.GetAllConnectionsInfo();
 
@@ -121,5 +120,14 @@ public class ServerConnectionsRepositoryAdapterTests
     {
         var sonarQube = new ServerConnection.SonarQube(new Uri("http://localhost"), new ServerConnectionSettings(isSmartNotificationsEnabled), Substitute.For<ICredentials>());
         return sonarQube;
+    }
+
+    private void MockServerConnections(List<ServerConnection> connections)
+    {
+        serverConnectionsRepository.TryGetAll(out Arg.Any<IReadOnlyList<ServerConnection>>()).Returns(callInfo =>
+        {
+            callInfo[0] = connections;
+            return true;
+        });
     }
 }

--- a/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
+++ b/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
@@ -1,0 +1,236 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Binding;
+using System.ComponentModel.Composition;
+using System.IO;
+using SonarLint.VisualStudio.Core.Persistence;
+using SonarLint.VisualStudio.ConnectedMode.Binding;
+
+namespace SonarLint.VisualStudio.ConnectedMode.Persistence;
+
+
+[Export(typeof(IServerConnectionsRepository))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+internal class ServerConnectionsRepository : IServerConnectionsRepository
+{
+    private const string ConnectionsFileName = "connections.json";
+
+    private readonly ISolutionBindingCredentialsLoader credentialsLoader;
+    private readonly ILogger logger;
+    private readonly IJsonFileHandler jsonFileHandle;
+    private readonly IServerConnectionModelMapper serverConnectionModelMapper;
+    private readonly string storageFilePath;
+    private static readonly object LockObject = new();
+
+    [ImportingConstructor]
+    public ServerConnectionsRepository(
+        IJsonFileHandler jsonFileHandle,
+        IServerConnectionModelMapper serverConnectionModelMapper,
+        ICredentialStoreService credentialStoreService,
+        ILogger logger) : this(jsonFileHandle,
+        serverConnectionModelMapper,
+        new SolutionBindingCredentialsLoader(credentialStoreService),
+        EnvironmentVariableProvider.Instance,
+        logger) { }
+
+    internal /* for testing */ ServerConnectionsRepository(
+        IJsonFileHandler jsonFileHandle,
+        IServerConnectionModelMapper serverConnectionModelMapper,
+        ISolutionBindingCredentialsLoader credentialsLoader,
+        IEnvironmentVariableProvider environmentVariables,
+        ILogger logger)
+    {
+        this.jsonFileHandle = jsonFileHandle;
+        this.serverConnectionModelMapper = serverConnectionModelMapper;
+        this.credentialsLoader = credentialsLoader;
+        this.logger = logger;
+        storageFilePath = GetStorageFilePath(environmentVariables);
+    }
+
+    public bool TryGet(string connectionId, out ServerConnection serverConnection)
+    {
+        serverConnection = ReadServerConnectionsFromFile()?.Find(c => c.Id == connectionId);
+        if (serverConnection is null)
+        {
+            return false;
+        }
+
+        serverConnection.Credentials = credentialsLoader.Load(serverConnection.CredentialsUri);
+        return true;
+
+    }
+
+    public bool TryGetAll(out IReadOnlyList<ServerConnection> serverConnections)
+    {
+        serverConnections = ReadServerConnectionsFromFile();
+
+        return serverConnections != null;
+    }
+
+    public bool TryAdd(ServerConnection connectionToAdd)
+    {
+        return SafeUpdateConnectionsFile(connections => TryAddConnection(connections, connectionToAdd));
+    }
+
+    public bool TryDelete(string connectionId)
+    {
+        ServerConnection removedConnection = null;
+        var wasDeleted = SafeUpdateConnectionsFile(connections =>
+        {
+            removedConnection = connections?.Find(c => c.Id == connectionId);
+            connections?.Remove(removedConnection);
+
+            return removedConnection != null;
+        });
+        if (wasDeleted)
+        {
+            TryDeleteCredentials(removedConnection);
+        }
+
+        return wasDeleted;
+    }
+
+    public bool TryUpdateSettingsById(string connectionId, ServerConnectionSettings connectionSettings)
+    {
+        return SafeUpdateConnectionsFile(connections => TryUpdateConnectionSettings(connections, connectionId, connectionSettings));
+    }
+
+    public bool TryUpdateCredentialsById(string connectionId, ICredentials credentials)
+    {
+        try
+        {
+            var wasFound = TryGet(connectionId, out ServerConnection serverConnection);
+            if (wasFound)
+            {
+                credentialsLoader.Save(credentials, serverConnection.CredentialsUri);
+                return true;
+            }
+        }
+        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        {
+            logger.WriteLine(ex.Message);
+        }
+        return false;
+    }
+
+    private bool TryAddConnection(List<ServerConnection> connections, ServerConnection connection)
+    {
+        if (connection.Credentials is null)
+        {
+            logger.LogVerbose($"Connection was not added.{nameof(ServerConnection.Credentials)} is not filled");
+            return false;
+        }
+
+        if (connections.Find(x => x.Id == connection.Id) is not null)
+        {
+            logger.LogVerbose($"Connection was not added.{nameof(ServerConnection.Id)} already exist");
+            return false;
+        }
+
+        try
+        {
+            connections.Add(connection);
+            credentialsLoader.Save(connection.Credentials, connection.CredentialsUri);
+            return true;
+        }
+        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        {
+            logger.WriteLine(ex.Message);
+        }
+
+        return false;
+    }
+
+
+    private void TryDeleteCredentials(ServerConnection removedConnection)
+    {
+        try
+        {
+            credentialsLoader.DeleteCredentials(removedConnection.CredentialsUri);
+        }
+        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        {
+            logger.WriteLine(ex.Message);
+        }
+    }
+
+    private static bool TryUpdateConnectionSettings(List<ServerConnection> connections, string connectionId, ServerConnectionSettings connectionSettings)
+    {
+        var serverConnectionToUpdate = connections?.Find(c => c.Id == connectionId);
+        if (serverConnectionToUpdate == null)
+        {
+            return false;
+        }
+
+        serverConnectionToUpdate.Settings = connectionSettings;
+        return true;
+    }
+
+    private static string GetStorageFilePath(IEnvironmentVariableProvider environmentVariables)
+    {
+        var appDataFolder = environmentVariables.GetSLVSAppDataRootPath();
+        return Path.Combine(appDataFolder, ConnectionsFileName);
+    }
+
+    private List<ServerConnection> ReadServerConnectionsFromFile()
+    {
+        try
+        {
+            var model = jsonFileHandle.ReadFile<ServerConnectionsListJsonModel>(storageFilePath);
+            return model.ServerConnections.Select(serverConnectionModelMapper.GetServerConnection).ToList();
+        }
+        catch (FileNotFoundException)
+        {
+            // file not existing should not be treated as an error, as it will be created at the first write
+            return [];
+        }
+        catch(Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        {
+            logger.WriteLine(ex.Message);
+        }
+
+        return null;
+    }
+
+    private bool SafeUpdateConnectionsFile(Func<List<ServerConnection>, bool> tryUpdateConnectionModels)
+    {
+        lock (LockObject)
+        {
+            try
+            {
+                var serverConnections = ReadServerConnectionsFromFile();
+
+                if (tryUpdateConnectionModels(serverConnections))
+                {
+                    var model = serverConnectionModelMapper.GetServerConnectionsListJsonModel(serverConnections);
+                    return jsonFileHandle.TryWriteToFile(storageFilePath, model);
+                }
+            }
+            catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+            {
+                logger.WriteLine(ex.Message);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
+++ b/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
@@ -32,7 +32,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.Persistence;
 [PartCreationPolicy(CreationPolicy.Shared)]
 internal class ServerConnectionsRepository : IServerConnectionsRepository
 {
-    private const string ConnectionsFileName = "connections.json";
+    internal const string ConnectionsFileName = "connections.json";
 
     private readonly ISolutionBindingCredentialsLoader credentialsLoader;
     private readonly ILogger logger;
@@ -127,7 +127,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         }
         catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
         {
-            logger.WriteLine(ex.Message);
+            logger.WriteLine($"Failed updating credentials: {ex.Message}");
         }
         return false;
     }
@@ -154,7 +154,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         }
         catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
         {
-            logger.WriteLine(ex.Message);
+            logger.WriteLine($"Failed adding server connection: {ex.Message}");
         }
 
         return false;
@@ -169,7 +169,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         }
         catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
         {
-            logger.WriteLine(ex.Message);
+            logger.WriteLine($"Failed deleting credentials: {ex.Message}");
         }
     }
 
@@ -205,7 +205,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         }
         catch(Exception ex) when (!ErrorHandler.IsCriticalException(ex))
         {
-            logger.WriteLine(ex.Message);
+            logger.WriteLine($"Failed reading the {ConnectionsFileName}: {ex.Message}");
         }
 
         return null;
@@ -227,7 +227,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
-                logger.WriteLine(ex.Message);
+                logger.WriteLine($"Failed updating the {ConnectionsFileName}: {ex.Message}");
             }
 
             return false;

--- a/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
+++ b/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
@@ -25,23 +25,26 @@ namespace SonarLint.VisualStudio.ConnectedMode;
 
 public interface IServerConnectionsRepositoryAdapter
 {
-    List<Connection> GetAllConnections();
-    List<ConnectionInfo> GetAllConnectionsInfo();
+    bool TryGetAllConnections(out List<Connection> connections);
+    bool TryGetAllConnectionsInfo(out List<ConnectionInfo> connectionInfos);
 }
 
 [Export(typeof(IServerConnectionsRepositoryAdapter))]
 [method: ImportingConstructor]
 internal class ServerConnectionsRepositoryAdapter(IServerConnectionsRepository serverConnectionsRepository) : IServerConnectionsRepositoryAdapter
 {
-    public List<Connection> GetAllConnections()
+    public bool TryGetAllConnections(out List<Connection> connections)
     {
-        serverConnectionsRepository.TryGetAll(out var connections);
-        return connections.Select(MapServerConnectionModel).ToList();
+        var succeeded = serverConnectionsRepository.TryGetAll(out var serverConnections);
+        connections = serverConnections?.Select(MapServerConnectionModel).ToList();
+        return succeeded;
     }
 
-    public List<ConnectionInfo> GetAllConnectionsInfo()
+    public bool TryGetAllConnectionsInfo(out List<ConnectionInfo> connectionInfos)
     {
-        return GetAllConnections().Select(conn => conn.Info).ToList();
+        var succeeded = TryGetAllConnections(out var connections);
+        connectionInfos = connections?.Select(conn => conn.Info).ToList();
+        return succeeded;
     }
 
     private static Connection MapServerConnectionModel(ServerConnection serverConnection)

--- a/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
+++ b/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
@@ -35,7 +35,7 @@ internal class ServerConnectionsRepositoryAdapter(IServerConnectionsRepository s
 {
     public List<Connection> GetAllConnections()
     {
-        var connections = serverConnectionsRepository.GetAll();
+        serverConnectionsRepository.TryGetAll(out var connections);
         return connections.Select(MapServerConnectionModel).ToList();
     }
 

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
@@ -175,26 +175,28 @@ public class ManageBindingViewModel(
 
     internal async Task<AdapterResponse> LoadDataAsync()
     {
+        var succeeded = false;
         try
         {
-            await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(LoadConnections);
-            return new AdapterResponse(true);
+            await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(() => succeeded = LoadConnections());
         }
         catch (Exception ex)
         {
             connectedModeServices.Logger.WriteLine(ex.Message);
+            succeeded = false;
         }
 
-        return new AdapterResponse(false);
+        return new AdapterResponse(succeeded);
     }
 
-    internal void LoadConnections()
+    internal bool LoadConnections()
     {
         Connections.Clear();
-        var slCoreConnections = connectedModeServices.ServerConnectionsRepositoryAdapter.GetAllConnectionsInfo();
-        slCoreConnections.ForEach(Connections.Add);
+        var succeeded = connectedModeServices.ServerConnectionsRepositoryAdapter.TryGetAllConnectionsInfo(out var slCoreConnections);
+        slCoreConnections?.ForEach(Connections.Add);
 
         RaisePropertyChanged(nameof(IsConnectionSelectionEnabled));
         RaisePropertyChanged(nameof(ConnectionSelectionCaptionText));
+        return succeeded;
     }
 }

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
@@ -38,24 +38,26 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 
         internal async Task<AdapterResponse> LoadConnectionsAsync()
         {
+            var succeeded = false;
             try
             {
-                await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(InitializeConnections);
-                return new AdapterResponse(true);
+                await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(() => succeeded = InitializeConnections());
             }
             catch (Exception ex)
             {
                 connectedModeServices.Logger.WriteLine(ex.Message);
+                succeeded = false;
             }
 
-            return new AdapterResponse(false);
+            return new AdapterResponse(succeeded);
         }
 
-        internal void InitializeConnections()
+        internal bool InitializeConnections()
         {
             ConnectionViewModels.Clear();
-            var connections = connectedModeServices.ServerConnectionsRepositoryAdapter.GetAllConnections();
-            connections.ToList().ForEach(AddConnection);
+            var succeeded = connectedModeServices.ServerConnectionsRepositoryAdapter.TryGetAllConnections(out var connections);
+            connections?.ForEach(AddConnection);
+            return succeeded;
         }
 
         public void RemoveConnection(ConnectionViewModel connectionViewModel)

--- a/src/Core/Binding/IServerConnectionsRepository.cs
+++ b/src/Core/Binding/IServerConnectionsRepository.cs
@@ -26,45 +26,9 @@ namespace SonarLint.VisualStudio.Core.Binding;
 public interface IServerConnectionsRepository
 {
     bool TryGet(string connectionId, out ServerConnection serverConnection);
-    List<ServerConnection> GetAll();
-    bool TryAdd(ServerConnection connection);
+    bool TryGetAll(out IReadOnlyList<ServerConnection> serverConnections);
+    bool TryAdd(ServerConnection connectionToAdd);
     bool TryDelete(string connectionId);
-    Task<bool> TryUpdateSettingsById(string connectionId, ServerConnectionSettings connectionSettings);
-    Task<bool> TryUpdateCredentialsById(string connectionId, ICredentials credentials);
-}
-
-[ExcludeFromCodeCoverage] // todo: remove this class in https://sonarsource.atlassian.net/browse/SLVS-1399
-[Export(typeof(IServerConnectionsRepository))]
-[PartCreationPolicy(CreationPolicy.Shared)]
-public class DummyServerConnectionsRepository : IServerConnectionsRepository
-{
-    public bool TryGet(string connectionId, out ServerConnection serverConnection)
-    {
-        throw new NotImplementedException();
-    }
-
-    public List<ServerConnection> GetAll()
-    {
-        return [new ServerConnection.SonarCloud("a")];
-    }
-
-    public bool TryAdd(ServerConnection connection)
-    {
-        throw new NotImplementedException();
-    }
-
-    public bool TryDelete(string connectionId)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<bool> TryUpdateSettingsById(string connectionId, ServerConnectionSettings connectionSettings)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<bool> TryUpdateCredentialsById(string connectionId, ICredentials credentials)
-    {
-        throw new NotImplementedException();
-    }
+    bool TryUpdateSettingsById(string connectionId, ServerConnectionSettings connectionSettings);
+    bool TryUpdateCredentialsById(string connectionId, ICredentials credentials);
 }


### PR DESCRIPTION
[SLVS-1399](https://sonarsource.atlassian.net/browse/SLVS-1399)

This PR targets this [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/5661), because it depends on it for the implementation.

The server connections could be tested with the UI: if the file exists, the connections are shown in the manage binding dialog and manage connections dialog. Adding a connection with the UI is not implemented yet.

Example of a valid json:
{
  "serverConnections": [
    {
      "id": "https://sonarcloud.io/organizations/myOrg",
      "setting": {
        "IsSmartNotificationsEnabled": false
      },
      "organizationKey": "mya",
      "serverUri": null
    }
  ]
}

[SLVS-1399]: https://sonarsource.atlassian.net/browse/SLVS-1399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ