### PR TITLE
SLVS-1487 Fix null reference exception in ManageBindingViewModel.CreteConnectionInfoFromSharedBinding

### DIFF
--- a/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
@@ -720,13 +720,16 @@ public class ManageBindingViewModelTests
     }
 
     [TestMethod]
-    public void DetectSharedBinding_CurrentProjectBound_DoesNothing()
+    public void DetectSharedBinding_CurrentProjectBound_UpdatesSharedBindingConfigModel()
     {
         testSubject.BoundProject = serverProject;
+        var sharedBindingModel = new SharedBindingConfigModel();
+        sharedBindingConfigProvider.GetSharedBinding().Returns(sharedBindingModel);
 
         testSubject.DetectSharedBinding();
 
-        sharedBindingConfigProvider.DidNotReceive().GetSharedBinding();
+        sharedBindingConfigProvider.Received(1).GetSharedBinding();
+        testSubject.SharedBindingConfigModel.Should().Be(sharedBindingModel);
     }
 
     [TestMethod]

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -71,7 +71,7 @@ public partial class ManageBindingDialog : Window
     private async void ManageBindingDialog_OnInitialized(object sender, EventArgs e)
     {
         await ViewModel.InitializeDataAsync();
-        if (useSharedBindingOnInitialization)
+        if (useSharedBindingOnInitialization && !ViewModel.IsCurrentProjectBound)
         {
             await ViewModel.UseSharedBindingWithProgressAsync();
         }

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
@@ -181,10 +181,6 @@ public sealed class ManageBindingViewModel : ViewModelBase, IDisposable
     
     internal void DetectSharedBinding()
     {
-        if (IsCurrentProjectBound)
-        {
-            return;
-        }
         SharedBindingConfigModel = connectedModeBindingServices.SharedBindingConfigProvider.GetSharedBinding();
     }
 


### PR DESCRIPTION
[SLVS-1487](https://sonarsource.atlassian.net/browse/SLVS-1487)

Fix null reference exception in ManageBindingViewModel.CreteConnectionInfoFromSharedBinding by making sure that the shared binding configuration is always read even when the IsCurrentProjectBound is true.

It can be the case that, when the SuggestSharedBindingGoldBar detects the shared binding config file, the project is not yet bound. But when the window is opened by using the "Bind" button from the goldbar, the project is already bound. In this case there is no reason why the shared binding config should not be read.

[SLVS-1487]: https://sonarsource.atlassian.net/browse/SLVS-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ