### PR TITLE
SLVS-1563 Raise CurrentConfigurationScopeChanged when configuration scope changed

### DIFF
--- a/src/SLCore.UnitTests/State/ActiveConfigScopeTrackerTests.cs
+++ b/src/SLCore.UnitTests/State/ActiveConfigScopeTrackerTests.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.ComponentModel;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Synchronization;
 using SonarLint.VisualStudio.SLCore.Core;
@@ -39,7 +38,7 @@ public class ActiveConfigScopeTrackerTests
     private ISLCoreServiceProvider serviceProvider;
     private IAsyncLockFactory asyncLockFactory;
     private IThreadHandling threadHandling;
-    private EventHandler currentConfigScopeChangedEventHandler;
+    private EventHandler<ConfigurationScope> currentConfigScopeChangedEventHandler;
 
     [TestInitialize]
     public void TestInitialize()
@@ -52,7 +51,7 @@ public class ActiveConfigScopeTrackerTests
         threadHandling = Substitute.For<IThreadHandling>();
         ConfigureServiceProvider(isServiceAvailable:true);
         ConfigureAsyncLockFactory();
-        currentConfigScopeChangedEventHandler = Substitute.For<EventHandler>();
+        currentConfigScopeChangedEventHandler = Substitute.For<EventHandler<ConfigurationScope>>();
 
         testSubject = new ActiveConfigScopeTracker(serviceProvider, asyncLockFactory, threadHandling);
         testSubject.CurrentConfigurationScopeChanged += currentConfigScopeChangedEventHandler;
@@ -84,7 +83,7 @@ public class ActiveConfigScopeTrackerTests
         VerifyThreadHandling();
         VerifyServiceAddCall();
         VerifyLockTakenSynchronouslyAndReleased();
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(configScopeId);
     }
 
     [TestMethod]
@@ -100,7 +99,7 @@ public class ActiveConfigScopeTrackerTests
         
         result.Should().BeTrue();
         testSubject.currentConfigScope.Should().BeEquivalentTo(new ConfigurationScope(configScopeId, connectionId, sonarProjectKey, "some root", isReady));
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(configScopeId);
     }
 
     [TestMethod]
@@ -132,7 +131,7 @@ public class ActiveConfigScopeTrackerTests
         
         result.Should().BeTrue();
         testSubject.currentConfigScope.Should().BeEquivalentTo(new ConfigurationScope(configScopeId, connectionId, sonarProjectKey, root, true));
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(configScopeId);
     }
 
     [TestMethod]
@@ -164,7 +163,7 @@ public class ActiveConfigScopeTrackerTests
         VerifyThreadHandling();
         VerifyServiceAddCall();
         VerifyLockTakenSynchronouslyAndReleased();
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(configScopeId);
     }
 
     [TestMethod]
@@ -184,7 +183,7 @@ public class ActiveConfigScopeTrackerTests
         VerifyThreadHandling();
         VerifyServiceUpdateCall();
         VerifyLockTakenSynchronouslyAndReleased();
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(configScopeId);
     }
 
     [TestMethod]
@@ -225,7 +224,7 @@ public class ActiveConfigScopeTrackerTests
         configScopeService.Received().DidRemoveConfigurationScope(Arg.Is<DidRemoveConfigurationScopeParams>(p => p.removedId == configScopeId));
         VerifyThreadHandling();
         VerifyLockTakenSynchronouslyAndReleased();
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(null);
     }
 
     [TestMethod]
@@ -295,7 +294,7 @@ public class ActiveConfigScopeTrackerTests
         serviceProvider.ReceivedCalls().Count().Should().Be(0);
         VerifyThreadHandling();
         VerifyLockTakenSynchronouslyAndReleased();
-        VerifyCurrentConfigurationScopeChangedRaised();
+        VerifyCurrentConfigurationScopeChangedRaised(null);
     }
 
     [TestMethod]
@@ -352,14 +351,19 @@ public class ActiveConfigScopeTrackerTests
         });
     }
 
-    private void VerifyCurrentConfigurationScopeChangedRaised()
+    private void VerifyCurrentConfigurationScopeChangedRaised(string configScopeId)
     {
-        currentConfigScopeChangedEventHandler.Received(1).Invoke(testSubject, Arg.Any<EventArgs>());
+        currentConfigScopeChangedEventHandler.Received(1).Invoke(testSubject, Arg.Is<ConfigurationScope>(c => IsSameConfigScope(c, configScopeId)));
+    }
+
+    private bool IsSameConfigScope(ConfigurationScope configurationScope, string configScopeId)
+    {
+        return configurationScope?.Id == configScopeId;
     }
 
     private void VerifyCurrentConfigurationScopeChangedNotRaised()
     {
-        currentConfigScopeChangedEventHandler.DidNotReceive().Invoke(testSubject, Arg.Any<EventArgs>());
+        currentConfigScopeChangedEventHandler.DidNotReceive().Invoke(testSubject, Arg.Any<ConfigurationScope>());
     }
 
     private class ConfigurationScopeDtoComparer : IEqualityComparer<ConfigurationScopeDto>

--- a/src/SLCore/State/ActiveConfigScopeTracker.cs
+++ b/src/SLCore/State/ActiveConfigScopeTracker.cs
@@ -18,9 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Synchronization;
 using SonarLint.VisualStudio.SLCore.Core;
@@ -109,26 +107,26 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
             {
                 configurationScopeService.DidUpdateBinding(new DidUpdateBindingParams(id, GetBinding(connectionId, sonarProjectKey)));
                 currentConfigScope = currentConfigScope with { ConnectionId = connectionId, SonarProjectId = sonarProjectKey };
-                OnCurrentConfigurationScopeChanged();
-                return;
             }
-
-            configurationScopeService.DidAddConfigurationScopes(new DidAddConfigurationScopesParams([
-                new ConfigurationScopeDto(id, id, true, GetBinding(connectionId, sonarProjectKey))]));
-            currentConfigScope = new ConfigurationScope(id, connectionId, sonarProjectKey);
-            OnCurrentConfigurationScopeChanged();
+            else
+            {
+                configurationScopeService.DidAddConfigurationScopes(new DidAddConfigurationScopesParams([
+                    new ConfigurationScopeDto(id, id, true, GetBinding(connectionId, sonarProjectKey))]));
+                currentConfigScope = new ConfigurationScope(id, connectionId, sonarProjectKey);
+            }
         }
+
+        OnCurrentConfigurationScopeChanged();
     }
 
     public void Reset()
     {
         threadHandling.ThrowIfOnUIThread();
-
         using (asyncLock.Acquire())
         {
             currentConfigScope = null;
-            OnCurrentConfigurationScopeChanged();
         }
+        OnCurrentConfigurationScopeChanged();
     }
 
     public void RemoveCurrentConfigScope()
@@ -150,8 +148,9 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
             configurationScopeService.DidRemoveConfigurationScope(
                 new DidRemoveConfigurationScopeParams(currentConfigScope.Id));
             currentConfigScope = null;
-            OnCurrentConfigurationScopeChanged();
         }
+
+        OnCurrentConfigurationScopeChanged();
     }
 
     public bool TryUpdateRootOnCurrentConfigScope(string id, string root)
@@ -164,9 +163,9 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
             }
 
             currentConfigScope = currentConfigScope with { RootPath = root };
-            OnCurrentConfigurationScopeChanged();
-            return true;
         }
+        OnCurrentConfigurationScopeChanged();
+        return true;
     }
 
     public bool TryUpdateAnalysisReadinessOnCurrentConfigScope(string id, bool isReady)
@@ -179,9 +178,9 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
             }
             
             currentConfigScope = currentConfigScope with { isReadyForAnalysis = isReady};
-            OnCurrentConfigurationScopeChanged();
-            return true;
         }
+        OnCurrentConfigurationScopeChanged();
+        return true;
     }
 
     public event EventHandler CurrentConfigurationScopeChanged;

--- a/src/SLCore/State/ActiveConfigScopeTracker.cs
+++ b/src/SLCore/State/ActiveConfigScopeTracker.cs
@@ -44,7 +44,7 @@ public interface IActiveConfigScopeTracker : IDisposable
 
     bool TryUpdateAnalysisReadinessOnCurrentConfigScope(string id, bool isReady);
 
-    event EventHandler<ConfigurationScope> CurrentConfigurationScopeChanged;
+    event EventHandler CurrentConfigurationScopeChanged;
 }
 
 public record ConfigurationScope(
@@ -184,7 +184,7 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
         }
     }
 
-    public event EventHandler<ConfigurationScope> CurrentConfigurationScopeChanged;
+    public event EventHandler CurrentConfigurationScopeChanged;
 
     public void Dispose()
     {
@@ -197,6 +197,6 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
 
     private void OnCurrentConfigurationScopeChanged()
     {
-        CurrentConfigurationScopeChanged?.Invoke(this, currentConfigScope);
+        CurrentConfigurationScopeChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/SLCore/State/ActiveConfigScopeTracker.cs
+++ b/src/SLCore/State/ActiveConfigScopeTracker.cs
@@ -44,7 +44,7 @@ public interface IActiveConfigScopeTracker : IDisposable
 
     bool TryUpdateAnalysisReadinessOnCurrentConfigScope(string id, bool isReady);
 
-    event EventHandler CurrentConfigurationScopeChanged;
+    event EventHandler<ConfigurationScope> CurrentConfigurationScopeChanged;
 }
 
 public record ConfigurationScope(
@@ -184,7 +184,7 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
         }
     }
 
-    public event EventHandler CurrentConfigurationScopeChanged;
+    public event EventHandler<ConfigurationScope> CurrentConfigurationScopeChanged;
 
     public void Dispose()
     {
@@ -197,6 +197,6 @@ internal sealed class ActiveConfigScopeTracker : IActiveConfigScopeTracker
 
     private void OnCurrentConfigurationScopeChanged()
     {
-        CurrentConfigurationScopeChanged?.Invoke(this, EventArgs.Empty);
+        CurrentConfigurationScopeChanged?.Invoke(this, currentConfigScope);
     }
 }


### PR DESCRIPTION
[SLVS-1563](https://sonarsource.atlassian.net/browse/SLVS-1563)

This is a draft, because it targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/5782), which is needed for the tests. It can still be reviewed. 

[SLVS-1563]: https://sonarsource.atlassian.net/browse/SLVS-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ