### PR TITLE
SLVS-1442 Fix JRE not persisted

### DIFF
--- a/src/Integration.Vsix/Settings/GeneralOptionsDialogControl.xaml
+++ b/src/Integration.Vsix/Settings/GeneralOptionsDialogControl.xaml
@@ -69,7 +69,7 @@
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Text="{x:Static res:Strings.JreLocationDescriptionText}" />
-                <TextBox Grid.Row="1" Margin="0,5" Text="{Binding Path=JreLocation}"/>
+                <TextBox Grid.Row="1" Margin="0,5" Text="{Binding Path=JreLocation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                 <TextBlock Grid.Row="2" Text="{x:Static res:Strings.RestartIdeToApplyOptionLabel}" />
             </Grid>
         </GroupBox>


### PR DESCRIPTION
The problem seemed to be that the binding was not updating the value of the view model property, so when the OK button was pressed in the Options page, the previous value was overwritten 