### PR TITLE
SLVS-1457 Open ManageBindingDialog from SharedBindingGoldBar

### DIFF
--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -22,10 +22,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Navigation;
 using Microsoft.VisualStudio.Threading;
-using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections;
 using SonarLint.VisualStudio.ConnectedMode.UI.ProjectSelection;
-using SonarLint.VisualStudio.Core;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageBinding;
 
@@ -33,10 +31,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageBinding;
 public partial class ManageBindingDialog : Window
 {
     private readonly IConnectedModeServices connectedModeServices;
+    private readonly bool useSharedBindingOnInitialization;
 
-    public ManageBindingDialog(IConnectedModeServices connectedModeServices, IConnectedModeBindingServices connectedModeBindingServices)
+    public ManageBindingDialog(
+        IConnectedModeServices connectedModeServices,
+        IConnectedModeBindingServices connectedModeBindingServices,
+        bool useSharedBindingOnInitialization = false)
     {
         this.connectedModeServices = connectedModeServices;
+        this.useSharedBindingOnInitialization = useSharedBindingOnInitialization;
         ViewModel = new ManageBindingViewModel(connectedModeServices, connectedModeBindingServices, new ProgressReporterViewModel());
         InitializeComponent();
     }
@@ -66,6 +69,10 @@ public partial class ManageBindingDialog : Window
     private async void ManageBindingDialog_OnInitialized(object sender, EventArgs e)
     {
         await ViewModel.InitializeDataAsync();
+        if (useSharedBindingOnInitialization)
+        {
+            await ViewModel.UseSharedBindingWithProgressAsync();
+        }
     }
 
     private void Unbind_OnClick(object sender, RoutedEventArgs e)

--- a/src/Integration.TeamExplorer.UnitTests/SectionControllerTests.cs
+++ b/src/Integration.TeamExplorer.UnitTests/SectionControllerTests.cs
@@ -25,6 +25,8 @@ using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.ConnectedMode.Binding;
+using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
@@ -70,7 +72,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
                 MefTestHelpers.CreateExport<SVsServiceProvider>(),
                 MefTestHelpers.CreateExport<IHost>(new ConfigurableHost()),
                 MefTestHelpers.CreateExport<IWebBrowser>(),
-                MefTestHelpers.CreateExport<IAutoBindTrigger>());
+                MefTestHelpers.CreateExport<IAutoBindTrigger>(),
+                MefTestHelpers.CreateExport<ISharedBindingConfigProvider>(),
+                MefTestHelpers.CreateExport<ICredentialStoreService>());
         }
 
         [TestMethod]
@@ -475,7 +479,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
         private SectionController CreateTestSubject(IWebBrowser webBrowser = null)
         {
-            var controller = new SectionController(serviceProvider, host, webBrowser ?? new ConfigurableWebBrowser(), Mock.Of<IAutoBindTrigger>());
+            var controller = new SectionController(serviceProvider, host, webBrowser ?? new ConfigurableWebBrowser(), Mock.Of<IAutoBindTrigger>(), Mock.Of<ISharedBindingConfigProvider>(), Mock.Of<ICredentialStoreService>());
             controller.Initialize(null, new SectionInitializeEventArgs(new ServiceContainer(), null));
             return controller;
         }

--- a/src/Integration.TeamExplorer/SectionController.cs
+++ b/src/Integration.TeamExplorer/SectionController.cs
@@ -28,6 +28,7 @@ using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
 using Microsoft.VisualStudio.Shell;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
+using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.Progress;
@@ -55,18 +56,24 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         private readonly IServiceProvider serviceProvider;
         private readonly IWebBrowser webBrowser;
         private readonly IAutoBindTrigger autoBindTrigger;
+        private readonly ISharedBindingConfigProvider sharedBindingConfigProvider;
+        private readonly ICredentialStoreService credentialStoreService;
 
         [ImportingConstructor]
         public SectionController(
             [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
             IHost host,
             IWebBrowser webBrowser,
-            IAutoBindTrigger autoBindTrigger)
+            IAutoBindTrigger autoBindTrigger, 
+            ISharedBindingConfigProvider sharedBindingConfigProvider, 
+            ICredentialStoreService credentialStoreService)
         {
             this.serviceProvider = serviceProvider;
             this.Host = host;
             this.webBrowser = webBrowser;
             this.autoBindTrigger = autoBindTrigger;
+            this.sharedBindingConfigProvider = sharedBindingConfigProvider;
+            this.credentialStoreService = credentialStoreService;
         }
 
         internal /*for testing purposes*/ List<IVSOleCommandTarget> CommandTargets
@@ -238,7 +245,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         {
             // Due to complexity of connect and bind we "outsource" the controlling part
             // to separate controllers which just expose commands
-            var connectionController = new Connection.ConnectionController(serviceProvider, Host, autoBindTrigger);
+            var connectionController = new Connection.ConnectionController(serviceProvider, Host, autoBindTrigger, sharedBindingConfigProvider, credentialStoreService);
             var bindingController = new Binding.BindingController(serviceProvider, Host);
 
             this.CommandTargets.Add(connectionController);

--- a/src/Integration.UnitTests/Connection/ConnectControllerTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectControllerTests.cs
@@ -238,7 +238,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             var connectionProviderMock = new Mock<IConnectionInformationProvider>();
             var testSubject = new ConnectionController(this.serviceProvider, this.host, null, connectionProviderMock.Object,
                 connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
-            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
+            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloud.io"), Organization = "Org" };
             sharedBindingConfigProvider.Setup(mock => mock.GetSharedBinding()).Returns(sharedBindingConfig);
             credentialsStore.Setup(mock => mock.ReadCredentials(It.IsAny<TargetUri>())).Returns(new Credential("user", "pwd"));
             
@@ -261,7 +261,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             var connectionProviderMock = new Mock<IConnectionInformationProvider>();
             var testSubject = new ConnectionController(this.serviceProvider, this.host, null, connectionProviderMock.Object,
                 connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
-            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
+            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloud.io"), Organization = "Org" };
             sharedBindingConfigProvider.Setup(mock => mock.GetSharedBinding()).Returns(sharedBindingConfig);
             var connectionInformation =
                 new ConnectionInformation(sharedBindingConfig.Uri, "user", "pwd".ToSecureString())
@@ -299,7 +299,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             SetupConnectionWorkflow(connectionWorkflowMock);
             SetUpOpenSolution();
             var connectionProviderMock = new Mock<IConnectionInformationProvider>();
-            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
+            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloud.io"), Organization = "Org" };
             sharedBindingConfigProvider.Setup(mock => mock.GetSharedBinding()).Returns(sharedBindingConfig);
             credentialsStore.Setup(mock => mock.ReadCredentials(It.IsAny<TargetUri>())).Returns(new Credential("user", "pwd"));
             var expectedConnection = new ConnectionInformation(new Uri("https://127.0.0.0"));

--- a/src/Integration.UnitTests/Connection/ConnectControllerTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectControllerTests.cs
@@ -25,6 +25,7 @@ using Microsoft.Alm.Authentication;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Integration.Binding;
@@ -48,6 +49,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         private ConfigurableSonarLintSettings settings;
         private Mock<ISolutionInfoProvider> solutionInfoProvider;
         private TestLogger logger;
+        private Mock<ISharedBindingConfigProvider> sharedBindingConfigProvider;
+        private Mock<ICredentialStoreService> credentialsStore;
 
         [TestInitialize]
         public void TestInit()
@@ -66,6 +69,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 SonarQubeService = this.sonarQubeServiceMock.Object,
                 Logger = logger
             };
+            this.sharedBindingConfigProvider = new Mock<ISharedBindingConfigProvider>();
+            this.credentialsStore = new Mock<ICredentialStoreService>();
 
             IComponentModel componentModel = ConfigurableComponentModel.CreateWithExports(
                 new []
@@ -81,9 +86,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         [TestMethod]
         public void ConnectionController_Ctor_ArgumentChecks()
         {
-            Exceptions.Expect<ArgumentNullException>(() => new ConnectionController(null, Mock.Of<IHost>(), Mock.Of<IAutoBindTrigger>()));
-            Exceptions.Expect<ArgumentNullException>(() => new ConnectionController(Mock.Of<IServiceProvider>(), null, Mock.Of<IAutoBindTrigger>()));
-            Exceptions.Expect<ArgumentNullException>(() => new ConnectionController(Mock.Of<IServiceProvider>(), Mock.Of<IHost>(), null));
+            Exceptions.Expect<ArgumentNullException>(() => new ConnectionController(null, Mock.Of<IHost>(), Mock.Of<IAutoBindTrigger>(), sharedBindingConfigProvider.Object, credentialsStore.Object));
+            Exceptions.Expect<ArgumentNullException>(() => new ConnectionController(Mock.Of<IServiceProvider>(), null, Mock.Of<IAutoBindTrigger>(), sharedBindingConfigProvider.Object, credentialsStore.Object));
+            Exceptions.Expect<ArgumentNullException>(() => new ConnectionController(Mock.Of<IServiceProvider>(), Mock.Of<IHost>(), null, sharedBindingConfigProvider.Object, credentialsStore.Object));
         }
 
         [TestMethod]
@@ -184,7 +189,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             var connectionWorkflowMock = CreateWorkflow();
             connectionWorkflowMock.Setup(x => x.EstablishConnection(It.IsAny<ConnectionInformation>(), It.IsAny<string>()));
             ConnectionController testSubject = new ConnectionController(this.serviceProvider, this.host, null,
-                this.connectionProvider, connectionWorkflowMock.Object);
+                this.connectionProvider, connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
             this.solutionInfoProvider.Setup(x => x.IsSolutionFullyOpened()).Returns(true);
 
             // Case 1: connection provider return null connection
@@ -232,9 +237,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             SetUpOpenSolution();
             var connectionProviderMock = new Mock<IConnectionInformationProvider>();
             var testSubject = new ConnectionController(this.serviceProvider, this.host, null, connectionProviderMock.Object,
-                connectionWorkflowMock.Object);
-            host.SharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org"};
-            host.CredentialsForSharedConfig = new Credential("user", "pwd");
+                connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
+            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
+            sharedBindingConfigProvider.Setup(mock => mock.GetSharedBinding()).Returns(sharedBindingConfig);
+            credentialsStore.Setup(mock => mock.ReadCredentials(It.IsAny<TargetUri>())).Returns(new Credential("user", "pwd"));
+            
             
             testSubject.ConnectCommand.Execute(new ConnectConfiguration(){UseSharedBinding = true});
             
@@ -253,12 +260,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             SetUpOpenSolution();
             var connectionProviderMock = new Mock<IConnectionInformationProvider>();
             var testSubject = new ConnectionController(this.serviceProvider, this.host, null, connectionProviderMock.Object,
-                connectionWorkflowMock.Object);
-            host.SharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org"};
+                connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
+            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
+            sharedBindingConfigProvider.Setup(mock => mock.GetSharedBinding()).Returns(sharedBindingConfig);
             var connectionInformation =
-                new ConnectionInformation(host.SharedBindingConfig.Uri, "user", "pwd".ToSecureString())
+                new ConnectionInformation(sharedBindingConfig.Uri, "user", "pwd".ToSecureString())
                 {
-                    Organization = new SonarQubeOrganization(host.SharedBindingConfig.Organization, string.Empty)
+                    Organization = new SonarQubeOrganization(sharedBindingConfig.Organization, string.Empty)
                 };
             SetupConnectionProvider(connectionProviderMock, connectionInformation);
             
@@ -269,7 +277,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 Times.Once);
             connectionProviderMock.Verify(x => 
                     x.GetConnectionInformation(It.Is<ConnectionInformation>(c => 
-                        c.ServerUri == host.SharedBindingConfig.Uri && c.Organization.Key == host.SharedBindingConfig.Organization)),
+                        c.ServerUri == sharedBindingConfig.Uri && c.Organization.Key == sharedBindingConfig.Organization)),
                 Times.Once);
         }
 
@@ -291,14 +299,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             SetupConnectionWorkflow(connectionWorkflowMock);
             SetUpOpenSolution();
             var connectionProviderMock = new Mock<IConnectionInformationProvider>();
-            host.SharedBindingConfig = new SharedBindingConfigModel
-                { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
-            host.CredentialsForSharedConfig = new Credential("user", "pwd");
+            var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "projectKey", Uri = new Uri("https://sonarcloudi.io"), Organization = "Org" };
+            sharedBindingConfigProvider.Setup(mock => mock.GetSharedBinding()).Returns(sharedBindingConfig);
+            credentialsStore.Setup(mock => mock.ReadCredentials(It.IsAny<TargetUri>())).Returns(new Credential("user", "pwd"));
             var expectedConnection = new ConnectionInformation(new Uri("https://127.0.0.0"));
             SetupConnectionProvider(connectionProviderMock, expectedConnection);
 
             var testSubject = new ConnectionController(this.serviceProvider, this.host, null,
-                connectionProviderMock.Object, connectionWorkflowMock.Object);
+                connectionProviderMock.Object, connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
 
             testSubject.ConnectCommand.Execute(config);
 
@@ -321,7 +329,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             SetupConnectionProvider(connectionProviderMock, expectedConnection);
             
             var testSubject = new ConnectionController(this.serviceProvider, this.host, null,
-                connectionProviderMock.Object, connectionWorkflowMock.Object);
+                connectionProviderMock.Object, connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
             
             testSubject.ConnectCommand.Execute(new ConnectConfiguration() { UseSharedBinding = true });
             
@@ -381,7 +389,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             // Arrange
             var connectionWorkflowMock = CreateWorkflow();
             ConnectionController testSubject = new ConnectionController(serviceProvider, host, null, connectionProvider,
-                connectionWorkflowMock.Object);
+                connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
             this.connectionProvider.ConnectionInformationToReturn = new ConnectionInformation(new Uri("http://notExpected"));
             var connection = new ConnectionInformation(new Uri("http://Expected"));
             // Sanity
@@ -405,7 +413,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             // Arrange
             var connectionWorkflowMock = CreateWorkflow();
             ConnectionController testSubject = new ConnectionController(serviceProvider, host, null, connectionProvider,
-                connectionWorkflowMock.Object);
+                connectionWorkflowMock.Object, sharedBindingConfigProvider.Object, credentialsStore.Object);
             this.solutionInfoProvider.Setup(x => x.IsSolutionFullyOpened()).Returns(true);
             this.connectionProvider.ConnectionInformationToReturn = null;
             var progressEvents = new ConfigurableProgressEvents();
@@ -463,6 +471,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         }
         
         private ConnectionController CreateTestSubject() =>
-            new ConnectionController(serviceProvider, host, Mock.Of<IAutoBindTrigger>());
+            new ConnectionController(serviceProvider, host, Mock.Of<IAutoBindTrigger>(), sharedBindingConfigProvider.Object, credentialsStore.Object);
     }
 }

--- a/src/Integration.UnitTests/MefServices/SharedBindingSuggestionServiceTests.cs
+++ b/src/Integration.UnitTests/MefServices/SharedBindingSuggestionServiceTests.cs
@@ -119,6 +119,14 @@ public class SharedBindingSuggestionServiceTests
         suggestSharedBindingGoldBar.DidNotReceive().Show(ServerType.SonarQube, Arg.Any<Action>());
     }
 
+    [TestMethod]
+    public void Dispose_UnsubscribesFromActiveSolutionChanged()
+    {
+        testSubject.Dispose();
+
+        activeSolutionTracker.Received(1).ActiveSolutionChanged -= Arg.Any<EventHandler<ActiveSolutionChangedEventArgs>>();
+    }
+
     private void RaiseActiveSolutionChanged(bool isSolutionOpened)
     {
         activeSolutionTracker.ActiveSolutionChanged += Raise.EventWith(new ActiveSolutionChangedEventArgs(isSolutionOpened));

--- a/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
@@ -18,16 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using FluentAssertions;
 using Microsoft.Alm.Authentication;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
-using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.MefServices;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
@@ -44,7 +40,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         private ConfigurableStateManager stateManager;
         private ConfigurableProgressStepRunner stepRunner;
         private ConfigurableConfigurationProvider configProvider;
-        private Mock<ISharedBindingConfigProvider> sharedBindingConfigProviderMock;
         private Mock<ICredentialStoreService> credentialStoreServiceMock;
         private Mock<ISharedBindingSuggestionService> sharedBindingSuggestionService;
         private Mock<IConnectedModeWindowEventListener> connectedModeWindowEventListener;
@@ -57,7 +52,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.sonarQubeServiceMock = new Mock<ISonarQubeService>();
             this.stepRunner = new ConfigurableProgressStepRunner();
             this.configProvider = new ConfigurableConfigurationProvider();
-            sharedBindingConfigProviderMock = new Mock<ISharedBindingConfigProvider>();
             credentialStoreServiceMock = new Mock<ICredentialStoreService>();
             sharedBindingSuggestionService = new Mock<ISharedBindingSuggestionService>();
             connectedModeWindowEventListener = new Mock<IConnectedModeWindowEventListener>();
@@ -72,9 +66,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
                 MefTestHelpers.CreateExport<ISonarQubeService>(),
                 MefTestHelpers.CreateExport<IActiveSolutionTracker>(),
                 MefTestHelpers.CreateExport<IConfigurationProvider>(),
-                MefTestHelpers.CreateExport<ISharedBindingConfigProvider>(),
                 MefTestHelpers.CreateExport<ICredentialStoreService>(),
-                MefTestHelpers.CreateExport<ISharedBindingSuggestionService>(),
                 MefTestHelpers.CreateExport<IConnectedModeWindowEventListener>(),
                 MefTestHelpers.CreateExport<ILogger>());
         }
@@ -100,7 +92,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
             trackerMock.VerifyRemove(x => x.ActiveSolutionChanged -= It.IsAny<EventHandler<ActiveSolutionChangedEventArgs>>(), Times.Once);
             connectedModeWindowEventListener.Verify(x => x.Dispose(), Times.Once);
-            sharedBindingSuggestionService.Verify(x => x.Close(), Times.Once);
         }
 
         [TestMethod]
@@ -373,14 +364,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = CreateTestSubject(tracker);
             var sharedBindingConfig = new SharedBindingConfigModel { ProjectKey = "abcd" };
-            sharedBindingConfigProviderMock.Setup(x => x.GetSharedBinding())
-                .Returns(sharedBindingConfig);
             
             tracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
             
             testSubject.SharedBindingConfig.Should().BeSameAs(sharedBindingConfig);
             testSubject.VisualStateManager.HasSharedBinding.Should().BeTrue();
-            CheckSuggestionShowCalledTimes(1);
             CheckResetConnectionCalledTimes(testSubject, 1);
         }
         
@@ -390,14 +378,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = CreateTestSubject(tracker);
             sharedBindingSuggestionService.Invocations.Clear();
-            sharedBindingConfigProviderMock.Setup(x => x.GetSharedBinding())
-                .Returns((SharedBindingConfigModel)null);
             
             tracker.SimulateActiveSolutionChanged(isSolutionOpen: true);
             
             testSubject.SharedBindingConfig.Should().BeNull();
             testSubject.VisualStateManager.HasSharedBinding.Should().BeFalse();
-            CheckSuggestionShowCalledTimes(1, serverType: null);
             CheckResetConnectionCalledTimes(testSubject, 1);
         }
 
@@ -407,15 +392,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = CreateTestSubject(tracker);
             sharedBindingSuggestionService.Invocations.Clear();
-            sharedBindingConfigProviderMock.Setup(x => x.GetSharedBinding())
-                .Returns((SharedBindingConfigModel)null);
             
             tracker.SimulateActiveSolutionChanged(isSolutionOpen: false);
             
             testSubject.SharedBindingConfig.Should().BeNull();
             testSubject.VisualStateManager.HasSharedBinding.Should().BeFalse();
-            CheckSuggestionClosed();
-            CheckSuggestionShowCalledTimes(0);
             CheckResetConnectionCalledTimes(testSubject, 0);
         }
         
@@ -424,14 +405,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         {
             var testSubject = CreateTestSubject();
             var section = ConfigurableSectionController.CreateDefault();
-            sharedBindingConfigProviderMock.Setup(x => x.GetSharedBinding())
-                .Returns(new SharedBindingConfigModel { ProjectKey = "abcd" });
             
             testSubject.SetActiveSection(section);
             
             testSubject.SharedBindingConfig.Should().NotBeNull();
             testSubject.VisualStateManager.HasSharedBinding.Should().BeTrue();
-            CheckSuggestionShowCalledTimes(1);
             CheckResetConnectionCalledTimes(testSubject, 1);
         }
 
@@ -441,8 +419,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             var tracker = new ConfigurableActiveSolutionTracker();
             var testSubject = CreateTestSubject(tracker);
             var section = ConfigurableSectionController.CreateDefault();
-            sharedBindingConfigProviderMock.Setup(x => x.GetSharedBinding())
-                .Returns(new SharedBindingConfigModel { ProjectKey = "abcd" });
             testSubject.SetActiveSection(section);
             ((ConfigurableStateManager)testSubject.VisualStateManager).ResetConnectionConfigCalled = 0;
 
@@ -456,7 +432,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
             testSubject.SharedBindingConfig.Should().BeNull();
             this.stateManager.BoundProjectKey.Should().Be("bla");
-            CheckSuggestionShowCalledTimes(0);
             CheckResetConnectionCalledTimes(testSubject, 0);
         }
 
@@ -468,8 +443,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         {
             var testSubject = CreateTestSubject();
             var section = ConfigurableSectionController.CreateDefault();
-            sharedBindingConfigProviderMock.Setup(x => x.GetSharedBinding())
-                .Returns(serverUri != null ? new SharedBindingConfigModel { Uri = new Uri(serverUri)} : null);
+           
             testSubject.SetActiveSection(section);
             var credential = new Credential("a");
             credentialStoreServiceMock.Setup(x => x.ReadCredentials(It.IsAny<TargetUri>())).Returns(credential);
@@ -500,10 +474,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
                 this.sonarQubeServiceMock.Object,
                 tracker ?? new ConfigurableActiveSolutionTracker(),
                 this.configProvider,
-                sharedBindingConfigProviderMock.Object,
                 credentialStoreServiceMock.Object,
                 connectedModeWindowEventListener.Object,
-                sharedBindingSuggestionService.Object,
                 Mock.Of<ILogger>());
 
             this.stateManager.Host = host;
@@ -523,17 +495,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             ((ConfigurableStateManager)testSubject.VisualStateManager).ResetConnectionConfigCalled.Should().Be(count);
         }
         
-        private void CheckSuggestionShowCalledTimes(int count, ServerType? serverType = ServerType.SonarQube)
-        {
-            sharedBindingSuggestionService.Verify(x => x.Suggest(serverType ?? It.IsAny<ServerType?>()),
-                Times.Exactly(count));
-            sharedBindingSuggestionService.VerifyNoOtherCalls();
-        }
-
-        private void CheckSuggestionClosed()
-        {
-            sharedBindingSuggestionService.Verify(x => x.Close());
-        }
 
         #endregion Helpers
     }

--- a/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/MefServices/VsSessionHostTests.cs
@@ -525,8 +525,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         
         private void CheckSuggestionShowCalledTimes(int count, ServerType? serverType = ServerType.SonarQube)
         {
-            sharedBindingSuggestionService.Verify(x => x.Suggest(serverType ?? It.IsAny<ServerType?>(),
-                    It.IsAny<Func<ICommand<ConnectConfiguration>>>()),
+            sharedBindingSuggestionService.Verify(x => x.Suggest(serverType ?? It.IsAny<ServerType?>()),
                 Times.Exactly(count));
             sharedBindingSuggestionService.VerifyNoOtherCalls();
         }

--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -22,10 +22,11 @@ using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using SonarLint.VisualStudio.ConnectedMode.Binding;
+using SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion;
 using SonarLint.VisualStudio.ConnectedMode.UI;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Infrastructure.VS;
+using SonarLint.VisualStudio.Integration.MefServices;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.IssueVisualization.Helpers;
 using SonarLint.VisualStudio.Roslyn.Suppressions.InProcess;
@@ -69,6 +70,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         private ILogger logger;
         private IRoslynSettingsFileSynchronizer roslynSettingsFileSynchronizer;
+        private ISharedBindingSuggestionService suggestSharedBindingGoldBar;
 
         protected override async System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
@@ -103,6 +105,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 roslynSettingsFileSynchronizer.UpdateFileStorageAsync().Forget(); // don't wait for it to finish
                 Debug.Assert(threadHandling.CheckAccess(), "Still expecting to be on the UI thread");
 
+                suggestSharedBindingGoldBar = serviceProvider.GetMefService<ISharedBindingSuggestionService>();
+                suggestSharedBindingGoldBar.Suggest();
+
                 logger.WriteLine(Resources.Strings.SL_InitializationComplete);
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
@@ -118,6 +123,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             if (disposing)
             {
                 this.roslynSettingsFileSynchronizer?.Dispose();
+                suggestSharedBindingGoldBar?.Dispose();
                 this.roslynSettingsFileSynchronizer = null;
             }
         }

--- a/src/Integration/MefServices/IHost.cs
+++ b/src/Integration/MefServices/IHost.cs
@@ -40,10 +40,6 @@ namespace SonarLint.VisualStudio.Integration
         /// </summary>
         IStateManager VisualStateManager { get; }
 
-        SharedBindingConfigModel SharedBindingConfig { get; }
-
-        Credential GetCredentialsForSharedConfig();
-
         /// <summary>
         /// The currently active section. Null when no active section.
         /// </summary>

--- a/src/Integration/MefServices/SharedBindingSuggestionService.cs
+++ b/src/Integration/MefServices/SharedBindingSuggestionService.cs
@@ -79,7 +79,7 @@ namespace SonarLint.VisualStudio.Integration.MefServices
 
         private void ShowManageBindingDialog()
         {
-            var manageBindingDialog = new ManageBindingDialog(connectedModeServices, connectedModeBindingServices);
+            var manageBindingDialog = new ManageBindingDialog(connectedModeServices, connectedModeBindingServices, useSharedBindingOnInitialization:true);
             manageBindingDialog.ShowDialog(Application.Current.MainWindow);
         }
 

--- a/src/Integration/MefServices/SharedBindingSuggestionService.cs
+++ b/src/Integration/MefServices/SharedBindingSuggestionService.cs
@@ -26,7 +26,6 @@ using SonarLint.VisualStudio.ConnectedMode.UI;
 using SonarLint.VisualStudio.ConnectedMode.UI.ManageBinding;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
-using SonarQube.Client;
 
 namespace SonarLint.VisualStudio.Integration.MefServices
 {
@@ -37,13 +36,12 @@ namespace SonarLint.VisualStudio.Integration.MefServices
     
     [Export(typeof(ISharedBindingSuggestionService))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    internal class SharedBindingSuggestionService : ISharedBindingSuggestionService
+    internal sealed class SharedBindingSuggestionService : ISharedBindingSuggestionService
     {
         private readonly ISuggestSharedBindingGoldBar suggestSharedBindingGoldBar;
         private readonly IConnectedModeServices connectedModeServices;
         private readonly IConnectedModeBindingServices connectedModeBindingServices;
         private readonly IActiveSolutionTracker activeSolutionTracker;
-        private bool disposed;
 
         [ImportingConstructor]
         public SharedBindingSuggestionService(
@@ -73,8 +71,7 @@ namespace SonarLint.VisualStudio.Integration.MefServices
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            activeSolutionTracker.ActiveSolutionChanged -= OnActiveSolutionChanged;
         }
 
         private void ShowManageBindingDialog()
@@ -88,20 +85,6 @@ namespace SonarLint.VisualStudio.Integration.MefServices
             if (e.IsSolutionOpen)
             {
                 Suggest();
-            }
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposed)
-            {
-                return;
-            }
-
-            disposed = true;
-            if (disposing)
-            {
-                activeSolutionTracker.ActiveSolutionChanged -= OnActiveSolutionChanged;
             }
         }
     }

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -102,16 +102,8 @@ namespace SonarLint.VisualStudio.Integration
         public event EventHandler ActiveSectionChanged;
 
         public IStateManager VisualStateManager { get; }
-        public SharedBindingConfigModel SharedBindingConfig { get; private set; }
 
         public ISonarQubeService SonarQubeService { get; }
-
-        public Credential GetCredentialsForSharedConfig()
-        {
-            return SharedBindingConfig == null 
-                ? null 
-                : credentialStoreService.ReadCredentials(SharedBindingConfig.Uri);
-        }
 
         public ISectionController ActiveSection { get; private set; }
 
@@ -233,8 +225,6 @@ namespace SonarLint.VisualStudio.Integration
 
         private void ApplyBindingInformation(BindingConfiguration bindingConfig)
         {
-            SharedBindingConfig = null;
-
             // Set the project key that should become bound once the connection workflow has completed
             this.VisualStateManager.BoundProjectKey = bindingConfig.Project.ServerProjectKey;
             this.VisualStateManager.BoundProjectName = bindingConfig.Project.ServerProjectKey;

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -255,7 +255,7 @@ namespace SonarLint.VisualStudio.Integration
             VisualStateManager.HasSharedBinding = SharedBindingConfig != null;
             VisualStateManager.ResetConnectionConfiguration();
 
-            sharedBindingSuggestionService.Suggest(SharedBindingConfig.GetServerType(),() => this.ActiveSection?.ConnectCommand);
+            sharedBindingSuggestionService.Suggest(SharedBindingConfig.GetServerType());
         }
 
         private void ClearCurrentBinding()

--- a/src/Integration/MefServices/VsSessionHost.cs
+++ b/src/Integration/MefServices/VsSessionHost.cs
@@ -18,16 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using Microsoft.Alm.Authentication;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
-using SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion;
 using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
-using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.MefServices;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.State;
@@ -43,13 +39,9 @@ namespace SonarLint.VisualStudio.Integration
     {
         private readonly IActiveSolutionTracker solutionTracker;
         private readonly IConfigurationProvider configurationProvider;
-        private readonly ISharedBindingConfigProvider sharedBindingConfigProvider;
         private readonly ICredentialStoreService credentialStoreService;
         private readonly IConnectedModeWindowEventListener connectedModeWindowEventListener;
-        private readonly ISharedBindingSuggestionService sharedBindingSuggestionService;
-
         private readonly IProgressStepRunnerWrapper progressStepRunner;
-
 
         private bool isDisposed;
         private bool resetBindingWhenAttaching = true;
@@ -58,10 +50,8 @@ namespace SonarLint.VisualStudio.Integration
         public VsSessionHost(ISonarQubeService sonarQubeService,
             IActiveSolutionTracker solutionTracker,
             IConfigurationProvider configurationProvider,
-            ISharedBindingConfigProvider sharedBindingConfigProvider,
             ICredentialStoreService credentialStoreService,
             IConnectedModeWindowEventListener connectedModeWindowEventListener,
-            ISharedBindingSuggestionService sharedBindingSuggestionService,
             ILogger logger)
             : this(
                 null,
@@ -69,10 +59,8 @@ namespace SonarLint.VisualStudio.Integration
                 sonarQubeService,
                 solutionTracker,
                 configurationProvider,
-                sharedBindingConfigProvider,
                 credentialStoreService,
                 connectedModeWindowEventListener,
-                sharedBindingSuggestionService,
                 logger)
         {
         }
@@ -82,10 +70,8 @@ namespace SonarLint.VisualStudio.Integration
             ISonarQubeService sonarQubeService,
             IActiveSolutionTracker solutionTracker,
             IConfigurationProvider configurationProvider,
-            ISharedBindingConfigProvider sharedBindingConfigProvider,
             ICredentialStoreService credentialStoreService,
             IConnectedModeWindowEventListener connectedModeWindowEventListener,
-            ISharedBindingSuggestionService sharedBindingSuggestionService,
             ILogger logger)
         {
             this.VisualStateManager = state ?? new StateManager(this, new TransferableVisualState());
@@ -93,10 +79,8 @@ namespace SonarLint.VisualStudio.Integration
             this.SonarQubeService = sonarQubeService ?? throw new ArgumentNullException(nameof(sonarQubeService));
             this.solutionTracker = solutionTracker ?? throw new ArgumentNullException(nameof(solutionTracker));
             this.configurationProvider = configurationProvider ?? throw new ArgumentNullException(nameof(configurationProvider));
-            this.sharedBindingConfigProvider = sharedBindingConfigProvider;
             this.credentialStoreService = credentialStoreService;
             this.connectedModeWindowEventListener = connectedModeWindowEventListener;
-            this.sharedBindingSuggestionService = sharedBindingSuggestionService;
             this.solutionTracker.ActiveSolutionChanged += this.OnActiveSolutionChanged;
             this.Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             connectedModeWindowEventListener.SubscribeToConnectedModeWindowEvents(this);
@@ -222,15 +206,6 @@ namespace SonarLint.VisualStudio.Integration
             if (clearCurrentBinding || bindingConfig == null || bindingConfig.Mode == SonarLintMode.Standalone)
             {
                 this.ClearCurrentBinding();
-
-                if (!clearCurrentBinding) // when solution is open, but unbound
-                {
-                    UpdateSharedBindingSuggestion();
-                }
-                else
-                {
-                    sharedBindingSuggestionService.Close();
-                }
             }
             else
             {
@@ -246,16 +221,6 @@ namespace SonarLint.VisualStudio.Integration
                     this.ApplyBindingInformation(bindingConfig);
                 }
             }
-        }
-
-        private void UpdateSharedBindingSuggestion()
-        {
-            SharedBindingConfig = sharedBindingConfigProvider.GetSharedBinding();
-
-            VisualStateManager.HasSharedBinding = SharedBindingConfig != null;
-            VisualStateManager.ResetConnectionConfiguration();
-
-            sharedBindingSuggestionService.Suggest(SharedBindingConfig.GetServerType());
         }
 
         private void ClearCurrentBinding()
@@ -316,7 +281,6 @@ namespace SonarLint.VisualStudio.Integration
                 {
                     this.solutionTracker.ActiveSolutionChanged -= this.OnActiveSolutionChanged;
                     connectedModeWindowEventListener.Dispose();
-                    sharedBindingSuggestionService.Close();
                 }
 
                 this.isDisposed = true;

--- a/src/TestInfrastructure/Framework/ConfigurableHost.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableHost.cs
@@ -42,13 +42,6 @@ namespace SonarLint.VisualStudio.TestInfrastructure
 
         public event EventHandler ActiveSectionChanged;
 
-        public SharedBindingConfigModel SharedBindingConfig { get; set; }
-
-        public Credential GetCredentialsForSharedConfig()
-        {
-            return CredentialsForSharedConfig;
-        }
-
         public ISectionController ActiveSection
         {
             get;
@@ -90,8 +83,6 @@ namespace SonarLint.VisualStudio.TestInfrastructure
         #endregion IHost
 
         #region Test helpers
-
-        public Credential CredentialsForSharedConfig { get; set; }
         
         public void SimulateActiveSectionChanged()
         {


### PR DESCRIPTION
[SLVS-1457](https://sonarsource.atlassian.net/browse/SLVS-1457)

It should have been easy: just instantiate the ManageBindingDialog in the SharedBindingSuggestionService and pass it to the goldbar. But it was a mess, because once you start adding the reference to IConnectedModeBindingServices you have a circular reference that crashes the app at runtime (the circular reference was VsSessionHost ->  SharedBindingSuggestionService -> UnintrusiveBindingController -> ActiveSolutionBoundTracker -> VsSessionHost)

So I had to restructure the logic to break the circular refernce.

[SLVS-1457]: https://sonarsource.atlassian.net/browse/SLVS-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ