### PR TITLE
SLVS-1423 Update embedded SonarText analyzer to 2.15.0.3845

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -7,7 +7,7 @@
     <EmbeddedSonarAnalyzerVersion>9.30.0.95878</EmbeddedSonarAnalyzerVersion>
     <EmbeddedSonarCFamilyAnalyzerVersion>6.57.0.73017</EmbeddedSonarCFamilyAnalyzerVersion>
     <EmbeddedSonarJSAnalyzerVersion>10.14.0.26080</EmbeddedSonarJSAnalyzerVersion>
-    <EmbeddedSonarSecretsJarVersion>2.13.0.3515</EmbeddedSonarSecretsJarVersion>
+    <EmbeddedSonarSecretsJarVersion>2.15.0.3845</EmbeddedSonarSecretsJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->
     <EmbeddedSloopVersion>10.4.0.78811</EmbeddedSloopVersion>
   </PropertyGroup>


### PR DESCRIPTION
[SLVS-1423](https://sonarsource.atlassian.net/browse/SLVS-1423)

This build fails, because the artifact for the SonarText 2.15.0.3845 was not published to the expected binaries location. But once we [change](https://github.com/SonarSource/sonarlint-visualstudio/pull/5674) the download logic to take the analyzer from repox, it should pass.


[SLVS-1423]: https://sonarsource.atlassian.net/browse/SLVS-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ