### PR TITLE
SLVS-1400 Add migration mechanism to separate connections from bindings

### DIFF
--- a/src/ConnectedMode.UnitTests/Migration/BindingToConnectionMigrationTests.cs
+++ b/src/ConnectedMode.UnitTests/Migration/BindingToConnectionMigrationTests.cs
@@ -1,0 +1,263 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO.Abstractions;
+using SonarLint.VisualStudio.ConnectedMode.Binding;
+using SonarLint.VisualStudio.ConnectedMode.Migration;
+using SonarLint.VisualStudio.ConnectedMode.Persistence;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Infrastructure.VS;
+using SonarLint.VisualStudio.TestInfrastructure;
+using SonarQube.Client.Helpers;
+
+namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Migration;
+
+[TestClass]
+public class BindingToConnectionMigrationTests
+{
+    private BindingToConnectionMigration testSubject;
+    private IFileSystem fileSystem;
+    private IServerConnectionsRepository serverConnectionsRepository;
+    private ILegacySolutionBindingRepository legacyBindingRepository;
+    private IUnintrusiveBindingPathProvider unintrusiveBindingPathProvider;
+    private IThreadHandling threadHandling;
+    private ILogger logger;
+    private ISolutionBindingRepository solutionBindingRepository;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        fileSystem = Substitute.For<IFileSystem>();
+        serverConnectionsRepository = Substitute.For<IServerConnectionsRepository>();
+        legacyBindingRepository = Substitute.For<ILegacySolutionBindingRepository>();
+        solutionBindingRepository = Substitute.For<ISolutionBindingRepository>();
+        unintrusiveBindingPathProvider = Substitute.For<IUnintrusiveBindingPathProvider>();
+        logger = Substitute.For<ILogger>();
+        threadHandling = new NoOpThreadHandler();
+
+        testSubject = new BindingToConnectionMigration(
+            fileSystem,
+            serverConnectionsRepository,
+            legacyBindingRepository,
+            solutionBindingRepository,
+            unintrusiveBindingPathProvider,
+            threadHandling,
+            logger);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckExports()
+    {
+        MefTestHelpers.CheckTypeCanBeImported<BindingToConnectionMigration, IBindingToConnectionMigration>(
+            MefTestHelpers.CreateExport<IServerConnectionsRepository>(),
+            MefTestHelpers.CreateExport<ILegacySolutionBindingRepository>(),
+            MefTestHelpers.CreateExport<ISolutionBindingRepository>(),
+            MefTestHelpers.CreateExport<IUnintrusiveBindingPathProvider>(),
+            MefTestHelpers.CreateExport<ILogger>());
+    }
+
+    [TestMethod]
+    public void Mef_CheckIsSingleton()
+    {
+        MefTestHelpers.CheckIsSingletonMefComponent<BindingToConnectionMigration>();
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_RunsOnBackgroundThread()
+    {
+        var mockedThreadHandling = Substitute.For<IThreadHandling>();
+        var migrateBindingToServer = new BindingToConnectionMigration(
+            fileSystem,
+            serverConnectionsRepository,
+            legacyBindingRepository,
+            solutionBindingRepository,
+            unintrusiveBindingPathProvider,
+            mockedThreadHandling,
+            logger);
+
+        await migrateBindingToServer.MigrateBindingToServerConnectionIfNeededAsync();
+
+        mockedThreadHandling.ReceivedCalls().Should().Contain(call => call.GetMethodInfo().Name == nameof(IThreadHandling.RunOnBackgroundThread));
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_ConnectionsStorageFileExists_ShouldNotMigrate()
+    {
+        fileSystem.File.Exists(serverConnectionsRepository.ConnectionsStorageFilePath).Returns(true);
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        fileSystem.File.Received(1).Exists(serverConnectionsRepository.ConnectionsStorageFilePath);
+        serverConnectionsRepository.DidNotReceiveWithAnyArgs().TryAdd(default);
+        unintrusiveBindingPathProvider.DidNotReceive().GetBindingPaths();
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_ConnectionsStorageDoesNotExists_PerformsMigration()
+    {
+        CreateTwoBindingPathsToMockedBoundProject();
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        Received.InOrder(() =>
+        {
+            fileSystem.File.Exists(serverConnectionsRepository.ConnectionsStorageFilePath);
+            logger.WriteLine(MigrationStrings.ConnectionMigration_StartMigration);
+            unintrusiveBindingPathProvider.GetBindingPaths();
+            serverConnectionsRepository.TryAdd(Arg.Any<ServerConnection>());
+            serverConnectionsRepository.TryAdd(Arg.Any<ServerConnection>());
+        });
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_MigrationIsExecuted_CreatesServerConnectionsFromBinding()
+    {
+        var boundProjects = CreateTwoBindingPathsToMockedBoundProject().Values.ToList();
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        serverConnectionsRepository.Received(1).TryAdd(Arg.Is<ServerConnection>(conn => conn.Id == boundProjects[0].ServerUri.ToString()));
+        serverConnectionsRepository.Received(1).TryAdd(Arg.Is<ServerConnection>(conn => conn.Id == boundProjects[1].ServerUri.ToString()));
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_MigrationIsExecuted_UpdatesBindingWithServerConnection()
+    {
+        var bindingPathToBoundProjectDictionary = CreateTwoBindingPathsToMockedBoundProject();
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        CheckBindingsWereMigrated(bindingPathToBoundProjectDictionary);
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_MigrationIsExecutedForTwoBindingsWithTheSameConnections_MigratesServerConnectionOnceAndUpdatesBothBindings()
+    {
+        var bindingPathToBoundProjectDictionary = CreateTwoBindingPathsToMockedBoundProject();
+        var boundProjects = bindingPathToBoundProjectDictionary.Values.ToList();
+        var expectedServerConnectionId = boundProjects[0].ServerUri.ToString();
+        serverConnectionsRepository.TryGet(expectedServerConnectionId, out _).Returns(true);
+        
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        logger.Received(1).WriteLine(string.Format(MigrationStrings.ConnectionMigration_ExistingServerConnectionNotMigrated, expectedServerConnectionId));
+        serverConnectionsRepository.DidNotReceive().TryAdd(Arg.Is<ServerConnection>(conn => conn.Id == expectedServerConnectionId));
+        CheckBindingsWereMigrated(bindingPathToBoundProjectDictionary);
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_ReadingBindingReturnsNull_SkipsAndLogs()
+    {
+        var boundProjects = CreateTwoBindingPathsToMockedBoundProject();
+        var bindingPathToExclude = boundProjects.Keys.First();
+        legacyBindingRepository.Read(Arg.Is<string>(path => path == bindingPathToExclude)).Returns((BoundSonarQubeProject)null);
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        logger.Received(1).WriteLine(string.Format(MigrationStrings.ConnectionMigration_BindingNotMigrated, bindingPathToExclude, "legacyBoundProject was not found"));
+        serverConnectionsRepository.DidNotReceive().TryAdd(Arg.Is<ServerConnection>(conn => IsExpectedServerConnection(conn, boundProjects.First().Value)));
+        solutionBindingRepository.DidNotReceive().Write(bindingPathToExclude, Arg.Any<BoundServerProject>());
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_MigratingConnectionFails_SkipsAndLogs()
+    {
+        var boundPathToBoundProject = CreateTwoBindingPathsToMockedBoundProject().First();
+        serverConnectionsRepository.TryAdd(Arg.Is<ServerConnection>(conn => IsExpectedServerConnection(conn, boundPathToBoundProject.Value))).Returns(false);
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        logger.Received(1).WriteLine(string.Format(MigrationStrings.ConnectionMigration_ServerConnectionNotMigrated, boundPathToBoundProject.Value.ServerUri));
+        serverConnectionsRepository.Received(1).TryAdd(Arg.Is<ServerConnection>(conn => IsExpectedServerConnection(conn, boundPathToBoundProject.Value)));
+        solutionBindingRepository.DidNotReceive().Write(boundPathToBoundProject.Key, Arg.Any<BoundServerProject>());
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_MigrationIsExecuted_CredentialsAreMigrated()
+    {
+        var boundProjects = CreateTwoBindingPathsToMockedBoundProject().Values.ToList();
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        CheckCredentialsAreLoaded(boundProjects[0]);
+        CheckCredentialsAreLoaded(boundProjects[1]);
+    }
+
+    [TestMethod]
+    public async Task MigrateBindingToServerConnectionIfNeeded_MigrationThrowsException_ErrorIsLogged()
+    {
+        var boundProjects = CreateTwoBindingPathsToMockedBoundProject();
+        var errorMessage = "loading failed";
+        solutionBindingRepository.When(repo => repo.Write(Arg.Any<string>(), Arg.Any<BoundServerProject>())).Throw(new Exception(errorMessage));
+
+        await testSubject.MigrateBindingToServerConnectionIfNeededAsync();
+
+        logger.Received(1).WriteLine(string.Format(MigrationStrings.ConnectionMigration_BindingNotMigrated, boundProjects.First().Key, errorMessage));
+        logger.Received(1).WriteLine(string.Format(MigrationStrings.ConnectionMigration_BindingNotMigrated, boundProjects.Last().Key, errorMessage));
+    }
+
+    private Dictionary<string, BoundSonarQubeProject> CreateTwoBindingPathsToMockedBoundProject()
+    {
+        Dictionary<string, BoundSonarQubeProject> pathToBindings = new()
+        {
+            {"bindings/proj1/binding.config", CreateBoundProject("http://server1", "proj1")},
+            {"bindings/proj2/binding.config", CreateBoundProject("http://server2", "proj2")}
+        };
+        unintrusiveBindingPathProvider.GetBindingPaths().Returns(pathToBindings.Select(kvp => kvp.Key));
+        foreach (var kvp in pathToBindings)
+        {
+            MockValidBinding(kvp.Key, kvp.Value);
+        }
+        return pathToBindings;
+    }
+
+    private void MockValidBinding(string bindingPath, BoundSonarQubeProject sonarQubeProject)
+    {
+        legacyBindingRepository.Read(bindingPath).Returns(sonarQubeProject);
+        serverConnectionsRepository.TryAdd(Arg.Is<ServerConnection>(conn => IsExpectedServerConnection(conn, sonarQubeProject))).Returns(true);
+    }
+
+    private static BoundSonarQubeProject CreateBoundProject(string url, string projectKey)
+    {
+        return new BoundSonarQubeProject(new Uri(url), projectKey, "projectName", credentials: new BasicAuthCredentials("admin", "admin".ToSecureString()));
+    }
+
+    private static bool IsExpectedServerConnection(ServerConnection serverConnection, BoundSonarQubeProject boundProject)
+    {
+        return serverConnection.Id == boundProject.ServerUri.ToString();
+    }
+
+    private void CheckCredentialsAreLoaded(BoundSonarQubeProject boundProject)
+    {
+        serverConnectionsRepository.Received(1).TryAdd(Arg.Is<ServerConnection>(proj =>
+            IsExpectedServerConnection(proj, boundProject) && proj.Credentials == boundProject.Credentials));
+    }
+
+    private void CheckBindingsWereMigrated(Dictionary<string, BoundSonarQubeProject> bindingPathToBoundProjectDictionary)
+    {
+        foreach (var boundSonarQubeProject in bindingPathToBoundProjectDictionary)
+        {
+            solutionBindingRepository.Received(1).Write(boundSonarQubeProject.Key,
+                Arg.Is<BoundServerProject>(proj => IsExpectedServerConnection(proj.ServerConnection, boundSonarQubeProject.Value)));
+        }
+    }
+}

--- a/src/ConnectedMode/Migration/BindingToConnectionMigration.cs
+++ b/src/ConnectedMode/Migration/BindingToConnectionMigration.cs
@@ -1,0 +1,152 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using System.IO.Abstractions;
+using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.ConnectedMode.Binding;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Infrastructure.VS;
+using SonarLint.VisualStudio.ConnectedMode.Persistence;
+
+namespace SonarLint.VisualStudio.ConnectedMode.Migration;
+
+public interface IBindingToConnectionMigration
+{
+    Task MigrateBindingToServerConnectionIfNeededAsync();
+}
+
+/// <summary>
+/// Migrates the information about the server connection that, in the past, was stored into the binding.config file to the new connections.json file.
+/// The binding.config file is also updated to contain a ServerConnectionId that references the new connection.
+/// </summary>
+[Export(typeof(IBindingToConnectionMigration))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+internal class BindingToConnectionMigration : IBindingToConnectionMigration
+{
+    private readonly IFileSystem fileSystem;
+    private readonly IServerConnectionsRepository serverConnectionsRepository;
+    private readonly ILegacySolutionBindingRepository legacyBindingRepository;
+    private readonly ISolutionBindingRepository solutionBindingRepository;
+    private readonly IUnintrusiveBindingPathProvider unintrusiveBindingPathProvider;
+    private readonly IThreadHandling threadHandling;
+    private readonly ILogger logger;
+
+    [ImportingConstructor]
+    public BindingToConnectionMigration(
+        IServerConnectionsRepository serverConnectionsRepository,
+        ILegacySolutionBindingRepository legacyBindingRepository,
+        ISolutionBindingRepository solutionBindingRepository,
+        IUnintrusiveBindingPathProvider unintrusiveBindingPathProvider,
+        ILogger logger) : 
+        this(
+            new FileSystem(),
+            serverConnectionsRepository,
+            legacyBindingRepository,
+            solutionBindingRepository,
+            unintrusiveBindingPathProvider,
+            ThreadHandling.Instance,
+            logger)
+    { }
+
+    internal /* for testing */ BindingToConnectionMigration(
+        IFileSystem fileSystem,
+        IServerConnectionsRepository serverConnectionsRepository,
+        ILegacySolutionBindingRepository legacyBindingRepository,
+        ISolutionBindingRepository solutionBindingRepository,
+        IUnintrusiveBindingPathProvider unintrusiveBindingPathProvider,
+        IThreadHandling threadHandling, 
+        ILogger logger) 
+    {
+        this.fileSystem = fileSystem;
+        this.serverConnectionsRepository = serverConnectionsRepository;
+        this.legacyBindingRepository = legacyBindingRepository;
+        this.solutionBindingRepository = solutionBindingRepository;
+        this.unintrusiveBindingPathProvider = unintrusiveBindingPathProvider;
+        this.threadHandling = threadHandling;
+        this.logger = logger;
+    }
+
+    public Task MigrateBindingToServerConnectionIfNeededAsync()
+    {
+        return threadHandling.RunOnBackgroundThread(MigrateBindingToServerConnectionIfNeeded);
+    }
+
+    private void MigrateBindingToServerConnectionIfNeeded()
+    {
+        if (fileSystem.File.Exists(serverConnectionsRepository.ConnectionsStorageFilePath))
+        {
+            return;
+        }
+
+        logger.WriteLine(MigrationStrings.ConnectionMigration_StartMigration);
+        foreach (var bindingPath in unintrusiveBindingPathProvider.GetBindingPaths())
+        {
+            MigrateBindingToServerConnection(bindingPath);
+        }
+    }
+
+    private void MigrateBindingToServerConnection(string bindingFilePath)
+    {
+        try
+        {
+            if (legacyBindingRepository.Read(bindingFilePath) is not {} legacyBoundProject)
+            {
+                logger.WriteLine(string.Format(MigrationStrings.ConnectionMigration_BindingNotMigrated, bindingFilePath, $"{nameof(legacyBoundProject)} was not found"));
+                return;
+            }
+
+            if (MigrateServerConnection(legacyBoundProject) is {} serverConnection)
+            {
+                MigrateBinding(bindingFilePath, legacyBoundProject, serverConnection);
+            }
+        }
+        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        {
+            logger.WriteLine(string.Format(MigrationStrings.ConnectionMigration_BindingNotMigrated, bindingFilePath, ex.Message));
+        }
+    }
+
+    private ServerConnection MigrateServerConnection(BoundSonarQubeProject legacyBoundProject)
+    {
+        var serverConnection = ServerConnection.FromBoundSonarQubeProject(legacyBoundProject);
+        serverConnection.Credentials = legacyBoundProject.Credentials;
+
+        if (serverConnectionsRepository.TryGet(serverConnection.Id, out _))
+        {
+            logger.WriteLine(string.Format(MigrationStrings.ConnectionMigration_ExistingServerConnectionNotMigrated, serverConnection.Id));
+            return serverConnection;
+        }
+
+        if (serverConnectionsRepository.TryAdd(serverConnection))
+        {
+            return serverConnection;
+        }
+
+        logger.WriteLine(string.Format(MigrationStrings.ConnectionMigration_ServerConnectionNotMigrated, serverConnection.Id));
+        return null;
+    }
+
+    private void MigrateBinding(string bindingPath, BoundSonarQubeProject legacyBoundProject, ServerConnection serverConnection)
+    {
+        var boundServerProject = BoundServerProject.FromBoundSonarQubeProject(legacyBoundProject, bindingPath, serverConnection);
+        solutionBindingRepository.Write(bindingPath, boundServerProject);
+    }
+}

--- a/src/ConnectedMode/Migration/MigrationStrings.Designer.cs
+++ b/src/ConnectedMode/Migration/MigrationStrings.Designer.cs
@@ -106,6 +106,42 @@ namespace SonarLint.VisualStudio.ConnectedMode.Migration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [Connection Migration] The binding {0} could not be migrated due to: {1}.
+        /// </summary>
+        internal static string ConnectionMigration_BindingNotMigrated {
+            get {
+                return ResourceManager.GetString("ConnectionMigration_BindingNotMigrated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Connection Migration] The server connection with the id {0} was not migrated as it already exists..
+        /// </summary>
+        internal static string ConnectionMigration_ExistingServerConnectionNotMigrated {
+            get {
+                return ResourceManager.GetString("ConnectionMigration_ExistingServerConnectionNotMigrated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Connection Migration] The binding with the id {0} could not be migrated.
+        /// </summary>
+        internal static string ConnectionMigration_ServerConnectionNotMigrated {
+            get {
+                return ResourceManager.GetString("ConnectionMigration_ServerConnectionNotMigrated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Connection Migration] Start migrating connections from existing bindings.
+        /// </summary>
+        internal static string ConnectionMigration_StartMigration {
+            get {
+                return ResourceManager.GetString("ConnectionMigration_StartMigration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Migration] Error during migration: {0}
         ///  Run migration again with verbose logging enabled for more information..
         /// </summary>

--- a/src/ConnectedMode/Migration/MigrationStrings.resx
+++ b/src/ConnectedMode/Migration/MigrationStrings.resx
@@ -215,4 +215,16 @@
   <data name="Cleaner_Unchanged" xml:space="preserve">
     <value>[Migration] No settings to remove from the file</value>
   </data>
+  <data name="ConnectionMigration_BindingNotMigrated" xml:space="preserve">
+    <value>[Connection Migration] The binding {0} could not be migrated due to: {1}</value>
+  </data>
+  <data name="ConnectionMigration_ServerConnectionNotMigrated" xml:space="preserve">
+    <value>[Connection Migration] The binding with the id {0} could not be migrated</value>
+  </data>
+  <data name="ConnectionMigration_StartMigration" xml:space="preserve">
+    <value>[Connection Migration] Start migrating connections from existing bindings</value>
+  </data>
+  <data name="ConnectionMigration_ExistingServerConnectionNotMigrated" xml:space="preserve">
+    <value>[Connection Migration] The server connection with the id {0} was not migrated as it already exists.</value>
+  </data>
 </root>

--- a/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
+++ b/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
@@ -38,8 +38,9 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
     private readonly ILogger logger;
     private readonly IJsonFileHandler jsonFileHandle;
     private readonly IServerConnectionModelMapper serverConnectionModelMapper;
-    private readonly string storageFilePath;
     private static readonly object LockObject = new();
+
+    public string ConnectionsStorageFilePath { get; }
 
     [ImportingConstructor]
     public ServerConnectionsRepository(
@@ -63,7 +64,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         this.serverConnectionModelMapper = serverConnectionModelMapper;
         this.credentialsLoader = credentialsLoader;
         this.logger = logger;
-        storageFilePath = GetStorageFilePath(environmentVariables);
+        ConnectionsStorageFilePath = GetStorageFilePath(environmentVariables);
     }
 
     public bool TryGet(string connectionId, out ServerConnection serverConnection)
@@ -195,7 +196,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
     {
         try
         {
-            var model = jsonFileHandle.ReadFile<ServerConnectionsListJsonModel>(storageFilePath);
+            var model = jsonFileHandle.ReadFile<ServerConnectionsListJsonModel>(ConnectionsStorageFilePath);
             return model.ServerConnections.Select(serverConnectionModelMapper.GetServerConnection).ToList();
         }
         catch (FileNotFoundException)
@@ -222,7 +223,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
                 if (tryUpdateConnectionModels(serverConnections))
                 {
                     var model = serverConnectionModelMapper.GetServerConnectionsListJsonModel(serverConnections);
-                    return jsonFileHandle.TryWriteToFile(storageFilePath, model);
+                    return jsonFileHandle.TryWriteToFile(ConnectionsStorageFilePath, model);
                 }
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))

--- a/src/Core/Binding/IServerConnectionsRepository.cs
+++ b/src/Core/Binding/IServerConnectionsRepository.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.ComponentModel.Composition;
-using System.Diagnostics.CodeAnalysis;
-
 namespace SonarLint.VisualStudio.Core.Binding;
 
 public interface IServerConnectionsRepository
@@ -31,4 +28,5 @@ public interface IServerConnectionsRepository
     bool TryDelete(string connectionId);
     bool TryUpdateSettingsById(string connectionId, ServerConnectionSettings connectionSettings);
     bool TryUpdateCredentialsById(string connectionId, ICredentials credentials);
+    string ConnectionsStorageFilePath { get; }
 }

--- a/src/Integration.Vsix/SonarLintDaemonPackage.cs
+++ b/src/Integration.Vsix/SonarLintDaemonPackage.cs
@@ -88,10 +88,11 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         {
             try
             {
-                await MigrateBindingsToServerConnectionsIfNeededAsync();
-
                 logger = await this.GetMefServiceAsync<ILogger>();
                 logger.WriteLine(Strings.Daemon_Initializing);
+
+                // This migration should be performed before initializing other services, independent if a solution or a folder is opened.
+                await MigrateBindingsToServerConnectionsIfNeededAsync();
 
                 await MuteIssueCommand.InitializeAsync(this, logger);
                 await DisableRuleCommand.InitializeAsync(this, logger);
@@ -113,10 +114,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             }
             logger?.WriteLine(Strings.Daemon_InitializationComplete);
         }
-
-        /// <summary>
-        /// This migration should be performed before initializing other services, independent if a solution or a folder is opened.
-        /// </summary>
+        
         private async Task MigrateBindingsToServerConnectionsIfNeededAsync()
         {
             var bindingToConnectionMigration = await this.GetMefServiceAsync<IBindingToConnectionMigration>();


### PR DESCRIPTION
Implemented the migration and called it in the SonarLintDaemonPackage at the very beginning, because it should be performed as early as possible. This package is also called if solutions or folders are opened, or even none of them, which is desirable.

When the migration is performed for the first time, if you open a solution super fast, it might not actually be bound. But if you re-open the solution, then everything works as expected. 

I did not find a workaround for this issue (even triggering the binding manually did not help, I guess because it was too early). But I don't think I should invest too much effort into this, as it will only happen once: when the migration is performed, after the first update.