### PR TITLE
SLVS-1629 Prevent SSESessionManager creating session for SonarCloud

### DIFF
--- a/src/ConnectedMode/ServerSentEvents/SSESessionManager.cs
+++ b/src/ConnectedMode/ServerSentEvents/SSESessionManager.cs
@@ -18,9 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
@@ -43,7 +41,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
         private bool disposed;
 
         [ImportingConstructor]
-        public SSESessionManager(IActiveSolutionBoundTracker activeSolutionBoundTracker, 
+        public SSESessionManager(IActiveSolutionBoundTracker activeSolutionBoundTracker,
             ISSESessionFactory sseSessionFactory,
             ILogger logger)
         {
@@ -83,12 +81,18 @@ namespace SonarLint.VisualStudio.ConnectedMode.ServerSentEvents
             lock (syncRoot)
             {
                 EndCurrentSession();
-                
+
                 var isInConnectedMode = !bindingConfiguration.Equals(BindingConfiguration.Standalone);
 
                 if (!isInConnectedMode)
                 {
                     logger.LogVerbose("[SSESessionManager] Not in connected mode");
+                    return;
+                }
+
+                if (bindingConfiguration.Project.ServerConnection is ServerConnection.SonarCloud)
+                {
+                    logger.LogVerbose("[SSESessionManager] Not available for the current server connection");
                     return;
                 }
 


### PR DESCRIPTION
[SLVS-1629](https://sonarsource.atlassian.net/browse/SLVS-1629)

SSESessionManager does not support SonarCloud connections and currently throws an Exception when project is connected to SonarCloud.

[SLVS-1629]: https://sonarsource.atlassian.net/browse/SLVS-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ