### PR TITLE
SLVS-1370 Incorporate UX feedback

### DIFF
--- a/.sonarlint/SonarLint.VisualStudio.Integration.json
+++ b/.sonarlint/SonarLint.VisualStudio.Integration.json
@@ -1,4 +1,4 @@
 {
-  "SonarCloudOrganization": "duncanp-sonar-test",
-  "ProjectKey": "slvs_samples_bound_vs2019"
+  "SonarCloudOrganization": "sonarsource",
+  "ProjectKey": "sonarlint-visualstudio"
 }

--- a/.sonarlint/SonarLint.VisualStudio.Integration.json
+++ b/.sonarlint/SonarLint.VisualStudio.Integration.json
@@ -1,4 +1,4 @@
 {
-  "SonarCloudOrganization": "sonarsource",
-  "ProjectKey": "sonarlint-visualstudio"
+  "SonarCloudOrganization": "duncanp-sonar-test",
+  "ProjectKey": "slvs_samples_bound_vs2019"
 }

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
@@ -5,8 +5,6 @@
                          xmlns:res="clr-namespace:SonarLint.VisualStudio.ConnectedMode.UI.Resources"
                          xmlns:ui="clr-namespace:SonarLint.VisualStudio.ConnectedMode.UI"
                          xmlns:wpf="clr-namespace:SonarLint.VisualStudio.Core.WPF;assembly=SonarLint.VisualStudio.Core"
-                         xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
-                         xmlns:vsimagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
                          Title="{x:Static res:UiResources.ManageBindingDialogTitle}" 
                          WindowStartupLocation="CenterOwner"
                          Initialized="ManageBindingDialog_OnInitialized"
@@ -55,20 +53,10 @@
                         </TextBlock>
                     </Grid>
 
-                    <Button Grid.Column="1" HorizontalAlignment="Right" Content="{x:Static res:UiResources.UseSharedBindingButton}" Padding="5,0" 
+                    <Button Grid.Column="1" HorizontalAlignment="Right" Content="{x:Static res:UiResources.UseSharedConfiguration}" 
                             IsEnabled="{Binding Path=IsUseSharedBindingButtonEnabled}"
                             Visibility="{Binding Path=IsUseSharedBindingButtonVisible, Converter={StaticResource TrueToVisibleConverter}}"
-                            ToolTipService.ShowOnDisabled="True"
                             Click="UseSharedBinding_OnClick">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=IsUseSharedBindingButtonVisible}" Value="False">
-                                        <Setter Property="ToolTip" Value="{x:Static res:UiResources.SharedBindingConfigurationTooltip}"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
                     </Button>
                 </Grid>
 
@@ -103,7 +91,7 @@
                         <Button Grid.Column="0" Content="{x:Static res:UiResources.UnbindButton}" IsEnabled="{Binding Path=IsUnbindButtonEnabled}" 
                            Visibility="Collapsed" VerticalAlignment="Center"
                            Click="Unbind_OnClick"/>
-                        <Button Grid.Column="1" Visibility="Collapsed" Content="{x:Static res:UiResources.ExportButton}" ToolTip="{x:Static res:UiResources.ExportBindingConfigurationTooltip}"
+                        <Button Grid.Column="1" Visibility="Collapsed" Content="{x:Static res:UiResources.ShareConfigurationButton}" ToolTip="{x:Static res:UiResources.ExportBindingConfigurationTooltip}"
                            IsEnabled="{Binding Path=IsExportButtonEnabled}" VerticalAlignment="Center"
                            Click="ExportBindingConfigurationButton_OnClick"/>
                     </Grid>
@@ -169,8 +157,8 @@
             <ui:ProgressAndErrorHandlerComponent ProgressReporterViewModel="{Binding Path=ProgressReporter}" />
         </Grid>
 
-        <TextBlock Grid.Row="3" Text="{x:Static res:UiResources.ConnectedModeExplanationText}" Margin="0,20">
-            <Hyperlink NavigateUri="https://docs.sonarsource.com/sonarlint/visual-studio/team-features/connected-mode/" RequestNavigate="ViewWebsite">here</Hyperlink>
+        <TextBlock Grid.Row="3" Text="{x:Static res:UiResources.LearnMoreAboutText}" Margin="0,20">
+            <Hyperlink NavigateUri="https://docs.sonarsource.com/sonarlint/visual-studio/team-features/connected-mode/" RequestNavigate="ViewWebsite">Connected Mode</Hyperlink>
         </TextBlock>
 
         <Grid Grid.Row="4" HorizontalAlignment="Right" Visibility="{Binding  Path=IsCurrentProjectBound, Converter={StaticResource TrueToCollapsedConverter}}">

--- a/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
+++ b/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
@@ -196,15 +196,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about connected mode .
-        /// </summary>
-        public static string ConnectedModeExplanationText {
-            get {
-                return ResourceManager.GetString("ConnectedModeExplanationText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Discover which connection is best for your team .
         /// </summary>
         public static string ConnectionDiscoveringText {
@@ -403,15 +394,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Export.
-        /// </summary>
-        public static string ExportButton {
-            get {
-                return ResourceManager.GetString("ExportButton", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Binding configuration is being exported....
         /// </summary>
         public static string ExportingBindingConfigurationProgressText {
@@ -480,6 +462,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         public static string IsNotBoundText {
             get {
                 return ResourceManager.GetString("IsNotBoundText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Learn more about .
+        /// </summary>
+        public static string LearnMoreAboutText {
+            get {
+                return ResourceManager.GetString("LearnMoreAboutText", resourceCulture);
             }
         }
         
@@ -819,11 +810,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No shared binding configuration was detected.
+        ///   Looks up a localized string similar to Share configuration.
         /// </summary>
-        public static string SharedBindingConfigurationTooltip {
+        public static string ShareConfigurationButton {
             get {
-                return ResourceManager.GetString("SharedBindingConfigurationTooltip", resourceCulture);
+                return ResourceManager.GetString("ShareConfigurationButton", resourceCulture);
             }
         }
         
@@ -900,11 +891,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use shared binding.
+        ///   Looks up a localized string similar to Use shared configuration.
         /// </summary>
-        public static string UseSharedBindingButton {
+        public static string UseSharedConfiguration {
             get {
-                return ResourceManager.GetString("UseSharedBindingButton", resourceCulture);
+                return ResourceManager.GetString("UseSharedConfiguration", resourceCulture);
             }
         }
         

--- a/src/ConnectedMode/UI/Resources/UiResources.resx
+++ b/src/ConnectedMode/UI/Resources/UiResources.resx
@@ -252,8 +252,8 @@
   <data name="UnbindButton" xml:space="preserve">
     <value>Unbind</value>
   </data>
-  <data name="UseSharedBindingButton" xml:space="preserve">
-    <value>Use shared binding</value>
+  <data name="UseSharedConfiguration" xml:space="preserve">
+    <value>Use shared configuration</value>
   </data>
   <data name="IsBoundToText" xml:space="preserve">
     <value>is bound to</value>
@@ -300,8 +300,8 @@
   <data name="ExportingBindingConfigurationProgressText" xml:space="preserve">
     <value>Binding configuration is being exported...</value>
   </data>
-  <data name="ExportButton" xml:space="preserve">
-    <value>Export</value>
+  <data name="ShareConfigurationButton" xml:space="preserve">
+    <value>Share configuration</value>
   </data>
   <data name="NoConnectionExistsLabel" xml:space="preserve">
     <value>No connection exists</value>
@@ -321,14 +321,11 @@
   <data name="BindingStatusLabel" xml:space="preserve">
     <value>Binding Status</value>
   </data>
-  <data name="ConnectedModeExplanationText" xml:space="preserve">
-    <value>Learn more about connected mode </value>
+  <data name="LearnMoreAboutText" xml:space="preserve">
+    <value>Learn more about </value>
   </data>
   <data name="ExistingProjectsLabel" xml:space="preserve">
     <value>Existing Projects</value>
-  </data>
-  <data name="SharedBindingConfigurationTooltip" xml:space="preserve">
-    <value>No shared binding configuration was detected</value>
   </data>
   <data name="BoundToLabel" xml:space="preserve">
     <value>bound to</value>


### PR DESCRIPTION
[SLVS-1370](https://sonarsource.atlassian.net/browse/SLVS-1370)

- rename "use shared binding" to "use shared configuration"
- rename "export" to "share configuration"
- remove tooltip that doesn't make sense anymore, because we only show the button when the shared binding configuration is present
- Change "Learn more about connected mode here" to "Learn more about Connected Mode"


[SLVS-1370]: https://sonarsource.atlassian.net/browse/SLVS-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ