### PR TITLE
SLVS-1550 Fix exception when connecting to SQ

### DIFF
--- a/src/Integration.Vsix/Integration.Vsix.csproj
+++ b/src/Integration.Vsix/Integration.Vsix.csproj
@@ -425,6 +425,7 @@
       <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Threading.Channels'" />
       <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Threading.Tasks.Extensions'" />
       <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'DiffPlex'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Google.Protobuf'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fix exception when connecting to SQ by making sure that the Google.Protobuf.dll is also part of the root folder inside vsix, which is needed by SonarQube.Client

[SLVS-1550](https://sonarsource.atlassian.net/browse/SLVS-1550)



[SLVS-1550]: https://sonarsource.atlassian.net/browse/SLVS-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ