### PR TITLE
SLVS-1385 Manage Connections Dialog: User should be able to edit credentials

### DIFF
--- a/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
+++ b/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
@@ -746,6 +746,24 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to refresh binding, please make sure that the credentials are correct..
+        /// </summary>
+        public static string RebindingFailedText {
+            get {
+                return ResourceManager.GetString("RebindingFailedText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Refreshing binding....
+        /// </summary>
+        public static string RebindingProgressText {
+            get {
+                return ResourceManager.GetString("RebindingProgressText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove connection.
         /// </summary>
         public static string RemoveConnectionToolTip {

--- a/src/ConnectedMode/UI/Resources/UiResources.resx
+++ b/src/ConnectedMode/UI/Resources/UiResources.resx
@@ -428,4 +428,10 @@ Please manually add the credentials for the connection and then try again.</valu
   <data name="UpdatingConnectionCredentialsFailedText" xml:space="preserve">
     <value>Failed to update the connection, please make sure that the credentials are correct.</value>
   </data>
+  <data name="RebindingProgressText" xml:space="preserve">
+    <value>Refreshing binding...</value>
+  </data>
+  <data name="RebindingFailedText" xml:space="preserve">
+    <value>Failed to refresh binding, please make sure that the credentials are correct.</value>
+  </data>
 </root>

--- a/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
@@ -123,17 +123,11 @@ namespace SonarLint.VisualStudio.Integration
             {
                 var newBindingConfiguration = GetBindingConfiguration();
 
-                var updateConnection = await UpdateConnectionAsync(newBindingConfiguration);
-
-                if (!updateConnection)
-                {
-                    CurrentConfiguration = BindingConfiguration.Standalone;
-                    return;
-                }
+                var connectionUpdatedSuccessfully = await UpdateConnectionAsync(newBindingConfiguration);
 
                 gitEventsMonitor.Refresh();
 
-                this.RaiseAnalyzersChangedIfBindingChanged(newBindingConfiguration);
+                RaiseAnalyzersChangedIfBindingChanged(connectionUpdatedSuccessfully ? newBindingConfiguration : BindingConfiguration.Standalone);
             }
             catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
             {
@@ -153,6 +147,7 @@ namespace SonarLint.VisualStudio.Integration
 
             if (!bindingConfiguration.Mode.IsInAConnectedMode())
             {
+                // The Standalone mode has no connection so there is nothing to update, thus nothing to fail
                 return true;
             }
 

--- a/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
@@ -25,7 +25,6 @@ using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarQube.Client;
 using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
-using Task = System.Threading.Tasks.Task;
 
 namespace SonarLint.VisualStudio.Integration
 {
@@ -83,7 +82,7 @@ namespace SonarLint.VisualStudio.Integration
 
             // The solution changed inside the IDE
             solutionTracker.ActiveSolutionChanged += OnActiveSolutionChanged;
-            
+
             CurrentConfiguration = GetBindingConfiguration();
 
             SetBoundSolutionUIContext();
@@ -97,7 +96,7 @@ namespace SonarLint.VisualStudio.Integration
             {
                 return;
             }
-            
+
             this.RaiseAnalyzersChangedIfBindingChanged(GetBindingConfiguration(), isBindingCleared);
         }
 
@@ -123,8 +122,14 @@ namespace SonarLint.VisualStudio.Integration
             try
             {
                 var newBindingConfiguration = GetBindingConfiguration();
-                
-                await UpdateConnectionAsync(newBindingConfiguration);
+
+                var updateConnection = await UpdateConnectionAsync(newBindingConfiguration);
+
+                if (!updateConnection)
+                {
+                    CurrentConfiguration = BindingConfiguration.Standalone;
+                    return;
+                }
 
                 gitEventsMonitor.Refresh();
 
@@ -136,7 +141,7 @@ namespace SonarLint.VisualStudio.Integration
             }
         }
 
-        private async Task UpdateConnectionAsync(BindingConfiguration bindingConfiguration)
+        private async Task<bool> UpdateConnectionAsync(BindingConfiguration bindingConfiguration)
         {
             if (sonarQubeService.IsConnected)
             {
@@ -146,20 +151,26 @@ namespace SonarLint.VisualStudio.Integration
             Debug.Assert(!sonarQubeService.IsConnected,
                 "SonarQube service should always be disconnected at this point");
 
-            var boundProject = bindingConfiguration.Project;
-
-            if (boundProject != null)
+            if (!bindingConfiguration.Mode.IsInAConnectedMode())
             {
-                var connectionInformation = boundProject.CreateConnectionInformation();
-                await WebServiceHelper.SafeServiceCallAsync(() => sonarQubeService.ConnectAsync(connectionInformation,
-                    CancellationToken.None), this.logger);
+                return true;
             }
+
+            var boundProject = bindingConfiguration.Project;
+            var connectionInformation = boundProject.CreateConnectionInformation();
+            var isConnected = await WebServiceHelper.SafeServiceCallAsync(async () =>
+            {
+                await sonarQubeService.ConnectAsync(connectionInformation, CancellationToken.None);
+                return sonarQubeService.IsConnected;
+            }, logger);
+
+            return isConnected;
         }
 
         private void RaiseAnalyzersChangedIfBindingChanged(BindingConfiguration newBindingConfiguration, bool? isBindingCleared = null)
         {
             configScopeUpdater.UpdateConfigScopeForCurrentSolution(newBindingConfiguration.Project);
-            
+
             if (!CurrentConfiguration.Equals(newBindingConfiguration))
             {
                 CurrentConfiguration = newBindingConfiguration;


### PR DESCRIPTION
[SLVS-1385](https://sonarsource.atlassian.net/browse/SLVS-1385)

Expectations:
* A connection should be re-triggered when the user edits the credentials
* If any error occurs, show an error message at the bottom of the dialog

To test:
1. Bind a solution with a token
2. Close the solution
3. Revoke the token
4. Open the solution again (expect that the binding is broken)
5. Update with a new token (expect that the solution is bound and you are able to view for example taints)

[SLVS-1385]: https://sonarsource.atlassian.net/browse/SLVS-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ