### PR TITLE
SLVS-1183 SLVS goldbars are not reset on solution/binding change

### DIFF
--- a/src/Integration.UnitTests/MefServices/SharedBindingSuggestionServiceTests.cs
+++ b/src/Integration.UnitTests/MefServices/SharedBindingSuggestionServiceTests.cs
@@ -123,14 +123,6 @@ public class SharedBindingSuggestionServiceTests
     }
 
     [TestMethod]
-    public void ActiveSolutionChanged_SolutionIsClosed_ClosesAnyOpenGoldBar()
-    {
-        RaiseActiveSolutionChanged(false);
-
-        suggestSharedBindingGoldBar.Received(1).Close();
-    }
-
-    [TestMethod]
     [DataRow(SonarLintMode.Connected, true)]
     [DataRow(SonarLintMode.Standalone, false)]
     public void SolutionBindingChanged_WhenConnectedMode_ClosesAnyOpenGoldBar(SonarLintMode mode, bool expectedToClose)

--- a/src/Integration/MefServices/SharedBindingSuggestionService.cs
+++ b/src/Integration/MefServices/SharedBindingSuggestionService.cs
@@ -41,6 +41,7 @@ namespace SonarLint.VisualStudio.Integration.MefServices
         private readonly IConnectedModeBindingServices connectedModeBindingServices;
         private readonly IConnectedModeUIManager connectedModeUiManager;
         private readonly IActiveSolutionTracker activeSolutionTracker;
+        private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
 
         [ImportingConstructor]
         public SharedBindingSuggestionService(
@@ -48,15 +49,18 @@ namespace SonarLint.VisualStudio.Integration.MefServices
             IConnectedModeServices connectedModeServices,
             IConnectedModeBindingServices connectedModeBindingServices,
             IConnectedModeUIManager connectedModeUiManager,
-            IActiveSolutionTracker activeSolutionTracker)
+            IActiveSolutionTracker activeSolutionTracker,
+            IActiveSolutionBoundTracker activeSolutionBoundTracker)
         {
             this.suggestSharedBindingGoldBar = suggestSharedBindingGoldBar;
             this.connectedModeServices = connectedModeServices;
             this.connectedModeBindingServices = connectedModeBindingServices;
             this.connectedModeUiManager = connectedModeUiManager;
             this.activeSolutionTracker = activeSolutionTracker;
+            this.activeSolutionBoundTracker = activeSolutionBoundTracker;
 
             this.activeSolutionTracker.ActiveSolutionChanged += OnActiveSolutionChanged;
+            this.activeSolutionBoundTracker.SolutionBindingChanged += OnActiveSolutionBindingChanged;
         }
 
         public void Suggest()
@@ -73,6 +77,7 @@ namespace SonarLint.VisualStudio.Integration.MefServices
         public void Dispose()
         {
             activeSolutionTracker.ActiveSolutionChanged -= OnActiveSolutionChanged;
+            activeSolutionBoundTracker.SolutionBindingChanged -= OnActiveSolutionBindingChanged;
         }
 
         private void ShowManageBindingDialog()
@@ -85,6 +90,14 @@ namespace SonarLint.VisualStudio.Integration.MefServices
             if (e.IsSolutionOpen)
             {
                 Suggest();
+            }
+        }
+        
+        private void OnActiveSolutionBindingChanged(object sender, ActiveSolutionBindingEventArgs e)
+        {
+            if (e.Configuration.Mode == SonarLintMode.Connected)
+            {
+                suggestSharedBindingGoldBar.Close();
             }
         }
     }


### PR DESCRIPTION
[SLVS-1183](https://sonarsource.atlassian.net/browse/SLVS-1183)

Expectations:

1. On a project with shared binding which is still in Standalone mode, after binding the notification should close
2. On a project which is still in Standalone mode and an Open in IDE request came, after binding the notification to connect should close

[SLVS-1183]: https://sonarsource.atlassian.net/browse/SLVS-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ