### PR TITLE
SLVS-1627 Graceful shutdown: Prevent exception when calling detached COM object

### DIFF
--- a/src/Integration.Vsix.UnitTests/Settings/SonarLintSettingsTests.cs
+++ b/src/Integration.Vsix.UnitTests/Settings/SonarLintSettingsTests.cs
@@ -22,361 +22,360 @@ using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Settings;
 using SonarLint.VisualStudio.Integration.Vsix.Settings;
 
-namespace SonarLint.VisualStudio.Integration.UnitTests.Settings
+namespace SonarLint.VisualStudio.Integration.UnitTests.Settings;
+
+[TestClass]
+public class SonarLintSettingsTests
 {
-    [TestClass]
-    public class SonarLintSettingsTests
+    [TestMethod]
+    public void MefCtor_CheckIsExported()
+        => MefTestHelpers.CheckTypeCanBeImported<SonarLintSettings, ISonarLintSettings>(
+            MefTestHelpers.CreateExport<IWritableSettingsStoreFactory>());
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton()
+        => MefTestHelpers.CheckIsSingletonMefComponent<SonarLintSettings>();
+
+    [TestMethod]
+    public void Ctor_DoesNotCallAnyServices()
     {
-        [TestMethod]
-        public void MefCtor_CheckIsExported()
-            => MefTestHelpers.CheckTypeCanBeImported<SonarLintSettings, ISonarLintSettings>(
-                MefTestHelpers.CreateExport<IWritableSettingsStoreFactory>());
-
-        [TestMethod]
-        public void MefCtor_CheckIsSingleton()
-            => MefTestHelpers.CheckIsSingletonMefComponent<SonarLintSettings>();
-
-        [TestMethod]
-        public void Ctor_DoesNotCallAnyServices()
-        {
-            var storeFactory = new Mock<IWritableSettingsStoreFactory>();
-            _ = CreateTestSubject(storeFactory.Object);
-
-            // The MEF constructor should be free-threaded, which it will be if
-            // it doesn't make any external calls.
-            storeFactory.Invocations.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void LazyInitialization_FactoryIsOnlyCalledOnce()
-        {
-            var store = new Mock<WritableSettingsStore>();
-            var factory = CreateStoreFactory(store.Object);
-
-            var testSubject = CreateTestSubject(factory.Object);
-
-            factory.Invocations.Should().BeEmpty(); // Sanity check
-            store.Reset();
-
-            // 1. Make any call to the test subject
-            _ = testSubject.GetValueOrDefault("any", "any");
-
-            factory.Invocations.Should().HaveCount(1);
-            store.Invocations.Should().HaveCount(1);
-
-            // 2. Call the settings again
-            _ = testSubject.GetValueOrDefault("any", true);
-            testSubject.SetValue("any", "any");
-
-            factory.Invocations.Should().HaveCount(1);
-            store.Invocations.Should().HaveCount(3);
-        }
-
-        [TestMethod]
-        public void JreLocation_DefaultValue_ShouldBeEmpty()
-        {
-            var store = new Mock<WritableSettingsStore>();
-
-            var testSubject = CreateTestSubject(store.Object);
-
-            testSubject.JreLocation.Should().BeEmpty();
-            store.Verify(x => x.GetString(SonarLintSettings.SettingsRoot, nameof(testSubject.JreLocation), string.Empty), Times.AtLeastOnce);
-        }
-
-        #region Boolean method tests
-
-        [TestMethod]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(true, true)]
-        [DataRow(false, false)]
-        public void GetValueOrDefault_Bool(bool valueToReturn, bool defaultValueSuppliedByCaller)
-        {
-            var store = new Mock<WritableSettingsStore>();
-            store.Setup(x => x.GetBoolean(SonarLintSettings.SettingsRoot, "aProp", defaultValueSuppliedByCaller)).Returns(valueToReturn);
-
-            var testSubject = CreateTestSubject(store.Object);
-
-            var actual = testSubject.GetValueOrDefault("aProp", defaultValueSuppliedByCaller);
-            actual.Should().Be(valueToReturn);
-        }
-
-        [TestMethod]
-        public void GetValueOrDefault_StoreThrows_ReturnsDefault_Bool()
-        {
-            var suppliedDefault = true;
-
-            var store = new Mock<WritableSettingsStore>();
-            store.Setup(x => x.GetBoolean(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Boolean>()))
-                .Throws(new ArgumentException("thrown in a test"));
-
-            var testSubject = CreateTestSubject(storeToReturn: store.Object);
-
-            var actual = testSubject.GetValueOrDefault("key1", suppliedDefault);
-            actual.Should().Be(suppliedDefault);
-        }
-
-        [TestMethod]
-        public void GetValueOrDefault_NoStore_Bool()
-        {
-            var expected = true;
-            var testSubject = CreateTestSubject(storeToReturn: null);
-
-            var actual = testSubject.GetValueOrDefault("key1", expected);
-            actual.Should().Be(expected);
-        }
-
-        [TestMethod]
-        [DataRow("a key", true)]
-        [DataRow("another key", false)]
-        public void SetValue_Bool(string propertyName, bool valueToSet)
-        {
-            var settingsStore = new Mock<WritableSettingsStore>();
-
-            var testSubject = CreateTestSubject(settingsStore.Object);
-
-            testSubject.SetValue(propertyName, valueToSet);
-
-            CheckPropertySet(settingsStore, propertyName, valueToSet);
-        }
-
-        [TestMethod]
-        public void SetValue_NoStore_Bool()
-        {
-            var testSubject = CreateTestSubject(storeToReturn: null);
-
-            // Act + Assert (no store -> no exception)
-            Action act = () => testSubject.SetValue("key1", false);
-
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        #region String method tests
-
-        [TestMethod]
-        [DataRow("val1", "unused default")]
-        [DataRow("xxx", "xxx")]
-        public void GetValueOrDefault_String(string valueToReturn, string defaultValueSuppliedByCaller)
-        {
-            var store = new Mock<WritableSettingsStore>();
-            store.Setup(x => x.GetString(SonarLintSettings.SettingsRoot, "aProp", defaultValueSuppliedByCaller)).Returns(valueToReturn);
-
-            var testSubject = CreateTestSubject(store.Object);
-
-            var actual = testSubject.GetValueOrDefault("aProp", defaultValueSuppliedByCaller);
-            actual.Should().Be(valueToReturn);
-        }
-
-        [TestMethod]
-        public void GetValueOrDefault_StoreThrows_ReturnsDefault_String()
-        {
-            var suppliedDefault = "the default";
-
-            var store = new Mock<WritableSettingsStore>();
-            store.Setup(x => x.GetString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Throws(new ArgumentException("thrown in a test"));
-
-            var testSubject = CreateTestSubject(storeToReturn: store.Object);
-
-            var actual = testSubject.GetValueOrDefault("key1", suppliedDefault);
-            actual.Should().Be(suppliedDefault);
-        }
-
-        [TestMethod]
-        public void GetValueOrDefault_NoStore_String()
-        {
-            string expected = "the value";
-            var testSubject = CreateTestSubject(storeToReturn: null);
-
-            var actual = testSubject.GetValueOrDefault("key1", expected);
-            actual.Should().Be(expected);
-        }
-
-        [TestMethod]
-        [DataRow("a key", "a value")]
-        [DataRow("another key", "another value")]
-        public void SetValue_String(string propertyName, string valueToSet)
-        {
-            var settingsStore = new Mock<WritableSettingsStore>();
-
-            var testSubject = CreateTestSubject(settingsStore.Object);
-
-            testSubject.SetValue(propertyName, valueToSet);
-
-            CheckPropertySet(settingsStore, propertyName, valueToSet);
-        }
-
-        [TestMethod]
-        public void SetValue_NoStore_String()
-        {
-            var testSubject = CreateTestSubject(storeToReturn: null);
-
-            // Act + Assert (no store -> no exception)
-            Action act = () => testSubject.SetValue("key1", "a value");
-
-            act.Should().NotThrow();
-        }
-
-        [TestMethod]
-        public void SetValue_Null_SetsEmptyString()
-        {
-            var settingsStore = new Mock<WritableSettingsStore>();
-            var testSubject = CreateTestSubject(settingsStore.Object);
-
-            testSubject.SetValue("key1", null);
-
-            settingsStore.Verify(x => x.SetString(SonarLintSettings.SettingsRoot, "key1", string.Empty), Times.Once);
-        }
-
-        #endregion
-
-        #region Int method tests
-
-        [TestMethod]
-        [DataRow(111, 222)]
-        [DataRow(333, 222)]
-        public void GetValueOrDefault_Int(int valueToReturn, int defaultValueSuppliedByCaller)
-        {
-            var store = new Mock<WritableSettingsStore>();
-            store.Setup(x => x.GetInt32(SonarLintSettings.SettingsRoot, "aProp", defaultValueSuppliedByCaller)).Returns(valueToReturn);
-
-            var testSubject = CreateTestSubject(store.Object);
-
-            var actual = testSubject.GetValueOrDefault("aProp", defaultValueSuppliedByCaller);
-            actual.Should().Be(valueToReturn);
-        }
-
-        [TestMethod]
-        public void GetValueOrDefault_StoreThrows_ReturnsDefault_Int()
-        {
-            var suppliedDefault = -123;
-
-            var store = new Mock<WritableSettingsStore>();
-            store.Setup(x => x.GetInt32(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Throws(new ArgumentException("thrown in a test"));
-
-            var testSubject = CreateTestSubject(storeToReturn: store.Object);
-
-            var actual = testSubject.GetValueOrDefault("key1", suppliedDefault);
-            actual.Should().Be(suppliedDefault);
-        }
-
-        [TestMethod]
-        public void GetValueOrDefault_NoStore_Int()
-        {
-            int expected = 888;
-            var testSubject = CreateTestSubject(storeToReturn: null);
-
-            var actual = testSubject.GetValueOrDefault("key1", expected);
-            actual.Should().Be(expected);
-        }
-
-        [TestMethod]
-        [DataRow("a key", 123)]
-        [DataRow("another key", 456)]
-        public void SetValue_Int(string propertyName, int valueToSet)
-        {
-            var settingsStore = new Mock<WritableSettingsStore>();
-
-            var testSubject = CreateTestSubject(settingsStore.Object);
-
-            testSubject.SetValue(propertyName, valueToSet);
-
-            CheckPropertySet(settingsStore, propertyName, valueToSet);
-        }
-
-        [TestMethod]
-        public void SetValue_NoStore_Int()
-        {
-            var testSubject = CreateTestSubject(storeToReturn: null);
-
-            // Act + Assert (no store -> no exception)
-            Action act = () => testSubject.SetValue("key1", 123);
-
-            act.Should().NotThrow();
-        }
-
-        #endregion
-
-        [TestMethod]
-        public void IsActivateMoreEnabled_WhenDisposed_ReturnsDefault()
-        {
-            var testSubject = CreateComDetachedTestSubject();
-
-            testSubject.IsActivateMoreEnabled = true;
-            var activateMoreEnabled = testSubject.IsActivateMoreEnabled;
-
-            activateMoreEnabled.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void DaemonLogLevel_WhenDisposed_ReturnsDefault()
-        {
-            var testSubject = CreateComDetachedTestSubject();
-
-            testSubject.DaemonLogLevel = DaemonLogLevel.Verbose;
-            var daemonLogLevel = testSubject.DaemonLogLevel;
-
-            daemonLogLevel.Should().Be(DaemonLogLevel.Minimal);
-        }
-
-        [TestMethod]
-        public void JreLocation_WhenDisposed_ReturnsDefault()
-        {
-            var testSubject = CreateComDetachedTestSubject();
-
-            testSubject.JreLocation = "/path/to/jre";
-            var jreLocation = testSubject.JreLocation;
-
-            jreLocation.Should().BeEmpty();
-        }
-
-        private static SonarLintSettings CreateComDetachedTestSubject()
-        {
-            var comException = new InvalidComObjectException("COM object that has been separated from its underlying RCW cannot be used.");
-            var writableSettingsStore = Substitute.For<WritableSettingsStore>();
-            writableSettingsStore.When(x => x.GetBoolean(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
-                .Do(x => throw comException);
-            writableSettingsStore.When(x => x.SetBoolean(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
-                .Do(x => throw comException);
-            writableSettingsStore.When(x => x.GetString(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()))
-                .Do(x => throw comException);
-            writableSettingsStore.When(x => x.SetString(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()))
-                .Do(x => throw comException);
-            writableSettingsStore.When(x => x.GetInt32(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()))
-                .Do(x => throw comException);
-            writableSettingsStore.When(x => x.SetInt32(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()))
-                .Do(x => throw comException);
-            var writableSettingsStoreFactory = Substitute.For<IWritableSettingsStoreFactory>();
-            writableSettingsStoreFactory.Create(SonarLintSettings.SettingsRoot).Returns(writableSettingsStore);
-            var testSubject = new SonarLintSettings(writableSettingsStoreFactory);
-            testSubject.Dispose();
-            return testSubject;
-        }
-
-        private static SonarLintSettings CreateTestSubject(IWritableSettingsStoreFactory storeFactory)
-            => new SonarLintSettings(storeFactory);
-
-        private static SonarLintSettings CreateTestSubject(WritableSettingsStore storeToReturn)
-            => CreateTestSubject(CreateStoreFactory(storeToReturn).Object);
-
-        private static Mock<IWritableSettingsStoreFactory> CreateStoreFactory(
-            WritableSettingsStore storeToReturn = null)
-        {
-            var factory = new Mock<IWritableSettingsStoreFactory>();
-            factory.Setup(x => x.Create(It.IsAny<string>())).Returns(storeToReturn);
-            return factory;
-        }
-
-        private static void CheckPropertySet(Mock<WritableSettingsStore> store, string propertyKey, bool value)
-            => store.Verify(x => x.SetBoolean(SonarLintSettings.SettingsRoot, propertyKey, value), Times.Once);
-
-        private static void CheckPropertySet(Mock<WritableSettingsStore> store, string propertyKey, int value)
-            => store.Verify(x => x.SetInt32(SonarLintSettings.SettingsRoot, propertyKey, value), Times.Once);
-
-        private static void CheckPropertySet(Mock<WritableSettingsStore> store, string propertyKey, string value)
-            => store.Verify(x => x.SetString(SonarLintSettings.SettingsRoot, propertyKey, value), Times.Once);
+        var storeFactory = new Mock<IWritableSettingsStoreFactory>();
+        _ = CreateTestSubject(storeFactory.Object);
+
+        // The MEF constructor should be free-threaded, which it will be if
+        // it doesn't make any external calls.
+        storeFactory.Invocations.Should().BeEmpty();
     }
+
+    [TestMethod]
+    public void LazyInitialization_FactoryIsOnlyCalledOnce()
+    {
+        var store = new Mock<WritableSettingsStore>();
+        var factory = CreateStoreFactory(store.Object);
+
+        var testSubject = CreateTestSubject(factory.Object);
+
+        factory.Invocations.Should().BeEmpty(); // Sanity check
+        store.Reset();
+
+        // 1. Make any call to the test subject
+        _ = testSubject.GetValueOrDefault("any", "any");
+
+        factory.Invocations.Should().HaveCount(1);
+        store.Invocations.Should().HaveCount(1);
+
+        // 2. Call the settings again
+        _ = testSubject.GetValueOrDefault("any", true);
+        testSubject.SetValue("any", "any");
+
+        factory.Invocations.Should().HaveCount(1);
+        store.Invocations.Should().HaveCount(3);
+    }
+
+    [TestMethod]
+    public void JreLocation_DefaultValue_ShouldBeEmpty()
+    {
+        var store = new Mock<WritableSettingsStore>();
+
+        var testSubject = CreateTestSubject(store.Object);
+
+        testSubject.JreLocation.Should().BeEmpty();
+        store.Verify(x => x.GetString(SonarLintSettings.SettingsRoot, nameof(testSubject.JreLocation), string.Empty), Times.AtLeastOnce);
+    }
+
+    #region Boolean method tests
+
+    [TestMethod]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(true, true)]
+    [DataRow(false, false)]
+    public void GetValueOrDefault_Bool(bool valueToReturn, bool defaultValueSuppliedByCaller)
+    {
+        var store = new Mock<WritableSettingsStore>();
+        store.Setup(x => x.GetBoolean(SonarLintSettings.SettingsRoot, "aProp", defaultValueSuppliedByCaller)).Returns(valueToReturn);
+
+        var testSubject = CreateTestSubject(store.Object);
+
+        var actual = testSubject.GetValueOrDefault("aProp", defaultValueSuppliedByCaller);
+        actual.Should().Be(valueToReturn);
+    }
+
+    [TestMethod]
+    public void GetValueOrDefault_StoreThrows_ReturnsDefault_Bool()
+    {
+        var suppliedDefault = true;
+
+        var store = new Mock<WritableSettingsStore>();
+        store.Setup(x => x.GetBoolean(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Boolean>()))
+            .Throws(new ArgumentException("thrown in a test"));
+
+        var testSubject = CreateTestSubject(storeToReturn: store.Object);
+
+        var actual = testSubject.GetValueOrDefault("key1", suppliedDefault);
+        actual.Should().Be(suppliedDefault);
+    }
+
+    [TestMethod]
+    public void GetValueOrDefault_NoStore_Bool()
+    {
+        var expected = true;
+        var testSubject = CreateTestSubject(storeToReturn: null);
+
+        var actual = testSubject.GetValueOrDefault("key1", expected);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    [DataRow("a key", true)]
+    [DataRow("another key", false)]
+    public void SetValue_Bool(string propertyName, bool valueToSet)
+    {
+        var settingsStore = new Mock<WritableSettingsStore>();
+
+        var testSubject = CreateTestSubject(settingsStore.Object);
+
+        testSubject.SetValue(propertyName, valueToSet);
+
+        CheckPropertySet(settingsStore, propertyName, valueToSet);
+    }
+
+    [TestMethod]
+    public void SetValue_NoStore_Bool()
+    {
+        var testSubject = CreateTestSubject(storeToReturn: null);
+
+        // Act + Assert (no store -> no exception)
+        Action act = () => testSubject.SetValue("key1", false);
+
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region String method tests
+
+    [TestMethod]
+    [DataRow("val1", "unused default")]
+    [DataRow("xxx", "xxx")]
+    public void GetValueOrDefault_String(string valueToReturn, string defaultValueSuppliedByCaller)
+    {
+        var store = new Mock<WritableSettingsStore>();
+        store.Setup(x => x.GetString(SonarLintSettings.SettingsRoot, "aProp", defaultValueSuppliedByCaller)).Returns(valueToReturn);
+
+        var testSubject = CreateTestSubject(store.Object);
+
+        var actual = testSubject.GetValueOrDefault("aProp", defaultValueSuppliedByCaller);
+        actual.Should().Be(valueToReturn);
+    }
+
+    [TestMethod]
+    public void GetValueOrDefault_StoreThrows_ReturnsDefault_String()
+    {
+        var suppliedDefault = "the default";
+
+        var store = new Mock<WritableSettingsStore>();
+        store.Setup(x => x.GetString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new ArgumentException("thrown in a test"));
+
+        var testSubject = CreateTestSubject(storeToReturn: store.Object);
+
+        var actual = testSubject.GetValueOrDefault("key1", suppliedDefault);
+        actual.Should().Be(suppliedDefault);
+    }
+
+    [TestMethod]
+    public void GetValueOrDefault_NoStore_String()
+    {
+        string expected = "the value";
+        var testSubject = CreateTestSubject(storeToReturn: null);
+
+        var actual = testSubject.GetValueOrDefault("key1", expected);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    [DataRow("a key", "a value")]
+    [DataRow("another key", "another value")]
+    public void SetValue_String(string propertyName, string valueToSet)
+    {
+        var settingsStore = new Mock<WritableSettingsStore>();
+
+        var testSubject = CreateTestSubject(settingsStore.Object);
+
+        testSubject.SetValue(propertyName, valueToSet);
+
+        CheckPropertySet(settingsStore, propertyName, valueToSet);
+    }
+
+    [TestMethod]
+    public void SetValue_NoStore_String()
+    {
+        var testSubject = CreateTestSubject(storeToReturn: null);
+
+        // Act + Assert (no store -> no exception)
+        Action act = () => testSubject.SetValue("key1", "a value");
+
+        act.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void SetValue_Null_SetsEmptyString()
+    {
+        var settingsStore = new Mock<WritableSettingsStore>();
+        var testSubject = CreateTestSubject(settingsStore.Object);
+
+        testSubject.SetValue("key1", null);
+
+        settingsStore.Verify(x => x.SetString(SonarLintSettings.SettingsRoot, "key1", string.Empty), Times.Once);
+    }
+
+    #endregion
+
+    #region Int method tests
+
+    [TestMethod]
+    [DataRow(111, 222)]
+    [DataRow(333, 222)]
+    public void GetValueOrDefault_Int(int valueToReturn, int defaultValueSuppliedByCaller)
+    {
+        var store = new Mock<WritableSettingsStore>();
+        store.Setup(x => x.GetInt32(SonarLintSettings.SettingsRoot, "aProp", defaultValueSuppliedByCaller)).Returns(valueToReturn);
+
+        var testSubject = CreateTestSubject(store.Object);
+
+        var actual = testSubject.GetValueOrDefault("aProp", defaultValueSuppliedByCaller);
+        actual.Should().Be(valueToReturn);
+    }
+
+    [TestMethod]
+    public void GetValueOrDefault_StoreThrows_ReturnsDefault_Int()
+    {
+        var suppliedDefault = -123;
+
+        var store = new Mock<WritableSettingsStore>();
+        store.Setup(x => x.GetInt32(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+            .Throws(new ArgumentException("thrown in a test"));
+
+        var testSubject = CreateTestSubject(storeToReturn: store.Object);
+
+        var actual = testSubject.GetValueOrDefault("key1", suppliedDefault);
+        actual.Should().Be(suppliedDefault);
+    }
+
+    [TestMethod]
+    public void GetValueOrDefault_NoStore_Int()
+    {
+        int expected = 888;
+        var testSubject = CreateTestSubject(storeToReturn: null);
+
+        var actual = testSubject.GetValueOrDefault("key1", expected);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    [DataRow("a key", 123)]
+    [DataRow("another key", 456)]
+    public void SetValue_Int(string propertyName, int valueToSet)
+    {
+        var settingsStore = new Mock<WritableSettingsStore>();
+
+        var testSubject = CreateTestSubject(settingsStore.Object);
+
+        testSubject.SetValue(propertyName, valueToSet);
+
+        CheckPropertySet(settingsStore, propertyName, valueToSet);
+    }
+
+    [TestMethod]
+    public void SetValue_NoStore_Int()
+    {
+        var testSubject = CreateTestSubject(storeToReturn: null);
+
+        // Act + Assert (no store -> no exception)
+        Action act = () => testSubject.SetValue("key1", 123);
+
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    [TestMethod]
+    public void IsActivateMoreEnabled_WhenDisposed_ReturnsDefault()
+    {
+        var testSubject = CreateComDetachedTestSubject();
+
+        testSubject.IsActivateMoreEnabled = true;
+        var activateMoreEnabled = testSubject.IsActivateMoreEnabled;
+
+        activateMoreEnabled.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void DaemonLogLevel_WhenDisposed_ReturnsDefault()
+    {
+        var testSubject = CreateComDetachedTestSubject();
+
+        testSubject.DaemonLogLevel = DaemonLogLevel.Verbose;
+        var daemonLogLevel = testSubject.DaemonLogLevel;
+
+        daemonLogLevel.Should().Be(DaemonLogLevel.Minimal);
+    }
+
+    [TestMethod]
+    public void JreLocation_WhenDisposed_ReturnsDefault()
+    {
+        var testSubject = CreateComDetachedTestSubject();
+
+        testSubject.JreLocation = "/path/to/jre";
+        var jreLocation = testSubject.JreLocation;
+
+        jreLocation.Should().BeEmpty();
+    }
+
+    private static SonarLintSettings CreateComDetachedTestSubject()
+    {
+        var comException = new InvalidComObjectException("COM object that has been separated from its underlying RCW cannot be used.");
+        var writableSettingsStore = Substitute.For<WritableSettingsStore>();
+        writableSettingsStore.When(x => x.GetBoolean(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
+            .Do(x => throw comException);
+        writableSettingsStore.When(x => x.SetBoolean(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
+            .Do(x => throw comException);
+        writableSettingsStore.When(x => x.GetString(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()))
+            .Do(x => throw comException);
+        writableSettingsStore.When(x => x.SetString(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()))
+            .Do(x => throw comException);
+        writableSettingsStore.When(x => x.GetInt32(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()))
+            .Do(x => throw comException);
+        writableSettingsStore.When(x => x.SetInt32(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()))
+            .Do(x => throw comException);
+        var writableSettingsStoreFactory = Substitute.For<IWritableSettingsStoreFactory>();
+        writableSettingsStoreFactory.Create(SonarLintSettings.SettingsRoot).Returns(writableSettingsStore);
+        var testSubject = new SonarLintSettings(writableSettingsStoreFactory);
+        testSubject.Dispose();
+        return testSubject;
+    }
+
+    private static SonarLintSettings CreateTestSubject(IWritableSettingsStoreFactory storeFactory)
+        => new SonarLintSettings(storeFactory);
+
+    private static SonarLintSettings CreateTestSubject(WritableSettingsStore storeToReturn)
+        => CreateTestSubject(CreateStoreFactory(storeToReturn).Object);
+
+    private static Mock<IWritableSettingsStoreFactory> CreateStoreFactory(
+        WritableSettingsStore storeToReturn = null)
+    {
+        var factory = new Mock<IWritableSettingsStoreFactory>();
+        factory.Setup(x => x.Create(It.IsAny<string>())).Returns(storeToReturn);
+        return factory;
+    }
+
+    private static void CheckPropertySet(Mock<WritableSettingsStore> store, string propertyKey, bool value)
+        => store.Verify(x => x.SetBoolean(SonarLintSettings.SettingsRoot, propertyKey, value), Times.Once);
+
+    private static void CheckPropertySet(Mock<WritableSettingsStore> store, string propertyKey, int value)
+        => store.Verify(x => x.SetInt32(SonarLintSettings.SettingsRoot, propertyKey, value), Times.Once);
+
+    private static void CheckPropertySet(Mock<WritableSettingsStore> store, string propertyKey, string value)
+        => store.Verify(x => x.SetString(SonarLintSettings.SettingsRoot, propertyKey, value), Times.Once);
 }

--- a/src/Integration.Vsix/Settings/SonarLintSettings.cs
+++ b/src/Integration.Vsix/Settings/SonarLintSettings.cs
@@ -20,99 +20,91 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Settings;
-using SonarLint.VisualStudio.Integration.Vsix.Settings;
 
-namespace SonarLint.VisualStudio.Integration.Vsix
+namespace SonarLint.VisualStudio.Integration.Vsix.Settings;
+
+[Export(typeof(ISonarLintSettings))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+internal sealed class SonarLintSettings : ISonarLintSettings, IDisposable
 {
-    [Export(typeof(ISonarLintSettings))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
-    internal sealed class SonarLintSettings : ISonarLintSettings, IDisposable
+    public const string SettingsRoot = "SonarLintForVisualStudio";
+
+    // Lazily create the settings store on first use (we can't create it in the constructor)
+    private readonly Lazy<WritableSettingsStore> writableSettingsStore;
+
+    private bool disposed;
+
+    [ImportingConstructor]
+    public SonarLintSettings(IWritableSettingsStoreFactory storeFactory)
     {
-        public const string SettingsRoot = "SonarLintForVisualStudio";
-
-        // Lazily create the settings store on first use (we can't create it in the constructor)
-        private readonly Lazy<WritableSettingsStore> writableSettingsStore;
-
-        private bool disposed;
-
-        [ImportingConstructor]
-        public SonarLintSettings(IWritableSettingsStoreFactory storeFactory)
-        {
-            // Called from MEF constructor -> must be free-threaded
-            writableSettingsStore = new Lazy<WritableSettingsStore>(() => storeFactory.Create(SettingsRoot), LazyThreadSafetyMode.PublicationOnly);
-        }
-
-        internal /* testing purposes */ bool GetValueOrDefault(string key, bool defaultValue)
-        {
-            try
-            {
-                return GetWritableSettingsStore()?.GetBoolean(SettingsRoot, key, defaultValue)
-                ?? defaultValue;
-            }
-            catch (ArgumentException)
-            {
-                return defaultValue;
-            }
-        }
-
-        internal /* testing purposes */ void SetValue(string key, bool value)
-        {
-            GetWritableSettingsStore()?.SetBoolean(SettingsRoot, key, value);
-        }
-
-        internal /* testing purposes */ string GetValueOrDefault(string key, string defaultValue)
-        {
-            try
-            {
-                return GetWritableSettingsStore()?.GetString(SettingsRoot, key, defaultValue)
-                ?? defaultValue;
-            }
-            catch (ArgumentException)
-            {
-                return defaultValue;
-            }
-        }
-
-        internal /* testing purposes */ void SetValue(string key, string value)
-        {
-            GetWritableSettingsStore()?.SetString(SettingsRoot, key, value ?? string.Empty);
-        }
-
-        internal /* testing purposes */ int GetValueOrDefault(string key, int defaultValue)
-        {
-            try
-            {
-                return GetWritableSettingsStore()?.GetInt32(SettingsRoot, key, defaultValue)
-                    ?? defaultValue;
-            }
-            catch (ArgumentException)
-            {
-                return defaultValue;
-            }
-        }
-
-        internal /* testing purposes */ void SetValue(string key, int value) => GetWritableSettingsStore()?.SetInt32(SettingsRoot, key, value);
-
-        public bool IsActivateMoreEnabled
-        {
-            get { return this.GetValueOrDefault(nameof(IsActivateMoreEnabled), false); }
-            set { this.SetValue(nameof(IsActivateMoreEnabled), value); }
-        }
-
-        public DaemonLogLevel DaemonLogLevel
-        {
-            get { return (DaemonLogLevel)this.GetValueOrDefault(nameof(DaemonLogLevel), (int)DaemonLogLevel.Minimal); }
-            set { this.SetValue(nameof(DaemonLogLevel), (int)value); }
-        }
-
-        public string JreLocation
-        {
-            get => this.GetValueOrDefault(nameof(JreLocation), string.Empty);
-            set => this.SetValue(nameof(JreLocation), value);
-        }
-
-        public void Dispose() => disposed = true;
-
-        private WritableSettingsStore GetWritableSettingsStore() => disposed ? null : writableSettingsStore.Value;
+        // Called from MEF constructor -> must be free-threaded
+        writableSettingsStore = new Lazy<WritableSettingsStore>(() => storeFactory.Create(SettingsRoot), LazyThreadSafetyMode.PublicationOnly);
     }
+
+    public bool IsActivateMoreEnabled
+    {
+        get => GetValueOrDefault(nameof(IsActivateMoreEnabled), false);
+        set => SetValue(nameof(IsActivateMoreEnabled), value);
+    }
+
+    public DaemonLogLevel DaemonLogLevel
+    {
+        get => (DaemonLogLevel) GetValueOrDefault(nameof(DaemonLogLevel), (int) DaemonLogLevel.Minimal);
+        set => SetValue(nameof(DaemonLogLevel), (int) value);
+    }
+
+    public string JreLocation
+    {
+        get => GetValueOrDefault(nameof(JreLocation), string.Empty);
+        set => SetValue(nameof(JreLocation), value);
+    }
+
+    public void Dispose() => disposed = true;
+
+    internal bool GetValueOrDefault(string key, bool defaultValue)
+    {
+        try
+        {
+            return GetWritableSettingsStore()?.GetBoolean(SettingsRoot, key, defaultValue)
+                   ?? defaultValue;
+        }
+        catch (ArgumentException)
+        {
+            return defaultValue;
+        }
+    }
+
+    internal string GetValueOrDefault(string key, string defaultValue)
+    {
+        try
+        {
+            return GetWritableSettingsStore()?.GetString(SettingsRoot, key, defaultValue)
+                   ?? defaultValue;
+        }
+        catch (ArgumentException)
+        {
+            return defaultValue;
+        }
+    }
+
+    internal int GetValueOrDefault(string key, int defaultValue)
+    {
+        try
+        {
+            return GetWritableSettingsStore()?.GetInt32(SettingsRoot, key, defaultValue)
+                   ?? defaultValue;
+        }
+        catch (ArgumentException)
+        {
+            return defaultValue;
+        }
+    }
+
+    internal void SetValue(string key, bool value) => GetWritableSettingsStore()?.SetBoolean(SettingsRoot, key, value);
+
+    internal void SetValue(string key, string value) => GetWritableSettingsStore()?.SetString(SettingsRoot, key, value ?? string.Empty);
+
+    internal void SetValue(string key, int value) => GetWritableSettingsStore()?.SetInt32(SettingsRoot, key, value);
+
+    private WritableSettingsStore GetWritableSettingsStore() => disposed ? null : writableSettingsStore.Value;
 }


### PR DESCRIPTION
When exiting Visual Studio we often get an Exception because SLCore is sending log messages for shutdown, but the log level settings have already been disposed and the COM object has been detached from VS.