### PR TITLE
SLVS-1393 Delete Connection Dialog: User should be able to delete a connectionGt/delete connection

### DIFF
--- a/src/ConnectedMode.UnitTests/ServerConnectionsRepositoryAdapterTests.cs
+++ b/src/ConnectedMode.UnitTests/ServerConnectionsRepositoryAdapterTests.cs
@@ -145,7 +145,7 @@ public class ServerConnectionsRepositoryAdapterTests
         var connectionInfoId = "http://localhost:9000";
         serverConnectionsRepository.TryDelete(connectionInfoId).Returns(expectedStatus);
 
-        var succeeded = testSubject.TryDeleteConnection(connectionInfoId);
+        var succeeded = testSubject.TryRemoveConnection(connectionInfoId);
 
         succeeded.Should().Be(expectedStatus);
     }

--- a/src/ConnectedMode.UnitTests/ServerConnectionsRepositoryAdapterTests.cs
+++ b/src/ConnectedMode.UnitTests/ServerConnectionsRepositoryAdapterTests.cs
@@ -137,6 +137,19 @@ public class ServerConnectionsRepositoryAdapterTests
         succeeded.Should().Be(expectedStatus);
     }
 
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void TryDeleteConnection_ReturnsStatusFromSlCore(bool expectedStatus)
+    {
+        var connectionInfoId = "http://localhost:9000";
+        serverConnectionsRepository.TryDelete(connectionInfoId).Returns(expectedStatus);
+
+        var succeeded = testSubject.TryDeleteConnection(connectionInfoId);
+
+        succeeded.Should().Be(expectedStatus);
+    }
+
     private static SonarCloud CreateSonarCloudServerConnection(bool isSmartNotificationsEnabled = true)
     {
         return new SonarCloud("myOrg", new ServerConnectionSettings(isSmartNotificationsEnabled), Substitute.For<ICredentials>());

--- a/src/ConnectedMode.UnitTests/UI/ManageConnections/ManageConnectionsViewModelTest.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageConnections/ManageConnectionsViewModelTest.cs
@@ -71,15 +71,15 @@ public class ManageConnectionsViewModelTest
     }
 
     [TestMethod]
-    public async Task DeleteConnectionWithProgressAsync_InitializesDataAndReportsProgress()
+    public async Task RemoveConnectionWithProgressAsync_InitializesDataAndReportsProgress()
     {
-        await testSubject.DeleteConnectionWithProgressAsync(new ConnectionViewModel(new Connection(new ConnectionInfo("myOrg", ConnectionServerType.SonarCloud))));
+        await testSubject.RemoveConnectionWithProgressAsync(new ConnectionViewModel(new Connection(new ConnectionInfo("myOrg", ConnectionServerType.SonarCloud))));
 
         await progressReporterViewModel.Received(1)
             .ExecuteTaskWithProgressAsync(
                 Arg.Is<TaskToPerformParams<AdapterResponse>>(x =>
-                    x.ProgressStatus == UiResources.DeletingConnectionText &&
-                    x.WarningText == UiResources.DeletingConnectionFailedText));
+                    x.ProgressStatus == UiResources.RemovingConnectionText &&
+                    x.WarningText == UiResources.RemovingConnectionFailedText));
     }
 
     [TestMethod]
@@ -89,20 +89,20 @@ public class ManageConnectionsViewModelTest
     {
         InitializeTwoConnections();
         var connectionToRemove = testSubject.ConnectionViewModels[0];
-        serverConnectionsRepositoryAdapter.TryDeleteConnection(connectionToRemove.Connection.Info.Id).Returns(expectedStatus);
+        serverConnectionsRepositoryAdapter.TryRemoveConnection(connectionToRemove.Connection.Info.Id).Returns(expectedStatus);
 
         var succeeded = testSubject.RemoveConnection(connectionToRemove);
 
         succeeded.Should().Be(expectedStatus);
-        serverConnectionsRepositoryAdapter.Received(1).TryDeleteConnection(connectionToRemove.Connection.Info.Id);
+        serverConnectionsRepositoryAdapter.Received(1).TryRemoveConnection(connectionToRemove.Connection.Info.Id);
     }
 
     [TestMethod]
-    public void RemoveConnection_ConnectionWasDeleted_RemovesProvidedConnectionViewModel()
+    public void RemoveConnection_ConnectionWasRemoved_RemovesProvidedConnectionViewModel()
     {
         InitializeTwoConnections();
         var connectionToRemove = testSubject.ConnectionViewModels[0];
-        serverConnectionsRepositoryAdapter.TryDeleteConnection(connectionToRemove.Connection.Info.Id).Returns(true);
+        serverConnectionsRepositoryAdapter.TryRemoveConnection(connectionToRemove.Connection.Info.Id).Returns(true);
 
         testSubject.RemoveConnection(connectionToRemove);
 
@@ -111,11 +111,11 @@ public class ManageConnectionsViewModelTest
     }
 
     [TestMethod]
-    public void RemoveConnection_ConnectionWasNotDeleted_DoesNotRemoveProvidedConnectionViewModel()
+    public void RemoveConnection_ConnectionWasNotRemoved_DoesNotRemoveProvidedConnectionViewModel()
     {
         InitializeTwoConnections();
         var connectionToRemove = testSubject.ConnectionViewModels[0];
-        serverConnectionsRepositoryAdapter.TryDeleteConnection(connectionToRemove.Connection.Info.Id).Returns(false);
+        serverConnectionsRepositoryAdapter.TryRemoveConnection(connectionToRemove.Connection.Info.Id).Returns(false);
 
         testSubject.RemoveConnection(connectionToRemove);
 
@@ -124,10 +124,10 @@ public class ManageConnectionsViewModelTest
     }
 
     [TestMethod]
-    public void RemoveConnection_ConnectionWasDeleted_RaisesEvents()
+    public void RemoveConnection_ConnectionWasRemoved_RaisesEvents()
     {
         InitializeTwoConnections();
-        serverConnectionsRepositoryAdapter.TryDeleteConnection(Arg.Any<string>()).Returns(true);
+        serverConnectionsRepositoryAdapter.TryRemoveConnection(Arg.Any<string>()).Returns(true);
         var eventHandler = Substitute.For<PropertyChangedEventHandler>();
         testSubject.PropertyChanged += eventHandler;
 
@@ -137,10 +137,10 @@ public class ManageConnectionsViewModelTest
     }
 
     [TestMethod]
-    public void RemoveConnection_ConnectionWasNotDeleted_DoesNotRaiseEvents()
+    public void RemoveConnection_ConnectionWasNotRemoved_DoesNotRaiseEvents()
     {
         InitializeTwoConnections();
-        serverConnectionsRepositoryAdapter.TryDeleteConnection(Arg.Any<string>()).Returns(false);
+        serverConnectionsRepositoryAdapter.TryRemoveConnection(Arg.Any<string>()).Returns(false);
         var eventHandler = Substitute.For<PropertyChangedEventHandler>();
         testSubject.PropertyChanged += eventHandler;
 

--- a/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
+++ b/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
@@ -27,6 +27,7 @@ public interface IServerConnectionsRepositoryAdapter
 {
     bool TryGetAllConnections(out List<Connection> connections);
     bool TryGetAllConnectionsInfo(out List<ConnectionInfo> connectionInfos);
+    bool TryDeleteConnection(string connectionInfoId);
 }
 
 [Export(typeof(IServerConnectionsRepositoryAdapter))]
@@ -45,6 +46,11 @@ internal class ServerConnectionsRepositoryAdapter(IServerConnectionsRepository s
         var succeeded = TryGetAllConnections(out var connections);
         connectionInfos = connections?.Select(conn => conn.Info).ToList();
         return succeeded;
+    }
+
+    public bool TryDeleteConnection(string connectionInfoId)
+    {
+       return serverConnectionsRepository.TryDelete(connectionInfoId);
     }
 
     private static Connection MapServerConnectionModel(ServerConnection serverConnection)

--- a/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
+++ b/src/ConnectedMode/ServerConnectionsRepositoryAdapter.cs
@@ -27,7 +27,7 @@ public interface IServerConnectionsRepositoryAdapter
 {
     bool TryGetAllConnections(out List<Connection> connections);
     bool TryGetAllConnectionsInfo(out List<ConnectionInfo> connectionInfos);
-    bool TryDeleteConnection(string connectionInfoId);
+    bool TryRemoveConnection(string connectionInfoId);
 }
 
 [Export(typeof(IServerConnectionsRepositoryAdapter))]
@@ -48,7 +48,7 @@ internal class ServerConnectionsRepositoryAdapter(IServerConnectionsRepository s
         return succeeded;
     }
 
-    public bool TryDeleteConnection(string connectionInfoId)
+    public bool TryRemoveConnection(string connectionInfoId)
     {
        return serverConnectionsRepository.TryDelete(connectionInfoId);
     }

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -41,9 +41,10 @@ public partial class ManageBindingDialog : Window
 
     public ManageBindingViewModel ViewModel { get; }
 
-    private void ManageConnections_OnClick(object sender, RoutedEventArgs e)
+    private async void ManageConnections_OnClick(object sender, RoutedEventArgs e)
     {
         new ManageConnectionsDialog(connectedModeServices).ShowDialog(this);
+        await ViewModel.InitializeDataAsync();
     }
 
     private void Binding_OnClick(object sender, RoutedEventArgs e)

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
@@ -111,7 +111,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             var deleteConnectionDialog = new DeleteConnectionDialog([], connectionViewModel.Connection.Info);
             if(deleteConnectionDialog.ShowDialog(this) == true)
             {
-                await ViewModel.DeleteConnectionWithProgressAsync(connectionViewModel);
+                await ViewModel.RemoveConnectionWithProgressAsync(connectionViewModel);
             }
         }
     }

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
@@ -101,20 +101,17 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             await ViewModel.LoadConnectionsWithProgressAsync();
         }
 
-        private void RemoveConnectionButton_OnClick(object sender, RoutedEventArgs e)
+        private async void RemoveConnectionButton_OnClick(object sender, RoutedEventArgs e)
         {
             if (sender is not System.Windows.Controls.Button { DataContext: ConnectionViewModel connectionViewModel })
             {
                 return;
             }
 
-            var deleteConnectionDialog = new DeleteConnectionDialog([
-                new ConnectedModeProject(new ServerProject("my proj key", "my proj name"), new SolutionInfoModel("my sol", SolutionType.Solution)),
-                new ConnectedModeProject(new ServerProject("my folder key", "my folder name"), new SolutionInfoModel("my folder", SolutionType.Folder))
-            ], connectionViewModel.Connection.Info);
+            var deleteConnectionDialog = new DeleteConnectionDialog([], connectionViewModel.Connection.Info);
             if(deleteConnectionDialog.ShowDialog(this) == true)
             {
-                ViewModel.RemoveConnection(connectionViewModel);
+                await ViewModel.DeleteConnectionWithProgressAsync(connectionViewModel);
             }
         }
     }

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
@@ -36,12 +36,12 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             await ProgressReporterViewModel.ExecuteTaskWithProgressAsync(validationParams);
         }
 
-        public async Task DeleteConnectionWithProgressAsync(ConnectionViewModel connectionViewModel)
+        public async Task RemoveConnectionWithProgressAsync(ConnectionViewModel connectionViewModel)
         {
             var validationParams = new TaskToPerformParams<AdapterResponse>(
                 async () => await SafeExecuteActionAsync(() => RemoveConnection(connectionViewModel)),
-                UiResources.DeletingConnectionText,
-                UiResources.DeletingConnectionFailedText);
+                UiResources.RemovingConnectionText,
+                UiResources.RemovingConnectionFailedText);
             await ProgressReporterViewModel.ExecuteTaskWithProgressAsync(validationParams);
         }
 
@@ -86,7 +86,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 
         internal bool RemoveConnection(ConnectionViewModel connectionViewModel)
         {
-            var succeeded = connectedModeServices.ServerConnectionsRepositoryAdapter.TryDeleteConnection(connectionViewModel.Connection.Info.Id);
+            var succeeded = connectedModeServices.ServerConnectionsRepositoryAdapter.TryRemoveConnection(connectionViewModel.Connection.Info.Id);
             if (succeeded)
             {
                 ConnectionViewModels.Remove(connectionViewModel);

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
@@ -36,6 +36,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             await ProgressReporterViewModel.ExecuteTaskWithProgressAsync(validationParams);
         }
 
+        public async Task DeleteConnectionWithProgressAsync(ConnectionViewModel connectionViewModel)
+        {
+            var validationParams = new TaskToPerformParams<AdapterResponse>(
+                async () => await SafeExecuteActionAsync(() => RemoveConnection(connectionViewModel)),
+                UiResources.DeletingConnectionText,
+                UiResources.DeletingConnectionFailedText);
+            await ProgressReporterViewModel.ExecuteTaskWithProgressAsync(validationParams);
+        }
+
         internal async Task<AdapterResponse> LoadConnectionsAsync()
         {
             var succeeded = false;
@@ -52,6 +61,21 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             return new AdapterResponse(succeeded);
         }
 
+        internal async Task<AdapterResponse> SafeExecuteActionAsync(Func<bool> funcToExecute)
+        {
+            var succeeded = false;
+            try
+            {
+                await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(() => succeeded = funcToExecute());
+            }
+            catch (Exception ex)
+            {
+                connectedModeServices.Logger.WriteLine(ex.Message);
+                succeeded = false;
+            }
+            return new AdapterResponse(succeeded);
+        }
+
         internal bool InitializeConnections()
         {
             ConnectionViewModels.Clear();
@@ -60,10 +84,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             return succeeded;
         }
 
-        public void RemoveConnection(ConnectionViewModel connectionViewModel)
+        internal bool RemoveConnection(ConnectionViewModel connectionViewModel)
         {
-            ConnectionViewModels.Remove(connectionViewModel);
-            RaisePropertyChanged(nameof(NoConnectionExists));
+            var succeeded = connectedModeServices.ServerConnectionsRepositoryAdapter.TryDeleteConnection(connectionViewModel.Connection.Info.Id);
+            if (succeeded)
+            {
+                ConnectionViewModels.Remove(connectionViewModel);
+                RaisePropertyChanged(nameof(NoConnectionExists));
+            }
+            return succeeded;
         }
 
         public void AddConnection(Connection connection)

--- a/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
+++ b/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
@@ -277,6 +277,24 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deleting the connection failed.
+        /// </summary>
+        public static string DeletingConnectionFailedText {
+            get {
+                return ResourceManager.GetString("DeletingConnectionFailedText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting connection....
+        /// </summary>
+        public static string DeletingConnectionText {
+            get {
+                return ResourceManager.GetString("DeletingConnectionText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authentication via username and password is deprecated and will be removed in the future. Please use a token instead..
         /// </summary>
         public static string DeprecatedAuthenticationTypeDescription {

--- a/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
+++ b/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
@@ -277,24 +277,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deleting the connection failed.
-        /// </summary>
-        public static string DeletingConnectionFailedText {
-            get {
-                return ResourceManager.GetString("DeletingConnectionFailedText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Deleting connection....
-        /// </summary>
-        public static string DeletingConnectionText {
-            get {
-                return ResourceManager.GetString("DeletingConnectionText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Authentication via username and password is deprecated and will be removed in the future. Please use a token instead..
         /// </summary>
         public static string DeprecatedAuthenticationTypeDescription {
@@ -606,6 +588,24 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         public static string RemoveConnectionToolTip {
             get {
                 return ResourceManager.GetString("RemoveConnectionToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing the connection failed.
+        /// </summary>
+        public static string RemovingConnectionFailedText {
+            get {
+                return ResourceManager.GetString("RemovingConnectionFailedText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing connection....
+        /// </summary>
+        public static string RemovingConnectionText {
+            get {
+                return ResourceManager.GetString("RemovingConnectionText", resourceCulture);
             }
         }
         

--- a/src/ConnectedMode/UI/Resources/UiResources.resx
+++ b/src/ConnectedMode/UI/Resources/UiResources.resx
@@ -357,4 +357,10 @@
   <data name="LoadingConnectionsText" xml:space="preserve">
     <value>Loading connections...</value>
   </data>
+  <data name="DeletingConnectionFailedText" xml:space="preserve">
+    <value>Deleting the connection failed</value>
+  </data>
+  <data name="DeletingConnectionText" xml:space="preserve">
+    <value>Deleting connection...</value>
+  </data>
 </root>

--- a/src/ConnectedMode/UI/Resources/UiResources.resx
+++ b/src/ConnectedMode/UI/Resources/UiResources.resx
@@ -357,10 +357,10 @@
   <data name="LoadingConnectionsText" xml:space="preserve">
     <value>Loading connections...</value>
   </data>
-  <data name="DeletingConnectionFailedText" xml:space="preserve">
-    <value>Deleting the connection failed</value>
+  <data name="RemovingConnectionFailedText" xml:space="preserve">
+    <value>Removing the connection failed</value>
   </data>
-  <data name="DeletingConnectionText" xml:space="preserve">
-    <value>Deleting connection...</value>
+  <data name="RemovingConnectionText" xml:space="preserve">
+    <value>Removing connection...</value>
   </data>
 </root>


### PR DESCRIPTION
[SLVS-1393](https://sonarsource.atlassian.net/browse/SLVS-1393)

Prevent deleting the connection when there are bindings that use that connection will be done in a separate PR, because it depends on the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/5685) (to get the list of bindings that contain the ConnectionId info). And that PR is still work in progress

[SLVS-1393]: https://sonarsource.atlassian.net/browse/SLVS-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ