### PR TITLE
SLVS-1473 Refactor AliveConnectionTracker

### DIFF
--- a/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
+++ b/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
@@ -184,7 +184,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         }
     }
 
-    private bool TryUpdateConnectionSettings(List<ServerConnection> connections, string connectionId, ServerConnectionSettings connectionSettings)
+    private static bool TryUpdateConnectionSettings(List<ServerConnection> connections, string connectionId, ServerConnectionSettings connectionSettings)
     {
         var serverConnectionToUpdate = connections?.Find(c => c.Id == connectionId);
         if (serverConnectionToUpdate == null)

--- a/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
+++ b/src/ConnectedMode/Persistence/ServerConnectionsRepository.cs
@@ -43,6 +43,9 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
     private readonly string connectionsStorageFilePath;
     private static readonly object LockObject = new();
 
+    public event EventHandler ConnectionChanged;
+    public event EventHandler<ServerConnectionUpdatedEventArgs> CredentialsChanged;
+
     [ImportingConstructor]
     public ServerConnectionsRepository(
         IJsonFileHandler jsonFileHandle,
@@ -127,6 +130,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
             if (wasFound)
             {
                 credentialsLoader.Save(credentials, serverConnection.CredentialsUri);
+                OnCredentialsChanged(serverConnection);
                 return true;
             }
         }
@@ -180,7 +184,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
         }
     }
 
-    private static bool TryUpdateConnectionSettings(List<ServerConnection> connections, string connectionId, ServerConnectionSettings connectionSettings)
+    private bool TryUpdateConnectionSettings(List<ServerConnection> connections, string connectionId, ServerConnectionSettings connectionSettings)
     {
         var serverConnectionToUpdate = connections?.Find(c => c.Id == connectionId);
         if (serverConnectionToUpdate == null)
@@ -229,7 +233,12 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
                 if (tryUpdateConnectionModels(serverConnections))
                 {
                     var model = serverConnectionModelMapper.GetServerConnectionsListJsonModel(serverConnections);
-                    return jsonFileHandle.TryWriteToFile(connectionsStorageFilePath, model);
+                    var wasSaved = jsonFileHandle.TryWriteToFile(connectionsStorageFilePath, model);
+                    if (wasSaved)
+                    {
+                        OnConnectionChanged();
+                    }
+                    return wasSaved;
                 }
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
@@ -240,4 +249,7 @@ internal class ServerConnectionsRepository : IServerConnectionsRepository
             return false;
         }
     }
+
+    private void OnConnectionChanged() => ConnectionChanged?.Invoke(this, EventArgs.Empty);
+    private void OnCredentialsChanged(ServerConnection serverConnection) => CredentialsChanged?.Invoke(this, new ServerConnectionUpdatedEventArgs(serverConnection));
 }

--- a/src/Core/Binding/IServerConnectionsRepository.cs
+++ b/src/Core/Binding/IServerConnectionsRepository.cs
@@ -29,4 +29,17 @@ public interface IServerConnectionsRepository
     bool TryUpdateSettingsById(string connectionId, ServerConnectionSettings connectionSettings);
     bool TryUpdateCredentialsById(string connectionId, ICredentials credentials);
     bool ConnectionsFileExists();
+    event EventHandler ConnectionChanged;
+    event EventHandler<ServerConnectionUpdatedEventArgs> CredentialsChanged;
 }
+
+public class ServerConnectionUpdatedEventArgs : EventArgs
+{
+    public ServerConnectionUpdatedEventArgs(ServerConnection serverConnection)
+    {
+        ServerConnection = serverConnection;
+    }
+
+    public ServerConnection ServerConnection { get; }
+}
+

--- a/src/SLCore.UnitTests/State/AliveConnectionTrackerTests.cs
+++ b/src/SLCore.UnitTests/State/AliveConnectionTrackerTests.cs
@@ -18,12 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Linq;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Synchronization;
-using SonarLint.VisualStudio.SLCore.Common.Helpers;
 using SonarLint.VisualStudio.SLCore.Core;
 using SonarLint.VisualStudio.SLCore.Service.Connection;
 using SonarLint.VisualStudio.SLCore.Service.Connection.Models;
@@ -39,8 +36,8 @@ public class AliveConnectionTrackerTests
     {
         MefTestHelpers.CheckTypeCanBeImported<AliveConnectionTracker, IAliveConnectionTracker>(
             MefTestHelpers.CreateExport<ISLCoreServiceProvider>(),
+            MefTestHelpers.CreateExport<IServerConnectionsRepository>(),
             MefTestHelpers.CreateExport<IServerConnectionsProvider>(),
-            MefTestHelpers.CreateExport<ISolutionBindingRepository>(),
             MefTestHelpers.CreateExport<IThreadHandling>(),
             MefTestHelpers.CreateExport<IAsyncLockFactory>());
     }
@@ -54,13 +51,14 @@ public class AliveConnectionTrackerTests
     [TestMethod]
     public void Ctor_SubscribesToEvents()
     {
-        var bindingRepositoryMock = new Mock<ISolutionBindingRepository>();
+        var serverConnectionsRepository = new Mock<IServerConnectionsRepository>();
         ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out _, out _);
 
-        CreateTestSubject(Mock.Of<ISLCoreServiceProvider>(), Mock.Of<IServerConnectionsProvider>(), bindingRepositoryMock.Object,
+        CreateTestSubject(Mock.Of<ISLCoreServiceProvider>(), Mock.Of<IServerConnectionsProvider>(), serverConnectionsRepository.Object,
             asyncLockFactoryMock.Object);
 
-        bindingRepositoryMock.VerifyAdd(x => x.BindingUpdated += It.IsAny<EventHandler>());
+        serverConnectionsRepository.VerifyAdd(x => x.ConnectionChanged += It.IsAny<EventHandler>());
+        serverConnectionsRepository.VerifyAdd(x => x.CredentialsChanged += It.IsAny<EventHandler<ServerConnectionUpdatedEventArgs>>());
         asyncLockFactoryMock.Verify(x => x.Create());
     }
 
@@ -74,7 +72,7 @@ public class AliveConnectionTrackerTests
         ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out var asyncLockMock, out var asyncLockReleaseMock);
         ConfigureConnectionProvider(out var connectionProviderMock, sonarQubeConnection);
         var testSubject = CreateTestSubject(serviceProviderMock.Object, connectionProviderMock.Object, 
-             Mock.Of<ISolutionBindingRepository>(), asyncLockFactoryMock.Object);
+             Mock.Of<IServerConnectionsRepository>(), asyncLockFactoryMock.Object);
 
         testSubject.RefreshConnectionList();
 
@@ -100,7 +98,7 @@ public class AliveConnectionTrackerTests
         ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out var asyncLockMock, out var asyncLockReleaseMock);
         ConfigureConnectionProvider(out var connectionProviderMock, sonarCloudConnection);
         var testSubject = CreateTestSubject(serviceProviderMock.Object, connectionProviderMock.Object,
-            Mock.Of<ISolutionBindingRepository>(), asyncLockFactoryMock.Object);
+            Mock.Of<IServerConnectionsRepository>(), asyncLockFactoryMock.Object);
 
         testSubject.RefreshConnectionList();
 
@@ -124,7 +122,7 @@ public class AliveConnectionTrackerTests
         ConfigureConnectionProvider(out var connectionProviderMock);
         var threadHandlingMock = new Mock<IThreadHandling>();
         var testSubject = CreateTestSubject(serviceProviderMock.Object, connectionProviderMock.Object,
-            Mock.Of<ISolutionBindingRepository>(), asyncLockFactoryMock.Object, threadHandlingMock.Object);
+            Mock.Of<IServerConnectionsRepository>(), asyncLockFactoryMock.Object, threadHandlingMock.Object);
 
         testSubject.RefreshConnectionList();
 
@@ -136,7 +134,7 @@ public class AliveConnectionTrackerTests
     {
         var serviceProviderMock = new Mock<ISLCoreServiceProvider>();
         var testSubject = CreateTestSubject(serviceProviderMock.Object, Mock.Of<IServerConnectionsProvider>(),
-            Mock.Of<ISolutionBindingRepository>(), Mock.Of<IAsyncLockFactory>());
+            Mock.Of<IServerConnectionsRepository>(), Mock.Of<IAsyncLockFactory>());
 
         var act = () => testSubject.RefreshConnectionList();
 
@@ -146,16 +144,16 @@ public class AliveConnectionTrackerTests
     [TestMethod]
     public void Event_TriggersRefresh()
     {
-        var bindingRepositoryMock = new Mock<ISolutionBindingRepository>();
+        var serverConnectionsRepository = new Mock<IServerConnectionsRepository>();
         var sonarQubeConnection = new SonarQubeConnectionConfigurationDto("sq1", true, "http://localhost/");
         var sonarCloudConnection = new SonarCloudConnectionConfigurationDto("sc2", true, "org");
         ConfigureServiceProvider(out var serviceProviderMock, out var connectionServiceMock);
         ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out var asyncLockMock, out var asyncLockReleaseMock);
         ConfigureConnectionProvider(out var connectionProviderMock, sonarQubeConnection, sonarCloudConnection);
-        var testSubject = CreateTestSubject(serviceProviderMock.Object, connectionProviderMock.Object,
-            bindingRepositoryMock.Object, asyncLockFactoryMock.Object);
+        CreateTestSubject(serviceProviderMock.Object, connectionProviderMock.Object,
+            serverConnectionsRepository.Object, asyncLockFactoryMock.Object);
 
-        bindingRepositoryMock.Raise(x => x.BindingUpdated += It.IsAny<EventHandler>(), EventArgs.Empty);
+        serverConnectionsRepository.Raise(x => x.ConnectionChanged += It.IsAny<EventHandler>(), EventArgs.Empty);
 
         connectionServiceMock.Verify(x => x.DidUpdateConnections(
             It.Is<DidUpdateConnectionsParams>(p =>
@@ -169,13 +167,13 @@ public class AliveConnectionTrackerTests
     [TestMethod]
     public void Event_RunsOnBackgroundThread()
     {
-        var bindingRepositoryMock = new Mock<ISolutionBindingRepository>();
+        var serverConnectionsRepository = new Mock<IServerConnectionsRepository>();
         var threadHandlingMock = new Mock<IThreadHandling>();
         ConfigureConnectionProvider(out var connectionProviderMock);
-        var testSubject = CreateTestSubject(Mock.Of<ISLCoreServiceProvider>(), connectionProviderMock.Object,
-            bindingRepositoryMock.Object, Mock.Of<IAsyncLockFactory>(), threadHandlingMock.Object);
+        CreateTestSubject(Mock.Of<ISLCoreServiceProvider>(), connectionProviderMock.Object,
+            serverConnectionsRepository.Object, Mock.Of<IAsyncLockFactory>(), threadHandlingMock.Object);
 
-        bindingRepositoryMock.Raise(x => x.BindingUpdated += It.IsAny<EventHandler>(), EventArgs.Empty);
+        serverConnectionsRepository.Raise(x => x.ConnectionChanged += It.IsAny<EventHandler>(), EventArgs.Empty);
 
         threadHandlingMock.Verify(x => x.RunOnBackgroundThread(It.IsAny<Func<Task<int>>>()));
     }
@@ -183,15 +181,74 @@ public class AliveConnectionTrackerTests
     [TestMethod]
     public void Dispose_UnsubscribesAndDisposesLock()
     {
-        var bindingRepositoryMock = new Mock<ISolutionBindingRepository>();
+        var serverConnectionsRepository = new Mock<IServerConnectionsRepository>();
         ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out var asyncLockMock, out _);
         var testSubject = CreateTestSubject(Mock.Of<ISLCoreServiceProvider>(), Mock.Of<IServerConnectionsProvider>(),
-            bindingRepositoryMock.Object, asyncLockFactoryMock.Object);
+            serverConnectionsRepository.Object, asyncLockFactoryMock.Object);
 
         testSubject.Dispose();
 
-        bindingRepositoryMock.VerifyRemove(x => x.BindingUpdated -= It.IsAny<EventHandler>());
+        serverConnectionsRepository.VerifyRemove(x => x.ConnectionChanged -= It.IsAny<EventHandler>());
         asyncLockMock.Verify(x => x.Dispose());
+    }
+
+    [TestMethod]
+    public void UpdateCredentials_ChecksThread()
+    {
+        ConfigureServiceProvider(out var serviceProviderMock, out _);
+        ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out _, out _);
+        ConfigureConnectionProvider(out var connectionProviderMock);
+        var threadHandlingMock = new Mock<IThreadHandling>();
+        var testSubject = CreateTestSubject(serviceProviderMock.Object, connectionProviderMock.Object, Mock.Of<IServerConnectionsRepository>(), asyncLockFactory: asyncLockFactoryMock.Object, threadHandlingMock.Object);
+
+        testSubject.UpdateCredentials("connId");
+
+        threadHandlingMock.Verify(x => x.ThrowIfOnUIThread());
+    }
+
+    [TestMethod]
+    public void UpdateCredentials_ServiceUnavailable_Throws()
+    {
+        var serviceProviderMock = new Mock<ISLCoreServiceProvider>();
+        var testSubject = CreateTestSubject(serviceProviderMock.Object, Mock.Of<IServerConnectionsProvider>(), Mock.Of<IServerConnectionsRepository>(), Mock.Of<IAsyncLockFactory>());
+
+        var act = () => testSubject.UpdateCredentials("connId");
+
+        act.Should().ThrowExactly<InvalidOperationException>().WithMessage(SLCoreStrings.ServiceProviderNotInitialized);
+    }
+
+    [TestMethod]
+    public void UpdateCredentials_SonarCloud_TriggersRefreshCredentials()
+    {
+        ConfigureServiceProvider(out var serviceProviderMock, out var connectionServiceMock);
+        ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out var asyncLockMock, out var asyncLockReleaseMock);
+        var serverConnectionRepository = new Mock<IServerConnectionsRepository>();
+        CreateTestSubject(serviceProviderMock.Object, Mock.Of<IServerConnectionsProvider>(), serverConnectionRepository.Object, asyncLockFactoryMock.Object);
+        var sonarCloud = new ServerConnection.SonarCloud("myOrg");
+
+        serverConnectionRepository.Raise(
+            x => x.CredentialsChanged += It.IsAny<EventHandler<ServerConnectionUpdatedEventArgs>>(), new ServerConnectionUpdatedEventArgs(sonarCloud));
+
+        connectionServiceMock.Verify(
+            x => x.DidChangeCredentials(It.Is<DidChangeCredentialsParams>(args => args.connectionId == sonarCloud.Id)), Times.Once);
+        VerifyLockTakenAndReleased(asyncLockMock, asyncLockReleaseMock);
+    }
+
+    [TestMethod]
+    public void UpdateCredentials_SonarQube_TriggersRefreshCredentials()
+    {
+        ConfigureServiceProvider(out var serviceProviderMock, out var connectionServiceMock);
+        ConfigureAsyncLockFactory(out var asyncLockFactoryMock, out var asyncLockMock, out var asyncLockReleaseMock);
+        var serverConnectionRepository = new Mock<IServerConnectionsRepository>();
+        CreateTestSubject(serviceProviderMock.Object, Mock.Of<IServerConnectionsProvider>(), serverConnectionRepository.Object, asyncLockFactoryMock.Object);
+        var sonarQube = new ServerConnection.SonarQube(new Uri("http://localhost:9000"));
+
+        serverConnectionRepository.Raise(
+            x => x.CredentialsChanged += It.IsAny<EventHandler<ServerConnectionUpdatedEventArgs>>(), new ServerConnectionUpdatedEventArgs(sonarQube));
+
+        connectionServiceMock.Verify(
+            x => x.DidChangeCredentials(It.Is<DidChangeCredentialsParams>(args => args.connectionId == sonarQube.Id)), Times.Once);
+        VerifyLockTakenAndReleased(asyncLockMock, asyncLockReleaseMock);
     }
 
     private static void VerifyLockTakenAndReleased(Mock<IAsyncLock> asyncLock, Mock<IReleaseAsyncLock> lockRelease)
@@ -228,13 +285,13 @@ public class AliveConnectionTrackerTests
 
     private static AliveConnectionTracker CreateTestSubject(ISLCoreServiceProvider slCoreServiceProvider,
         IServerConnectionsProvider serverConnectionsProvider,
-        ISolutionBindingRepository bindingRepository,
+        IServerConnectionsRepository connectionsRepository,
         IAsyncLockFactory asyncLockFactory,
         IThreadHandling threadHandling = null)
     {
         return new AliveConnectionTracker(slCoreServiceProvider,
             serverConnectionsProvider,
-            bindingRepository,
+            connectionsRepository,
             asyncLockFactory,
             threadHandling ?? new NoOpThreadHandler());
     }


### PR DESCRIPTION
[SLVS-1473](https://sonarsource.atlassian.net/browse/SLVS-1473)

Update ActiveConnectionTracker to listen to events from ServerConnectionRepository instead of ISolutionBindingRepository.

The connections are saved in a dedicated file and are no longer calculated from binding. Therefore, we need to listen to the repository.

Update the ServerConnectionRepository to raise events when a connection is added/deleted/updated and when the credentials are changed.

This PR is only really testable in conjunction with the [this PR ](https://github.com/SonarSource/sonarlint-visualstudio/pull/5718)

[SLVS-1473]: https://sonarsource.atlassian.net/browse/SLVS-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ