### PR TITLE
SLVS-1489 Use Shared Binding Config infobar not shown unless Manage Binding dialog is clicked

### DIFF
--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -70,7 +70,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
         private ILogger logger;
         private IRoslynSettingsFileSynchronizer roslynSettingsFileSynchronizer;
-        private ISharedBindingSuggestionService suggestSharedBindingGoldBar;
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
@@ -105,9 +104,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 roslynSettingsFileSynchronizer.UpdateFileStorageAsync().Forget(); // don't wait for it to finish
                 Debug.Assert(threadHandling.CheckAccess(), "Still expecting to be on the UI thread");
 
-                suggestSharedBindingGoldBar = serviceProvider.GetMefService<ISharedBindingSuggestionService>();
-                suggestSharedBindingGoldBar.Suggest();
-
                 logger.WriteLine(Strings.SL_InitializationComplete);
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
@@ -123,7 +119,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             if (disposing)
             {
                 this.roslynSettingsFileSynchronizer?.Dispose();
-                suggestSharedBindingGoldBar?.Dispose();
                 this.roslynSettingsFileSynchronizer = null;
             }
         }

--- a/src/Integration.Vsix/SonarLintNotificationsPackage.cs
+++ b/src/Integration.Vsix/SonarLintNotificationsPackage.cs
@@ -42,6 +42,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     [Guid(PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     [ProvideAutoLoad(UIContextGuids.SolutionExists, PackageAutoLoadFlags.BackgroundLoad)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.FolderOpened_string, PackageAutoLoadFlags.BackgroundLoad)]
     public sealed class SonarLintNotificationsPackage : AsyncPackage
     {
         /// <summary>

--- a/src/Integration.Vsix/SonarLintNotificationsPackage.cs
+++ b/src/Integration.Vsix/SonarLintNotificationsPackage.cs
@@ -18,21 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Threading;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.SystemAbstractions;
+using SonarLint.VisualStudio.Integration.MefServices;
 using SonarLint.VisualStudio.Integration.Notifications;
-using SonarLint.VisualStudio.Integration.Telemetry;
 using SonarQube.Client;
 
 using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
@@ -60,6 +58,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
         private ILogger logger;
         private NotificationData notificationData;
         private bool disposed;
+        private ISharedBindingSuggestionService suggestSharedBindingGoldBar;
 
         protected override System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
@@ -101,6 +100,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
                 PerformUIInitialisation();
                 logger.WriteLine(Resources.Strings.Notifications_InitializationComplete);
+
+                suggestSharedBindingGoldBar = this.GetMefService<ISharedBindingSuggestionService>();
+                suggestSharedBindingGoldBar.Suggest();
             });
         }
         private void PerformUIInitialisation()
@@ -151,6 +153,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
 
             activeSolutionBoundTracker.SolutionBindingChanged -= OnSolutionBindingChanged;
 
+            suggestSharedBindingGoldBar?.Dispose();
             (notifications as IDisposable)?.Dispose();
             disposed = true;
         }


### PR DESCRIPTION
[SLVS-1489](https://sonarsource.atlassian.net/browse/SLVS-1489)

Moved the call to ISharedBindingSuggestionService to SonarLintNotificationsPackage and made sure that the package is also initialized when opening a folder and a workspace.

[SLVS-1489]: https://sonarsource.atlassian.net/browse/SLVS-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ