### PR TITLE
BUILD-6437 fix dogfooding task

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -124,7 +124,7 @@ dogfood_task:
   calculate_version_script: *CALCULATE_VERSION_SCRIPT_DEFINITION
   dogfood_script: |
     mkdir -p /tmp/dogfood/${PROJECT_VERSION}
-    PrivateGalleryCreator.exe --input=. --terminate --source="https://binaries.sonarsource.com/SonarLint-for-VisualStudio/dogfood/${PROJECT_VERSION}/" --output=/tmp/dogfood/feed.xml
+    PrivateGalleryCreator.exe --input=binaries --terminate --source="https://binaries.sonarsource.com/SonarLint-for-VisualStudio/dogfood/${PROJECT_VERSION}/" --output=/tmp/dogfood/feed.xml
     cp binaries/SonarLint.VSIX-${PROJECT_VERSION}-2022.vsix /tmp/dogfood/${PROJECT_VERSION}/
     .cirrus/publish-dogfood-site.sh /tmp/dogfood
 


### PR DESCRIPTION
[BUILD-6437](https://sonarsource.atlassian.net/browse/BUILD-6437)

Fixes the dogfooding task producing an empty feed.xml

[BUILD-6437]: https://sonarsource.atlassian.net/browse/BUILD-6437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ