### PR TITLE
SLVS-1529 Cache analyzerAssemblyLoader

### DIFF
--- a/src/Infrastructure.VS.UnitTests/Infrastructure.VS.UnitTests.csproj
+++ b/src/Infrastructure.VS.UnitTests/Infrastructure.VS.UnitTests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Infrastructure.VS\Infrastructure.VS.csproj" />
     <ProjectReference Include="..\TestInfrastructure\TestInfrastructure.csproj" />
   </ItemGroup>

--- a/src/Infrastructure.VS.UnitTests/Roslyn/AnalyzerAssemblyLoaderFactoryTests.cs
+++ b/src/Infrastructure.VS.UnitTests/Roslyn/AnalyzerAssemblyLoaderFactoryTests.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Infrastructure.VS.Roslyn;
+
+namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests.Roslyn;
+
+[TestClass]
+public class AnalyzerAssemblyLoaderFactoryTests
+{
+    private AnalyzerAssemblyLoaderFactory testSubject;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        testSubject = new AnalyzerAssemblyLoaderFactory();
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckExports()
+    {
+        MefTestHelpers.CheckTypeCanBeImported<AnalyzerAssemblyLoaderFactory, IAnalyzerAssemblyLoaderFactory>();
+    }
+
+    [TestMethod]
+    public void Mef_CheckIsSingleton()
+    {
+        MefTestHelpers.CheckIsSingletonMefComponent<AnalyzerAssemblyLoaderFactory>();
+    }
+
+    [TestMethod]
+    public void Create_CachesLoader()
+    {
+        var loader1 = testSubject.Create();
+        var loader2 = testSubject.Create();
+
+        Assert.AreSame(loader1, loader2);
+    }
+}

--- a/src/Infrastructure.VS.UnitTests/packages.lock.json
+++ b/src/Infrastructure.VS.UnitTests/packages.lock.json
@@ -14,6 +14,21 @@
         "resolved": "0.11.4",
         "contentHash": "zSCkwOgc5OyfMfEeMr9x0K7WCDf8i6VdF2RtCLN/4m6iebTtJQdeoJ9IS4/RyYHuLUYjrm0sd+siWbaSvSzRYQ=="
       },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Direct",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
+          "System.Collections.Immutable": "5.0.0",
+          "System.Memory": "4.5.4",
+          "System.Reflection.Metadata": "5.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
+          "System.Text.Encoding.CodePages": "4.5.1",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[16.6.1, )",
@@ -161,6 +176,11 @@
         "type": "Transitive",
         "resolved": "16.5.0",
         "contentHash": "K0hfdWy+0p8DJXxzpNc4T5zHm4hf9QONAvyzvw3utKExmxRBShtV/+uHVYTblZWk+rIHNEHeglyXMmqfSshdFA=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.3.2",
+        "contentHash": "7xt6zTlIEizUgEsYAIgm37EbdkiMmr6fP6J9pDoKEpiGM4pi32BCPGr/IczmSJI9Zzp0a6HOzpr9OvpMP+2veA=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -1049,6 +1069,14 @@
         "resolved": "4.6.0",
         "contentHash": "j/V5HVvxvBQ7uubYD0PptQW2KGsi1Pc2kZ9yfwLixv3ADdjL/4M78KyC5e+ymW612DY8ZE4PFoZmWpoNmN2mqg=="
       },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "5.0.0"
+        }
+      },
       "System.Runtime": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1101,6 +1129,14 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        }
       },
       "System.Threading.AccessControl": {
         "type": "Transitive",

--- a/src/Infrastructure.VS/Roslyn/AnalyzerAssemblyLoaderFactory.cs
+++ b/src/Infrastructure.VS/Roslyn/AnalyzerAssemblyLoaderFactory.cs
@@ -18,18 +18,28 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
 namespace SonarLint.VisualStudio.Infrastructure.VS.Roslyn;
 
+[Export(typeof(IAnalyzerAssemblyLoaderFactory))]
+[PartCreationPolicy(CreationPolicy.Shared)]
 internal class AnalyzerAssemblyLoaderFactory : IAnalyzerAssemblyLoaderFactory
 {
-    [ExcludeFromCodeCoverage]
-    public IAnalyzerAssemblyLoader Create()
+    private AnalyzerAssemblyLoader analyzerAssemblyLoader;
+
+    [ImportingConstructor]
+    public AnalyzerAssemblyLoaderFactory()
     {
-        return new AnalyzerAssemblyLoader();
+    }
+
+    public IAnalyzerAssemblyLoader Create()
+    { 
+        analyzerAssemblyLoader ??= new AnalyzerAssemblyLoader();
+        return analyzerAssemblyLoader;
     }
 
     [ExcludeFromCodeCoverage]

--- a/src/Infrastructure.VS/Roslyn/AnalyzerAssemblyLoaderFactory.cs
+++ b/src/Infrastructure.VS/Roslyn/AnalyzerAssemblyLoaderFactory.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 
 namespace SonarLint.VisualStudio.Infrastructure.VS.Roslyn;
@@ -28,6 +29,19 @@ internal class AnalyzerAssemblyLoaderFactory : IAnalyzerAssemblyLoaderFactory
     [ExcludeFromCodeCoverage]
     public IAnalyzerAssemblyLoader Create()
     {
-        throw new NotImplementedException();
+        return new AnalyzerAssemblyLoader();
+    }
+
+    [ExcludeFromCodeCoverage]
+    private sealed class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+    {
+        public void AddDependencyLocation(string fullPath)
+        {
+        }
+
+        public Assembly LoadFromPath(string fullPath)
+        {
+            return Assembly.Load(fullPath);
+        }
     }
 }


### PR DESCRIPTION
[SLVS-1529](https://sonarsource.atlassian.net/browse/SLVS-1529)

This PR targets the [implementation of the AnalyzerAssemblyLoader,](https://github.com/SonarSource/sonarlint-visualstudio/pull/5764) because it depends on it

[SLVS-1529]: https://sonarsource.atlassian.net/browse/SLVS-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ