### PR TITLE
SLVS-1625 CaYC: Replace Moq with Nsubstitute

### DIFF
--- a/SonarLint.VisualStudio.Integration.sln.DotSettings
+++ b/SonarLint.VisualStudio.Integration.sln.DotSettings
@@ -132,4 +132,9 @@
 	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=Async/@EntryIndexedValue">False</s:String>
 	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=Mutable/@EntryIndexedValue">False</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNotificationDisabled/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Dpa/IsNoEtwHostNotificationEnabled/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Dpa/IsNoEtwHostNotificationEnabled/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/ConnectedMode.UnitTests/UI/ProgressReporterViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ProgressReporterViewModelTests.cs
@@ -27,8 +27,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI;
 [TestClass]
 public class ProgressReporterViewModelTests
 {
-    private ProgressReporterViewModel testSubject;
     private ILogger logger;
+    private ProgressReporterViewModel testSubject;
 
     [TestInitialize]
     public void TestInitialize()

--- a/src/Education.UnitTests/EducationTests.cs
+++ b/src/Education.UnitTests/EducationTests.cs
@@ -19,163 +19,140 @@
  */
 
 using System.Windows.Documents;
-using Moq;
 using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Core.Suppressions;
 using SonarLint.VisualStudio.Education.Rule;
 using SonarLint.VisualStudio.Education.XamlGenerator;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests
+namespace SonarLint.VisualStudio.Education.UnitTests;
+
+[TestClass]
+public class EducationTests
 {
-    [TestClass]
-    public class EducationTests
+    private readonly SonarCompositeRuleId knownRule = new("repoKey", "ruleKey");
+    private readonly SonarCompositeRuleId unknownRule = new("known", "xxx");
+
+    private ILogger logger;
+    private IRuleHelpToolWindow ruleDescriptionToolWindow;
+    private IRuleHelpXamlBuilder ruleHelpXamlBuilder;
+    private IRuleInfo ruleInfo;
+    private IRuleMetaDataProvider ruleMetadataProvider;
+    private IShowRuleInBrowser showRuleInBrowser;
+    private Education testSubject;
+    private IThreadHandling threadHandling;
+    private IToolWindowService toolWindowService;
+
+    [TestInitialize]
+    public void TestInitialize()
     {
-        [TestMethod]
-        public void MefCtor_CheckIsExported()
-        {
-            MefTestHelpers.CheckTypeCanBeImported<Education, IEducation>(
-                MefTestHelpers.CreateExport<IToolWindowService>(),
-                MefTestHelpers.CreateExport<IRuleMetaDataProvider>(),
-                MefTestHelpers.CreateExport<IShowRuleInBrowser>(),
-                MefTestHelpers.CreateExport<IRuleHelpXamlBuilder>(),
-                MefTestHelpers.CreateExport<ILogger>());
-        }
+        toolWindowService = Substitute.For<IToolWindowService>();
+        ruleMetadataProvider = Substitute.For<IRuleMetaDataProvider>();
+        showRuleInBrowser = Substitute.For<IShowRuleInBrowser>();
+        ruleHelpXamlBuilder = Substitute.For<IRuleHelpXamlBuilder>();
+        ruleDescriptionToolWindow = Substitute.For<IRuleHelpToolWindow>();
+        ruleInfo = Substitute.For<IRuleInfo>();
+        logger = new TestLogger(true);
+        threadHandling = new NoOpThreadHandler();
+        GetRuleInfoAsync(ruleInfo);
 
-        [TestMethod]
-        public void ShowRuleHelp_KnownRule_DocumentIsDisplayedInToolWindow()
-        {
-            var ruleMetaDataProvider = new Mock<IRuleMetaDataProvider>();
-            var ruleId = new SonarCompositeRuleId("repoKey", "ruleKey");
+        testSubject = new Education(toolWindowService, ruleMetadataProvider, showRuleInBrowser, logger, ruleHelpXamlBuilder, threadHandling);
+    }
 
-            var ruleInfo = Mock.Of<IRuleInfo>();
-            ruleMetaDataProvider.Setup(x => x.GetRuleInfoAsync(It.IsAny<SonarCompositeRuleId>(), It.IsAny<Guid?>())).ReturnsAsync(ruleInfo);
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<Education, IEducation>(
+            MefTestHelpers.CreateExport<IToolWindowService>(),
+            MefTestHelpers.CreateExport<IRuleMetaDataProvider>(),
+            MefTestHelpers.CreateExport<IShowRuleInBrowser>(),
+            MefTestHelpers.CreateExport<IRuleHelpXamlBuilder>(),
+            MefTestHelpers.CreateExport<ILogger>());
 
-            var flowDocument = Mock.Of<FlowDocument>();
-            var ruleHelpXamlBuilder = new Mock<IRuleHelpXamlBuilder>();
-            ruleHelpXamlBuilder.Setup(x => x.Create(ruleInfo, /* todo by SLVS-1630 */ null)).Returns(flowDocument);
+    [TestMethod]
+    public void ShowRuleHelp_KnownRule_DocumentIsDisplayedInToolWindow()
+    {
+        var flowDocument = MockFlowDocument();
+        toolWindowService.GetToolWindow<RuleHelpToolWindow, IRuleHelpToolWindow>().Returns(ruleDescriptionToolWindow);
+        // Sanity check - tool window not yet fetched
+        toolWindowService.ReceivedCalls().Should().HaveCount(0);
 
-            var ruleDescriptionToolWindow = new Mock<IRuleHelpToolWindow>();
+        // Act
+        testSubject.ShowRuleHelp(knownRule, null, null);
 
-            var toolWindowService = new Mock<IToolWindowService>();
-            toolWindowService.Setup(x => x.GetToolWindow<RuleHelpToolWindow, IRuleHelpToolWindow>()).Returns(ruleDescriptionToolWindow.Object);
+        VerifyGetsRuleInfoForCorrectRuleId(knownRule);
+        VerifyRuleIsDisplayedInIde(flowDocument);
+        VerifyRuleNotShownInBrowser();
+    }
 
-            var showRuleInBrowser = new Mock<IShowRuleInBrowser>();
-            var testSubject = CreateEducation(toolWindowService.Object,
-                ruleMetaDataProvider.Object,
-                showRuleInBrowser.Object,
-                ruleHelpXamlBuilder.Object);
+    [TestMethod]
+    public void ShowRuleHelp_FailedToDisplayRule_RuleIsShownInBrowser()
+    {
+        ruleHelpXamlBuilder.When(x => x.Create(ruleInfo, /* todo by SLVS-1630 */ null)).Do(x => throw new Exception("some layout error"));
+        toolWindowService.ClearReceivedCalls(); // Called in the constructor, so need to reset to clear the list of invocations
 
-            // Sanity check - tool window not yet fetched
-            toolWindowService.Invocations.Should().HaveCount(0);
+        testSubject.ShowRuleHelp(knownRule, null, /* todo by SLVS-1630 */ null);
 
-            // Act
-            testSubject.ShowRuleHelp(ruleId, null, null);
+        VerifyGetsRuleInfoForCorrectRuleId(knownRule);
+        VerifyRuleShownInBrowser(knownRule);
+        VerifyAttemptsToBuildRuleButFails();
+    }
 
-            ruleMetaDataProvider.Verify(x => x.GetRuleInfoAsync(ruleId, It.IsAny<Guid?>()), Times.Once);
-            ruleHelpXamlBuilder.Verify(x => x.Create(ruleInfo, /* todo by SLVS-1630 */ null), Times.Once);
-            ruleDescriptionToolWindow.Verify(x => x.UpdateContent(flowDocument), Times.Once);
-            toolWindowService.Verify(x => x.Show(RuleHelpToolWindow.ToolWindowId), Times.Once);
+    [TestMethod]
+    public void ShowRuleHelp_UnknownRule_RuleIsShownInBrowser()
+    {
+        GetRuleInfoAsync(null);
+        toolWindowService.ClearReceivedCalls(); // Called in the constructor, so need to reset to clear the list of invocations
 
-            showRuleInBrowser.Invocations.Should().HaveCount(0);
-        }
+        testSubject.ShowRuleHelp(unknownRule, null, /* todo by SLVS-1630 */ null);
 
-        [TestMethod]
-        public void ShowRuleHelp_FailedToDisplayRule_RuleIsShownInBrowser()
-        {
-            var toolWindowService = new Mock<IToolWindowService>();
-            var ruleMetadataProvider = new Mock<IRuleMetaDataProvider>();
-            var ruleHelpXamlBuilder = new Mock<IRuleHelpXamlBuilder>();
-            var showRuleInBrowser = new Mock<IShowRuleInBrowser>();
+        VerifyGetsRuleInfoForCorrectRuleId(unknownRule);
+        VerifyRuleShownInBrowser(unknownRule);
+        VerifyNotAttemptsBuildRule();
+    }
 
-            var ruleId = new SonarCompositeRuleId("repoKey", "ruleKey");
+    [TestMethod]
+    public void ShowRuleHelp_FilterableIssueProvided_CallsGetRuleInfoForIssue()
+    {
+        var issueId = Guid.NewGuid();
+        GetRuleInfoAsync(null);
 
-            var ruleInfo = Mock.Of<IRuleInfo>();
-            ruleMetadataProvider.Setup(x => x.GetRuleInfoAsync(It.IsAny<SonarCompositeRuleId>(), It.IsAny<Guid?>())).ReturnsAsync(ruleInfo);
+        testSubject.ShowRuleHelp(knownRule, issueId, null);
 
-            ruleHelpXamlBuilder.Setup(x => x.Create(ruleInfo, /* todo by SLVS-1630 */ null)).Throws(new Exception("some layout error"));
+        ruleMetadataProvider.Received(1).GetRuleInfoAsync(knownRule, issueId);
+    }
 
-            var testSubject = CreateEducation(
-                toolWindowService.Object,
-                ruleMetadataProvider.Object,
-                showRuleInBrowser.Object,
-                ruleHelpXamlBuilder.Object);
+    private void GetRuleInfoAsync(IRuleInfo returnedRuleInfo) => ruleMetadataProvider.GetRuleInfoAsync(Arg.Any<SonarCompositeRuleId>(), Arg.Any<Guid?>()).Returns(returnedRuleInfo);
 
-            toolWindowService.Reset(); // Called in the constructor, so need to reset to clear the list of invocations
+    private void VerifyGetsRuleInfoForCorrectRuleId(SonarCompositeRuleId ruleId) => ruleMetadataProvider.Received(1).GetRuleInfoAsync(ruleId, Arg.Any<Guid?>());
 
-            testSubject.ShowRuleHelp(ruleId, null, /* todo by SLVS-1630 */null);
+    private void VerifyRuleShownInBrowser(SonarCompositeRuleId ruleId) => showRuleInBrowser.Received(1).ShowRuleDescription(ruleId);
 
-            ruleMetadataProvider.Verify(x => x.GetRuleInfoAsync(ruleId, It.IsAny<Guid?>()), Times.Once);
-            showRuleInBrowser.Verify(x => x.ShowRuleDescription(ruleId), Times.Once);
+    private void VerifyRuleNotShownInBrowser() => showRuleInBrowser.ReceivedCalls().Should().HaveCount(0);
 
-            // should have attempted to build the rule, but failed
-            ruleHelpXamlBuilder.Invocations.Should().HaveCount(1);
-            toolWindowService.Invocations.Should().HaveCount(1);
-        }
+    private void VerifyToolWindowShown() => toolWindowService.Received(1).Show(RuleHelpToolWindow.ToolWindowId);
 
-        [TestMethod]
-        public void ShowRuleHelp_UnknownRule_RuleIsShownInBrowser()
-        {
-            var toolWindowService = new Mock<IToolWindowService>();
-            var ruleMetadataProvider = new Mock<IRuleMetaDataProvider>();
-            var ruleHelpXamlBuilder = new Mock<IRuleHelpXamlBuilder>();
-            var showRuleInBrowser = new Mock<IShowRuleInBrowser>();
+    private void VerifyAttemptsToBuildRuleButFails()
+    {
+        ruleHelpXamlBuilder.ReceivedCalls().Should().HaveCount(1);
+        toolWindowService.ReceivedCalls().Should().HaveCount(1);
+    }
 
-            var unknownRule = new SonarCompositeRuleId("known", "xxx");
-            ruleMetadataProvider.Setup(x => x.GetRuleInfoAsync(unknownRule, It.IsAny<Guid?>())).ReturnsAsync((IRuleInfo)null);
+    private void VerifyNotAttemptsBuildRule()
+    {
+        ruleHelpXamlBuilder.ReceivedCalls().Should().HaveCount(0);
+        toolWindowService.ReceivedCalls().Should().HaveCount(0);
+    }
 
-            var testSubject = CreateEducation(
-                toolWindowService.Object,
-                ruleMetadataProvider.Object,
-                showRuleInBrowser.Object,
-                ruleHelpXamlBuilder.Object);
+    private void VerifyRuleIsDisplayedInIde(FlowDocument flowDocument)
+    {
+        ruleHelpXamlBuilder.Received(1).Create(ruleInfo, /* todo by SLVS-1630 */ null);
+        ruleDescriptionToolWindow.Received(1).UpdateContent(flowDocument);
+        VerifyToolWindowShown();
+    }
 
-            toolWindowService.Reset(); // Called in the constructor, so need to reset to clear the list of invocations
-
-            testSubject.ShowRuleHelp(unknownRule, null, /* todo by SLVS-1630 */ null);
-
-            ruleMetadataProvider.Verify(x => x.GetRuleInfoAsync(unknownRule, It.IsAny<Guid?>()), Times.Once);
-            showRuleInBrowser.Verify(x => x.ShowRuleDescription(unknownRule), Times.Once);
-
-            // Should not have attempted to build the rule
-            ruleHelpXamlBuilder.Invocations.Should().HaveCount(0);
-            toolWindowService.Invocations.Should().HaveCount(0);
-        }
-
-        [TestMethod]
-        public void ShowRuleHelp_FilterableIssueProvided_CallsGetRuleInfoForIssue()
-        {
-            var toolWindowService = new Mock<IToolWindowService>();
-            var ruleMetadataProvider = new Mock<IRuleMetaDataProvider>();
-            var ruleHelpXamlBuilder = new Mock<IRuleHelpXamlBuilder>();
-            var showRuleInBrowser = new Mock<IShowRuleInBrowser>();
-            var issueId = Guid.NewGuid();
-            var ruleId = new SonarCompositeRuleId("repoKey", "ruleKey");
-            ruleMetadataProvider.Setup(x => x.GetRuleInfoAsync(ruleId, issueId)).ReturnsAsync((IRuleInfo)null);
-            var testSubject = CreateEducation(
-                toolWindowService.Object,
-                ruleMetadataProvider.Object,
-                showRuleInBrowser.Object,
-                ruleHelpXamlBuilder.Object);
-
-            testSubject.ShowRuleHelp(ruleId,issueId, null);
-
-            ruleMetadataProvider.Verify(x => x.GetRuleInfoAsync(ruleId, issueId), Times.Once);
-        }
-
-        private Education CreateEducation(IToolWindowService toolWindowService = null,
-            IRuleMetaDataProvider ruleMetadataProvider = null,
-            IShowRuleInBrowser showRuleInBrowser = null,
-            IRuleHelpXamlBuilder ruleHelpXamlBuilder = null)
-        {
-            toolWindowService ??= Mock.Of<IToolWindowService>();
-            ruleMetadataProvider ??= Mock.Of<IRuleMetaDataProvider>();
-            showRuleInBrowser ??= Mock.Of<IShowRuleInBrowser>();
-            ruleHelpXamlBuilder ??= Mock.Of<IRuleHelpXamlBuilder>();
-            var logger = new TestLogger(logToConsole: true);
-            var threadHandling = new NoOpThreadHandler();
-
-            return new Education(toolWindowService, ruleMetadataProvider, showRuleInBrowser, logger, ruleHelpXamlBuilder, threadHandling);
-        }
+    private FlowDocument MockFlowDocument()
+    {
+        var flowDocument = Substitute.For<FlowDocument>();
+        ruleHelpXamlBuilder.Create(ruleInfo, /* todo by SLVS-1630 */ null).Returns(flowDocument);
+        return flowDocument;
     }
 }

--- a/src/Education.UnitTests/ErrorList/SonarErrorListEventProcessorProviderTests.cs
+++ b/src/Education.UnitTests/ErrorList/SonarErrorListEventProcessorProviderTests.cs
@@ -18,37 +18,31 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using FluentAssertions;
 using Microsoft.VisualStudio.Shell.TableControl;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using SonarLint.VisualStudio.Core;
-using SonarLint.VisualStudio.Education.SonarLint.VisualStudio.Education.ErrorList;
+using SonarLint.VisualStudio.Education.ErrorList;
 using SonarLint.VisualStudio.Infrastructure.VS;
 using SonarLint.VisualStudio.TestInfrastructure;
 
-namespace SonarLint.VisualStudio.Education.UnitTests.ErrorList
+namespace SonarLint.VisualStudio.Education.UnitTests.ErrorList;
+
+[TestClass]
+public class SonarErrorListEventProcessorProviderTests
 {
-    [TestClass]
-    public class SonarErrorListEventProcessorProviderTests
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<SonarErrorListEventProcessorProvider, ITableControlEventProcessorProvider>(
+            MefTestHelpers.CreateExport<IEducation>(),
+            MefTestHelpers.CreateExport<IErrorListHelper>(),
+            MefTestHelpers.CreateExport<ILogger>());
+
+    [TestMethod]
+    public void Get_CreatesAndReturnsProcessor()
     {
-        [TestMethod]
-        public void MefCtor_CheckIsExported()
-        {
-            MefTestHelpers.CheckTypeCanBeImported<SonarErrorListEventProcessorProvider, ITableControlEventProcessorProvider>(
-                MefTestHelpers.CreateExport<IEducation>(),
-                MefTestHelpers.CreateExport<IErrorListHelper>(),
-                MefTestHelpers.CreateExport<ILogger>());
-        }
+        var testSubject = new SonarErrorListEventProcessorProvider(Substitute.For<IEducation>(), Substitute.For<IErrorListHelper>(), Substitute.For<ILogger>());
 
-        [TestMethod]
-        public void Get_CreatesAndReturnsProcessor()
-        {
-            var testSubject = new SonarErrorListEventProcessorProvider(Mock.Of<IEducation>(), Mock.Of<IErrorListHelper>(), Mock.Of<ILogger>());
+        var actual = testSubject.GetAssociatedEventProcessor(Substitute.For<IWpfTableControl>());
 
-            var actual = testSubject.GetAssociatedEventProcessor(Mock.Of<IWpfTableControl>());
-
-            actual.Should().NotBeNull();
-        }
+        actual.Should().NotBeNull();
     }
 }

--- a/src/Education.UnitTests/ErrorList/SonarErrorListEventProcessorTests.cs
+++ b/src/Education.UnitTests/ErrorList/SonarErrorListEventProcessorTests.cs
@@ -46,7 +46,7 @@ public class SonarErrorListEventProcessorTests
         errorListHelper = Substitute.For<IErrorListHelper>();
         handle = Substitute.For<ITableEntryHandle>();
         filterableIssue = Substitute.For<IFilterableIssue>();
-        logger = new TestLogger(true);
+        logger = new TestLogger();
 
         testSubject = new SonarErrorListEventProcessor(education, errorListHelper, logger);
     }

--- a/src/Education.UnitTests/Rule/SLCoreRuleMetaDataProviderTests.cs
+++ b/src/Education.UnitTests/Rule/SLCoreRuleMetaDataProviderTests.cs
@@ -128,7 +128,7 @@ public class SLCoreRuleMetaDataProviderTests
 
         ruleInfo.Should().NotBeNull();
         logger.AssertNoOutputMessages();
-        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
     }
 
     [TestMethod]
@@ -147,8 +147,8 @@ public class SLCoreRuleMetaDataProviderTests
     {
         await testSubject.GetRuleInfoAsync(compositeRuleId, null);
 
-        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
-        await VerifyIssueDetailsWasNotCalled();
+        VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        VerifyIssueDetailsWasNotCalled();
     }
 
     [TestMethod]
@@ -158,8 +158,8 @@ public class SLCoreRuleMetaDataProviderTests
 
         await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
-        await VerifyRuleDetailsWasNotCalled();
-        await VerifyGetIssueDetailsWasCalled(issueId);
+        VerifyRuleDetailsWasNotCalled();
+        VerifyGetIssueDetailsWasCalled(issueId);
     }
 
     [TestMethod]
@@ -169,8 +169,8 @@ public class SLCoreRuleMetaDataProviderTests
 
         await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
-        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
-        await VerifyGetIssueDetailsWasCalled(issueId);
+        VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        VerifyGetIssueDetailsWasCalled(issueId);
     }
 
     [TestMethod]
@@ -182,8 +182,8 @@ public class SLCoreRuleMetaDataProviderTests
         var result = await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
         result.Should().BeNull();
-        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
-        await VerifyGetIssueDetailsWasCalled(issueId);
+        VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        VerifyGetIssueDetailsWasCalled(issueId);
     }
 
     private void SetUpConfigScopeTracker(ConfigurationScope scope) => configScopeTrackerMock.Current.Returns(scope);
@@ -224,12 +224,11 @@ public class SLCoreRuleMetaDataProviderTests
 
     private void MockRuleInfoConverter() => ruleInfoConverter.Convert(Arg.Any<IRuleDetails>()).Returns(defaultRuleInfo);
 
-    private async Task VerifyGetIssueDetailsWasCalled(Guid id) => await issueServiceMock.Received(1).GetEffectiveIssueDetailsAsync(Arg.Is<GetEffectiveIssueDetailsParams>(x => x.issueId == id));
+    private void VerifyGetIssueDetailsWasCalled(Guid id) => issueServiceMock.Received(1).GetEffectiveIssueDetailsAsync(Arg.Is<GetEffectiveIssueDetailsParams>(x => x.issueId == id));
 
-    private async Task VerifyGetRuleDetailsWasCalled(string ruleKey) =>
-        await rulesServiceMock.Received(1).GetEffectiveRuleDetailsAsync(Arg.Is<GetEffectiveRuleDetailsParams>(x => x.ruleKey == ruleKey));
+    private void VerifyGetRuleDetailsWasCalled(string ruleKey) => rulesServiceMock.Received(1).GetEffectiveRuleDetailsAsync(Arg.Is<GetEffectiveRuleDetailsParams>(x => x.ruleKey == ruleKey));
 
-    private async Task VerifyIssueDetailsWasNotCalled() => await issueServiceMock.DidNotReceive().GetEffectiveIssueDetailsAsync(Arg.Any<GetEffectiveIssueDetailsParams>());
+    private void VerifyIssueDetailsWasNotCalled() => issueServiceMock.DidNotReceive().GetEffectiveIssueDetailsAsync(Arg.Any<GetEffectiveIssueDetailsParams>());
 
-    private async Task VerifyRuleDetailsWasNotCalled() => await rulesServiceMock.DidNotReceive().GetEffectiveRuleDetailsAsync(Arg.Any<GetEffectiveRuleDetailsParams>());
+    private void VerifyRuleDetailsWasNotCalled() => rulesServiceMock.DidNotReceive().GetEffectiveRuleDetailsAsync(Arg.Any<GetEffectiveRuleDetailsParams>());
 }

--- a/src/Education.UnitTests/Rule/SLCoreRuleMetaDataProviderTests.cs
+++ b/src/Education.UnitTests/Rule/SLCoreRuleMetaDataProviderTests.cs
@@ -18,24 +18,50 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Moq;
+using NSubstitute.ExceptionExtensions;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Education.Rule;
 using SonarLint.VisualStudio.SLCore.Core;
-using SonarLint.VisualStudio.SLCore.Protocol;
+using SonarLint.VisualStudio.SLCore.Service.Issue;
+using SonarLint.VisualStudio.SLCore.Service.Issue.Models;
 using SonarLint.VisualStudio.SLCore.Service.Rules;
 using SonarLint.VisualStudio.SLCore.Service.Rules.Models;
 using SonarLint.VisualStudio.SLCore.State;
 using SonarLint.VisualStudio.TestInfrastructure;
-using SonarLint.VisualStudio.SLCore.Service.Issue;
-using SonarLint.VisualStudio.SLCore.Service.Issue.Models;
 
 namespace SonarLint.VisualStudio.Education.UnitTests.Rule;
 
 [TestClass]
 public class SLCoreRuleMetaDataProviderTests
 {
-    private static readonly SonarCompositeRuleId CompositeRuleId = new("rule", "key1");
+    private readonly SonarCompositeRuleId compositeRuleId = new("rule", "key1");
+    private readonly ConfigurationScope configurationScope = new("id");
+    private readonly RuleInfo defaultRuleInfo = new(default, default, default, default, default, default, default, default);
+    private readonly EffectiveIssueDetailsDto effectiveIssueDetailsDto = new(default, default, default, default, default, default, default, default);
+    private readonly string errorMessage = "my message";
+    private readonly Guid issueId = Guid.NewGuid();
+
+    private IActiveConfigScopeTracker configScopeTrackerMock;
+    private IIssueSLCoreService issueServiceMock;
+    private TestLogger logger;
+    private IRuleInfoConverter ruleInfoConverter;
+    private IRulesSLCoreService rulesServiceMock;
+    private ISLCoreServiceProvider serviceProviderMock;
+    private SLCoreRuleMetaDataProvider testSubject;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        serviceProviderMock = Substitute.For<ISLCoreServiceProvider>();
+        configScopeTrackerMock = Substitute.For<IActiveConfigScopeTracker>();
+        issueServiceMock = Substitute.For<IIssueSLCoreService>();
+        rulesServiceMock = Substitute.For<IRulesSLCoreService>();
+        ruleInfoConverter = Substitute.For<IRuleInfoConverter>();
+        logger = new TestLogger();
+
+        testSubject = new SLCoreRuleMetaDataProvider(serviceProviderMock, configScopeTrackerMock, ruleInfoConverter, logger);
+        MockupServices();
+    }
 
     [TestMethod]
     public void MefCtor_CheckIsExported() =>
@@ -51,12 +77,9 @@ public class SLCoreRuleMetaDataProviderTests
     [TestMethod]
     public async Task GetRuleInfoAsync_NoActiveScope_ReturnsNull()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out var logger);
-        SetUpServiceProvider(serviceProviderMock, out _);
-        SetUpConfigScopeTracker(configScopeTrackerMock, null);
+        SetUpConfigScopeTracker(null);
 
-        var ruleInfo = await testSubject.GetRuleInfoAsync(CompositeRuleId);
+        var ruleInfo = await testSubject.GetRuleInfoAsync(compositeRuleId);
 
         ruleInfo.Should().BeNull();
         logger.AssertNoOutputMessages();
@@ -65,10 +88,9 @@ public class SLCoreRuleMetaDataProviderTests
     [TestMethod]
     public async Task GetRuleInfoAsync_ServiceUnavailable_ReturnsNull()
     {
-        var testSubject = CreateTestSubject(out _, out var configScopeTrackerMock, out var logger);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("id"));
+        SetUpRuleServiceProvider(false);
 
-        var ruleInfo = await testSubject.GetRuleInfoAsync(CompositeRuleId);
+        var ruleInfo = await testSubject.GetRuleInfoAsync(compositeRuleId);
 
         ruleInfo.Should().BeNull();
         logger.AssertNoOutputMessages();
@@ -77,209 +99,137 @@ public class SLCoreRuleMetaDataProviderTests
     [TestMethod]
     public void GetRuleInfoAsync_ServiceThrows_ReturnsNullAndLogs()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out var logger);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("id"));
-        SetUpServiceProvider(serviceProviderMock, out var rulesServiceMock);
-        rulesServiceMock
-            .Setup(x => x.GetEffectiveRuleDetailsAsync(It.IsAny<GetEffectiveRuleDetailsParams>()))
-            .ThrowsAsync(new Exception("my message"));
+        MockGetEffectiveRuleDetailsAsyncThrows();
 
-        var act = () => testSubject.GetRuleInfoAsync(CompositeRuleId);
+        var act = () => testSubject.GetRuleInfoAsync(compositeRuleId);
 
         act.Should().NotThrow();
-        logger.AssertPartialOutputStringExists("my message");
+        logger.AssertPartialOutputStringExists(errorMessage);
     }
 
     [TestMethod]
     public async Task GetRuleInfoAsync_ForIssue_NoActiveScope_ReturnsNull()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out var logger);
-        SetUpIssueServiceProvider(serviceProviderMock, out _);
-        SetUpConfigScopeTracker(configScopeTrackerMock, null);
-        var issueId = Guid.NewGuid();
+        SetUpConfigScopeTracker(null);
 
-        var ruleInfo = await testSubject.GetRuleInfoAsync(default,issueId);
+        var ruleInfo = await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
         ruleInfo.Should().BeNull();
         logger.AssertNoOutputMessages();
     }
 
     [TestMethod]
-    public async Task GetRuleInfoAsync_ForIssue_ServiceUnavailable_ReturnsNull()
+    public async Task GetRuleInfoAsync_ForIssue_IssueServiceUnavailable_ReturnsResultFromRulesService()
     {
-        var testSubject = CreateTestSubject(out _, out var configScopeTrackerMock, out var logger);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("id"));
+        SetUpIssueServiceProvider(false);
+        MockGetEffectiveRuleDetailsAsync(compositeRuleId.ToString(), configurationScope.Id);
 
-        var ruleInfo = await testSubject.GetRuleInfoAsync(default,Guid.NewGuid());
+        var ruleInfo = await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
-        ruleInfo.Should().BeNull();
+        ruleInfo.Should().NotBeNull();
         logger.AssertNoOutputMessages();
+        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
     }
 
     [TestMethod]
-    public void GetRuleInfoAsync_ForIssue_ServiceThrows_ReturnsNullAndLogs()
+    public void GetRuleInfoAsync_ForIssue_IssueServiceThrows_ReturnsNullAndLogs()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out var logger);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("id"));
-        SetUpIssueServiceProvider(serviceProviderMock, out var issueServiceMock);
-        issueServiceMock
-            .Setup(x => x.GetEffectiveIssueDetailsAsync(It.IsAny<GetEffectiveIssueDetailsParams>()))
-            .ThrowsAsync(new Exception("my message"));
+        MockGetEffectiveIssueDetailsAsyncThrows();
 
-        var act = () => testSubject.GetRuleInfoAsync(default,Guid.NewGuid());
+        var act = () => testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
         act.Should().NotThrow();
-        logger.AssertPartialOutputStringExists("my message");
+        logger.AssertPartialOutputStringExists(errorMessage);
     }
 
     [TestMethod]
-    public async Task GetRuleInfoAsync_FilterableIssueNull_CallsGetEffectiveRuleDetailsAsync()
+    public async Task GetRuleInfoAsync_IssueIdNull_CallsGetEffectiveRuleDetailsAsync()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out _);
-        SetUpIssueServiceProvider(serviceProviderMock, out var issueServiceMock);
-        SetUpServiceProvider(serviceProviderMock, out var rulesServiceMock);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("configscope"));
+        await testSubject.GetRuleInfoAsync(compositeRuleId, null);
 
-        await testSubject.GetRuleInfoAsync(CompositeRuleId, null);
-
-        rulesServiceMock.Verify(x => x.GetEffectiveRuleDetailsAsync(It.Is<GetEffectiveRuleDetailsParams>(p => p.ruleKey == CompositeRuleId.ToString())), Times.Once);
-        issueServiceMock.Verify(x => x.GetEffectiveIssueDetailsAsync(It.IsAny<GetEffectiveIssueDetailsParams>()), Times.Never);
+        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        await VerifyIssueDetailsWasNotCalled();
     }
 
     [TestMethod]
-    public async Task GetRuleInfoAsync_FilterableIssueIdNull_CallsGetEffectiveRuleDetailsAsync()
+    public async Task GetRuleInfoAsync_IssueIdNotNull_CallsGetEffectiveIssueDetailsAsync()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out _);
-        SetUpIssueServiceProvider(serviceProviderMock, out var issueServiceMock);
-        SetUpServiceProvider(serviceProviderMock, out var rulesServiceMock);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("configscope"));
-        Guid? issueId = null;
+        MockGetEffectiveIssueDetailsAsync(issueId, configurationScope.Id);
 
-        await testSubject.GetRuleInfoAsync(CompositeRuleId, issueId);
+        await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
-        rulesServiceMock.Verify(x => x.GetEffectiveRuleDetailsAsync(It.Is<GetEffectiveRuleDetailsParams>(p => p.ruleKey == CompositeRuleId.ToString())), Times.Once);
-        issueServiceMock.Verify(x => x.GetEffectiveIssueDetailsAsync(It.IsAny<GetEffectiveIssueDetailsParams>()), Times.Never);
-    }
-
-    [TestMethod]
-    public async Task GetRuleInfoAsync_FilterableIssueIdNotNull_CallsGetEffectiveIssueDetailsAsync()
-    {
-        var configScopeId = "configscope";
-        var issueId = Guid.NewGuid();
-        var testSubject = CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out _);
-        SetUpIssueServiceProvider(serviceProviderMock, out var issueServiceMock);
-        SetUpServiceProvider(serviceProviderMock, out var rulesServiceMock);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope(configScopeId));
-        SetupIssuesService(issueServiceMock, issueId, configScopeId, CreateEffectiveIssueDetailsDto(new MQRModeDetails(default, default)));
-
-        await testSubject.GetRuleInfoAsync(CompositeRuleId, issueId);
-
-        rulesServiceMock.Verify(x => x.GetEffectiveRuleDetailsAsync(It.IsAny<GetEffectiveRuleDetailsParams>()), Times.Never);
-        issueServiceMock.Verify(x => x.GetEffectiveIssueDetailsAsync(It.Is<GetEffectiveIssueDetailsParams>(p => p.issueId == issueId)), Times.Once);
+        await VerifyRuleDetailsWasNotCalled();
+        await VerifyGetIssueDetailsWasCalled(issueId);
     }
 
     [TestMethod]
     public async Task GetRuleInfoAsync_GetEffectiveIssueDetailsAsyncThrows_CallsGetEffectiveRuleDetailsAsync()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out _);
-        SetUpIssueServiceProvider(serviceProviderMock, out var issueServiceMock);
-        SetUpServiceProvider(serviceProviderMock, out var rulesServiceMock);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("configscope"));
-        var issueId = Guid.NewGuid();
-        issueServiceMock
-            .Setup(x => x.GetEffectiveIssueDetailsAsync(It.IsAny<GetEffectiveIssueDetailsParams>()))
-            .ThrowsAsync(new Exception("my message"));
+        MockGetEffectiveIssueDetailsAsyncThrows();
 
-        await testSubject.GetRuleInfoAsync(CompositeRuleId, issueId);
+        await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
-        rulesServiceMock.Verify(x => x.GetEffectiveRuleDetailsAsync(It.Is<GetEffectiveRuleDetailsParams>(p => p.ruleKey == CompositeRuleId.ToString())), Times.Once);
-        issueServiceMock.Verify(x => x.GetEffectiveIssueDetailsAsync(It.Is<GetEffectiveIssueDetailsParams>(p => p.issueId == issueId)), Times.Once);
+        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        await VerifyGetIssueDetailsWasCalled(issueId);
     }
 
     [TestMethod]
     public async Task GetRuleInfoAsync_BothServicesThrow_ReturnsNull()
     {
-        var testSubject =
-            CreateTestSubject(out var serviceProviderMock, out var configScopeTrackerMock, out _);
-        SetUpIssueServiceProvider(serviceProviderMock, out var issueServiceMock);
-        SetUpServiceProvider(serviceProviderMock, out var rulesServiceMock);
-        SetUpConfigScopeTracker(configScopeTrackerMock, new ConfigurationScope("configscope"));
-        var issueId = Guid.NewGuid();
-        issueServiceMock
-            .Setup(x => x.GetEffectiveIssueDetailsAsync(It.IsAny<GetEffectiveIssueDetailsParams>()))
-            .ThrowsAsync(new Exception("my message"));
-        rulesServiceMock
-            .Setup(x => x.GetEffectiveRuleDetailsAsync(It.IsAny<GetEffectiveRuleDetailsParams>()))
-            .ThrowsAsync(new Exception("my message"));
+        MockGetEffectiveIssueDetailsAsyncThrows();
+        MockGetEffectiveRuleDetailsAsyncThrows();
 
-        var result = await testSubject.GetRuleInfoAsync(CompositeRuleId, issueId);
+        var result = await testSubject.GetRuleInfoAsync(compositeRuleId, issueId);
 
         result.Should().BeNull();
-        rulesServiceMock.Verify(x => x.GetEffectiveRuleDetailsAsync(It.Is<GetEffectiveRuleDetailsParams>(p => p.ruleKey == CompositeRuleId.ToString())), Times.Once);
-        issueServiceMock.Verify(x => x.GetEffectiveIssueDetailsAsync(It.Is<GetEffectiveIssueDetailsParams>(p => p.issueId == issueId)), Times.Once);
+        await VerifyGetRuleDetailsWasCalled(compositeRuleId.ToString());
+        await VerifyGetIssueDetailsWasCalled(issueId);
     }
 
-    private static void SetUpConfigScopeTracker(
-        Mock<IActiveConfigScopeTracker> configScopeTrackerMock,
-        ConfigurationScope scope) =>
-        configScopeTrackerMock.SetupGet(x => x.Current).Returns(scope);
+    private void SetUpConfigScopeTracker(ConfigurationScope scope) => configScopeTrackerMock.Current.Returns(scope);
 
-    private static void SetupIssuesService(
-        Mock<IIssueSLCoreService> issuesServiceMock,
-        Guid id,
-        string configScopeId,
-        EffectiveIssueDetailsDto response) =>
-        issuesServiceMock
-            .Setup(r => r.GetEffectiveIssueDetailsAsync(It.Is<GetEffectiveIssueDetailsParams>(p => p.configurationScopeId == configScopeId && p.issueId == id)))
-            .ReturnsAsync(new GetEffectiveIssueDetailsResponse(response));
+    private void MockGetEffectiveIssueDetailsAsyncThrows() => issueServiceMock.GetEffectiveIssueDetailsAsync(Arg.Any<GetEffectiveIssueDetailsParams>()).ThrowsAsync(new Exception(errorMessage));
 
-    private static void SetUpServiceProvider(
-        Mock<ISLCoreServiceProvider> serviceProviderMock,
-        out Mock<IRulesSLCoreService> rulesServiceMock)
+    private void MockGetEffectiveRuleDetailsAsyncThrows() => rulesServiceMock.GetEffectiveRuleDetailsAsync(Arg.Any<GetEffectiveRuleDetailsParams>()).ThrowsAsync(new Exception(errorMessage));
+
+    private void MockGetEffectiveIssueDetailsAsync(Guid id, string configScopeId) =>
+        issueServiceMock.GetEffectiveIssueDetailsAsync(Arg.Is<GetEffectiveIssueDetailsParams>(x => x.configurationScopeId == configScopeId && x.issueId == id))
+            .Returns(new GetEffectiveIssueDetailsResponse(effectiveIssueDetailsDto));
+
+    private void MockGetEffectiveRuleDetailsAsync(string ruleKey, string configScopeId) =>
+        rulesServiceMock.GetEffectiveRuleDetailsAsync(Arg.Is<GetEffectiveRuleDetailsParams>(x => x.configurationScopeId == configScopeId && x.ruleKey == ruleKey))
+            .Returns(new GetEffectiveRuleDetailsResponse(default));
+
+    private void SetUpRuleServiceProvider(bool result) =>
+        serviceProviderMock.TryGetTransientService(out Arg.Any<IRulesSLCoreService>()).Returns(callInfo =>
+        {
+            callInfo[0] = rulesServiceMock;
+            return result;
+        });
+
+    private void SetUpIssueServiceProvider(bool result) =>
+        serviceProviderMock.TryGetTransientService(out Arg.Any<IIssueSLCoreService>()).Returns(callInfo =>
+        {
+            callInfo[0] = issueServiceMock;
+            return result;
+        });
+
+    private void MockupServices()
     {
-        rulesServiceMock = new Mock<IRulesSLCoreService>();
-        var rulesService = rulesServiceMock.Object;
-        serviceProviderMock.Setup(x => x.TryGetTransientService(out rulesService)).Returns(true);
+        MockRuleInfoConverter();
+        SetUpIssueServiceProvider(true);
+        SetUpRuleServiceProvider(true);
+        SetUpConfigScopeTracker(configurationScope);
     }
 
-    private static void SetUpIssueServiceProvider(
-        Mock<ISLCoreServiceProvider> serviceProviderMock,
-        out Mock<IIssueSLCoreService> rulesServiceMock)
-    {
-        rulesServiceMock = new Mock<IIssueSLCoreService>();
-        var rulesService = rulesServiceMock.Object;
-        serviceProviderMock.Setup(x => x.TryGetTransientService(out rulesService)).Returns(true);
-    }
+    private void MockRuleInfoConverter() => ruleInfoConverter.Convert(Arg.Any<IRuleDetails>()).Returns(defaultRuleInfo);
 
-    private static SLCoreRuleMetaDataProvider CreateTestSubject(
-        out Mock<ISLCoreServiceProvider> serviceProviderMock,
-        out Mock<IActiveConfigScopeTracker> configScopeTrackerMock,
-        out TestLogger logger)
-    {
-        serviceProviderMock = new Mock<ISLCoreServiceProvider>();
-        configScopeTrackerMock = new Mock<IActiveConfigScopeTracker>();
-        configScopeTrackerMock = new Mock<IActiveConfigScopeTracker>();
-        var ruleInfoConverter = new Mock<IRuleInfoConverter>();
-        ruleInfoConverter.Setup(x => x.Convert(It.IsAny<IRuleDetails>())).Returns(new RuleInfo(default, default, default, default, default, default, default, default));
-        logger = new TestLogger();
-        return new SLCoreRuleMetaDataProvider(serviceProviderMock.Object, configScopeTrackerMock.Object, ruleInfoConverter.Object, logger);
-    }
+    private async Task VerifyGetIssueDetailsWasCalled(Guid id) => await issueServiceMock.Received(1).GetEffectiveIssueDetailsAsync(Arg.Is<GetEffectiveIssueDetailsParams>(x => x.issueId == id));
 
-    private static EffectiveIssueDetailsDto CreateEffectiveIssueDetailsDto(Either<StandardModeDetails, MQRModeDetails> severityDetails,
-        Either<RuleMonolithicDescriptionDto, RuleSplitDescriptionDto> description = default) =>
-        new(
-            default,
-            default,
-            default,
-            default,
-            description,
-            default,
-            severityDetails, 
-            default);
+    private async Task VerifyGetRuleDetailsWasCalled(string ruleKey) =>
+        await rulesServiceMock.Received(1).GetEffectiveRuleDetailsAsync(Arg.Is<GetEffectiveRuleDetailsParams>(x => x.ruleKey == ruleKey));
+
+    private async Task VerifyIssueDetailsWasNotCalled() => await issueServiceMock.DidNotReceive().GetEffectiveIssueDetailsAsync(Arg.Any<GetEffectiveIssueDetailsParams>());
+
+    private async Task VerifyRuleDetailsWasNotCalled() => await rulesServiceMock.DidNotReceive().GetEffectiveRuleDetailsAsync(Arg.Any<GetEffectiveRuleDetailsParams>());
 }

--- a/src/Education/ErrorList/SonarErrorListEventProcessorProvider.cs
+++ b/src/Education/ErrorList/SonarErrorListEventProcessorProvider.cs
@@ -22,6 +22,7 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Utilities;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Education.ErrorList;
 using SonarLint.VisualStudio.Infrastructure.VS;
 
 namespace SonarLint.VisualStudio.Education

--- a/src/Education/Rule/SLCoreRuleMetaDataProvider.cs
+++ b/src/Education/Rule/SLCoreRuleMetaDataProvider.cs
@@ -29,25 +29,14 @@ namespace SonarLint.VisualStudio.Education.Rule;
 
 [Export(typeof(IRuleMetaDataProvider))]
 [PartCreationPolicy(CreationPolicy.Shared)]
-internal class SLCoreRuleMetaDataProvider : IRuleMetaDataProvider
+[method: ImportingConstructor]
+internal class SLCoreRuleMetaDataProvider(
+    ISLCoreServiceProvider slCoreServiceProvider,
+    IActiveConfigScopeTracker activeConfigScopeTracker,
+    IRuleInfoConverter ruleInfoConverter,
+    ILogger logger)
+    : IRuleMetaDataProvider
 {
-    private readonly IActiveConfigScopeTracker activeConfigScopeTracker;
-    private readonly IRuleInfoConverter ruleInfoConverter;
-    private readonly ILogger logger;
-    private readonly ISLCoreServiceProvider slCoreServiceProvider;
-
-    [ImportingConstructor]
-    public SLCoreRuleMetaDataProvider(ISLCoreServiceProvider slCoreServiceProvider,
-        IActiveConfigScopeTracker activeConfigScopeTracker,
-        IRuleInfoConverter ruleInfoConverter,
-        ILogger logger)
-    {
-        this.slCoreServiceProvider = slCoreServiceProvider;
-        this.activeConfigScopeTracker = activeConfigScopeTracker;
-        this.ruleInfoConverter = ruleInfoConverter;
-        this.logger = logger;
-    }
-
     /// <inheritdoc />
     public async Task<IRuleInfo> GetRuleInfoAsync(SonarCompositeRuleId ruleId, Guid? issueId = null)
     {

--- a/src/Infrastructure.VS.UnitTests/ErrorListHelperTests.cs
+++ b/src/Infrastructure.VS.UnitTests/ErrorListHelperTests.cs
@@ -22,538 +22,480 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
-using Moq;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 
-namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests
+namespace SonarLint.VisualStudio.Infrastructure.VS.UnitTests;
+
+[TestClass]
+public class ErrorListHelperTests
 {
-    [TestClass]
-    public class ErrorListHelperTests
+    private IAnalysisIssueVisualization issueMock;
+    private ErrorListHelper testSubject;
+    private IVsUIServiceOperation vsUiServiceOperation;
+
+    [TestInitialize]
+    public void TestInitialize()
     {
-        internal enum TestVsSuppressionState
-        {
-            Active,
-            Suppressed,
-            NotApplicable,
-        }
+        vsUiServiceOperation = Substitute.For<IVsUIServiceOperation>();
+        issueMock = Substitute.For<IAnalysisIssueVisualization>();
 
-        [TestMethod]
-        public void MefCtor_CheckIsExported()
-        {
-            MefTestHelpers.CheckTypeCanBeImported<ErrorListHelper, IErrorListHelper>(
-                MefTestHelpers.CreateExport<IVsUIServiceOperation>());
-        }
+        testSubject = new ErrorListHelper(vsUiServiceOperation);
+    }
 
-        [TestMethod]
-        public void MefCtor_CheckIsSingleton()
-        => MefTestHelpers.CheckIsSingletonMefComponent<ErrorListHelper>();
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<ErrorListHelper, IErrorListHelper>(
+            MefTestHelpers.CreateExport<IVsUIServiceOperation>());
 
-        [TestMethod]
-        public void MefCtor_DoesNotCallAnyServices()
-        {
-            var serviceOp = new Mock<IVsUIServiceOperation>();
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<ErrorListHelper>();
 
-            _ = new ErrorListHelper(serviceOp.Object);
+    [TestMethod]
+    public void MefCtor_DoesNotCallAnyServices() =>
+        // The MEF constructor should be free-threaded, which it will be if
+        // it doesn't make any external calls.
+        vsUiServiceOperation.ReceivedCalls().Should().BeEmpty();
 
-            // The MEF constructor should be free-threaded, which it will be if
-            // it doesn't make any external calls.
-            serviceOp.Invocations.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void TryGetIssueFromSelectedRow_SingleSonarIssue_IssueReturned()
-        {
-            var issueMock = Mock.Of<IAnalysisIssueVisualization>();
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetIssueFromSelectedRow_SingleSonarIssue_IssueReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
                 { SonarLintTableControlConstants.IssueVizColumnName, issueMock }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetIssueFromSelectedRow(out var issue);
+        var result = testSubject.TryGetIssueFromSelectedRow(out var issue);
 
-            result.Should().BeTrue();
-            issue.Should().BeSameAs(issueMock);
-        }
+        result.Should().BeTrue();
+        issue.Should().BeSameAs(issueMock);
+    }
 
-        [TestMethod]
-        public void TryGetIssueFromSelectedRow_SingleItemButNoAnalysisIssue_IssueNotReturned()
-        {
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetIssueFromSelectedRow_SingleItemButNoAnalysisIssue_IssueNotReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
                 { SonarLintTableControlConstants.IssueVizColumnName, null }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            var result = testSubject.TryGetIssueFromSelectedRow(out _);
+        var result = testSubject.TryGetIssueFromSelectedRow(out _);
 
-            result.Should().BeFalse();
-        }
+        result.Should().BeFalse();
+    }
 
-        [TestMethod]
-        public void TryGetIssueFromSelectedRow_MultipleItemsSelected_IssueNotReturned()
-        {
-            var cppIssueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetIssueFromSelectedRow_MultipleItemsSelected_IssueNotReturned()
+    {
+        var cppIssueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
                 { StandardTableKeyNames.ErrorCode, "cpp:S222" },
-                { SonarLintTableControlConstants.IssueVizColumnName, Mock.Of<IAnalysisIssueVisualization>() }
+                { SonarLintTableControlConstants.IssueVizColumnName, Substitute.For<IAnalysisIssueVisualization>() }
             });
-            var jsIssueHandle = CreateIssueHandle(222, new Dictionary<string, object>
+        var jsIssueHandle = CreateIssueHandle(222,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint.CSharp" },
                 { StandardTableKeyNames.ErrorCode, "csharpsquid:S222" },
-                { SonarLintTableControlConstants.IssueVizColumnName, Mock.Of<IAnalysisIssueVisualization>() }
+                { SonarLintTableControlConstants.IssueVizColumnName, Substitute.For<IAnalysisIssueVisualization>() }
             });
+        MockErrorList(cppIssueHandle, jsIssueHandle);
 
-            var errorList = CreateErrorList(cppIssueHandle, jsIssueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        var result = testSubject.TryGetIssueFromSelectedRow(out _);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            var result = testSubject.TryGetIssueFromSelectedRow(out _);
+        result.Should().BeFalse();
+    }
 
-            result.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TryGetRoslynIssueFromSelectedRow_SingleRoslynIssue_IssueReturned()
-        {
-            var path = "filepath";
-            var line = 12;
-            var column = 101;
-            var errorCode = "javascript:S333";
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetRoslynIssueFromSelectedRow_SingleRoslynIssue_IssueReturned()
+    {
+        var path = "filepath";
+        var line = 12;
+        var column = 101;
+        var errorCode = "javascript:S333";
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, errorCode},
+                { StandardTableKeyNames.ErrorCode, errorCode },
                 { StandardTableKeyNames.DocumentName, path },
                 { StandardTableKeyNames.Line, line },
                 { StandardTableKeyNames.Column, column }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRoslynIssueFromSelectedRow(out var issue);
+        var result = testSubject.TryGetRoslynIssueFromSelectedRow(out var issue);
 
-            result.Should().BeTrue();
-            issue.RuleId.Should().BeSameAs(errorCode);
-            issue.FilePath.Should().BeSameAs(path);
-            issue.StartLine.Should().Be(line + 1);
-            issue.RoslynStartLine.Should().Be(line + 1);
-            issue.RoslynStartColumn.Should().Be(column + 1);
-            issue.LineHash.Should().BeNull();
-        }
+        result.Should().BeTrue();
+        issue.RuleId.Should().BeSameAs(errorCode);
+        issue.FilePath.Should().BeSameAs(path);
+        issue.StartLine.Should().Be(line + 1);
+        issue.RoslynStartLine.Should().Be(line + 1);
+        issue.RoslynStartColumn.Should().Be(column + 1);
+        issue.LineHash.Should().BeNull();
+    }
 
-        [TestMethod]
-        public void TryGetRoslynIssueFromSelectedRow_NonSonarIssue_NothingReturned()
-        {
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetRoslynIssueFromSelectedRow_NonSonarIssue_NothingReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "Not SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
                 { StandardTableKeyNames.DocumentName, "filepath" },
                 { StandardTableKeyNames.Line, 1 },
                 { StandardTableKeyNames.Column, 2 }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
+        var result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
 
-            result.Should().BeFalse();
-        }
+        result.Should().BeFalse();
+    }
 
-        [TestMethod]
-        public void TryGetRoslynIssueFromSelectedRow_NoFilePath_NothingReturned()
-        {
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetRoslynIssueFromSelectedRow_NoFilePath_NothingReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
-                { StandardTableKeyNames.Line, 1 },
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
+                { StandardTableKeyNames.Line, 1 }, { StandardTableKeyNames.Column, 2 }
+            });
+        MockErrorList(issueHandle);
+
+        var result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
+
+        result.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryGetRoslynIssueFromSelectedRow_NoStartLine_NothingReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
+            {
+                { StandardTableKeyNames.BuildTool, "SonarLint" },
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
+                { StandardTableKeyNames.DocumentName, "filepath" },
                 { StandardTableKeyNames.Column, 2 }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
+        var result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
 
-            result.Should().BeFalse();
-        }
+        result.Should().BeFalse();
+    }
 
-        [TestMethod]
-        public void TryGetRoslynIssueFromSelectedRow_NoStartLine_NothingReturned()
-        {
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetRoslynIssueFromSelectedRow_NoStartColumn_NothingReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
                 { StandardTableKeyNames.DocumentName, "filepath" },
-                { StandardTableKeyNames.Column, 2 },
+                { StandardTableKeyNames.Line, 1 }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
+        var result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
 
-            result.Should().BeFalse();
-        }
+        result.Should().BeFalse();
+    }
 
-        [TestMethod]
-        public void TryGetRoslynIssueFromSelectedRow_NoStartColumn_NothingReturned()
+    [TestMethod]
+    [DataRow("S666", "csharpsquid", "S666", "SonarAnalyzer.CSharp", null)]
+    [DataRow("S666", "vbnet", "S666", "SonarAnalyzer.VisualBasic", null)]
+    [DataRow("S234", "vbnet", "S234", "SonarAnalyzer.VisualBasic", null)]
+    [DataRow("c:S111", "c", "S111", "SonarLint", null)]
+    [DataRow("cpp:S222", "cpp", "S222", "SonarLint", null)]
+    [DataRow("javascript:S333", "javascript", "S333", "SonarLint", null)]
+    [DataRow("typescript:S444", "typescript", "S444", "SonarLint", null)]
+    [DataRow("secrets:S555", "secrets", "S555", "SonarLint", null)]
+    [DataRow("foo:bar", "foo", "bar", "SonarLint", null)]
+    [DataRow("S666", "csharpsquid", "S666", null, "https://rules.sonarsource.com/csharp/RSPEC-666/")]
+    [DataRow("S666", "vbnet", "S666", null, "https://rules.sonarsource.com/vbnet/RSPEC-666/")]
+    [DataRow("S234", "vbnet", "S234", null, "https://rules.sonarsource.com/vbnet/RSPEC-234/")]
+    public void TryGetRuleIdFromSelectedRow_SingleSonarIssue_ErrorCodeReturned(
+        string fullRuleKey,
+        string expectedRepo,
+        string expectedRule,
+        string buildTool,
+        string helpLink)
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object> { { StandardTableKeyNames.BuildTool, buildTool }, { StandardTableKeyNames.HelpLink, helpLink }, { StandardTableKeyNames.ErrorCode, fullRuleKey } });
+        MockErrorList(issueHandle);
+
+        var result = testSubject.TryGetRuleIdFromSelectedRow(out var ruleId);
+
+        result.Should().BeTrue();
+        ruleId.RepoKey.Should().Be(expectedRepo);
+        ruleId.RuleKey.Should().Be(expectedRule);
+    }
+
+    [TestMethod]
+    [DataRow("S666", "csharpsquid", "S666", "SonarAnalyzer.CSharp", null)]
+    [DataRow("S666", "vbnet", "S666", "SonarAnalyzer.VisualBasic", null)]
+    [DataRow("S234", "vbnet", "S234", "SonarAnalyzer.VisualBasic", null)]
+    [DataRow("c:S111", "c", "S111", "SonarLint", null)]
+    [DataRow("cpp:S222", "cpp", "S222", "SonarLint", null)]
+    [DataRow("javascript:S333", "javascript", "S333", "SonarLint", null)]
+    [DataRow("typescript:S444", "typescript", "S444", "SonarLint", null)]
+    [DataRow("secrets:S555", "secrets", "S555", "SonarLint", null)]
+    [DataRow("foo:bar", "foo", "bar", "SonarLint", null)]
+    [DataRow("S666", "csharpsquid", "S666", null, "https://rules.sonarsource.com/csharp/RSPEC-666/")]
+    [DataRow("S666", "vbnet", "S666", null, "https://rules.sonarsource.com/vbnet/RSPEC-666/")]
+    [DataRow("S234", "vbnet", "S234", null, "https://rules.sonarsource.com/vbnet/RSPEC-234/")]
+    public void TryGetRuleId_FromHandle_ErrorCodeReturned(
+        string fullRuleKey,
+        string expectedRepo,
+        string expectedRule,
+        string buildTool,
+        string helpLink)
+    {
+        // Note: this is a copy of TryGetRuleIdFromSelectedRow_SingleSonarIssue_ErrorCodeReturned,
+        //       but without the serviceProvider and IErrorList setup
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object> { { StandardTableKeyNames.BuildTool, buildTool }, { StandardTableKeyNames.HelpLink, helpLink }, { StandardTableKeyNames.ErrorCode, fullRuleKey } });
+
+        var result = testSubject.TryGetRuleId(issueHandle, out var ruleId);
+
+        result.Should().BeTrue();
+        ruleId.RepoKey.Should().Be(expectedRepo);
+        ruleId.RuleKey.Should().Be(expectedRule);
+    }
+
+    [TestMethod]
+    public void TryGetRuleIdFromSelectedRow_NonStandardErrorCode_NoException_ErrorCodeNotReturned()
+    {
+        var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
         {
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
-                { StandardTableKeyNames.DocumentName, "filepath" },
-                { StandardTableKeyNames.Line, 1 },
-            });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+            { StandardTableKeyNames.BuildTool, "SonarLint" },
+            { StandardTableKeyNames.ErrorCode, ":" } // should not happen
+        });
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRoslynIssueFromSelectedRow(out _);
+        var result = testSubject.TryGetRuleIdFromSelectedRow(out var errorCode);
 
-            result.Should().BeFalse();
-        }
+        result.Should().BeFalse();
+        errorCode.Should().BeNull();
+    }
 
-        [TestMethod]
-        [DataRow("S666", "csharpsquid", "S666", "SonarAnalyzer.CSharp", null)]
-        [DataRow("S666", "vbnet", "S666", "SonarAnalyzer.VisualBasic", null)]
-        [DataRow("S234", "vbnet", "S234", "SonarAnalyzer.VisualBasic", null)]
-        [DataRow("c:S111", "c", "S111", "SonarLint", null)]
-        [DataRow("cpp:S222", "cpp", "S222", "SonarLint", null)]
-        [DataRow("javascript:S333", "javascript", "S333", "SonarLint", null)]
-        [DataRow("typescript:S444", "typescript", "S444", "SonarLint", null)]
-        [DataRow("secrets:S555", "secrets", "S555", "SonarLint", null)]
-        [DataRow("foo:bar", "foo", "bar", "SonarLint", null)]
-        [DataRow("S666", "csharpsquid", "S666", null, "https://rules.sonarsource.com/csharp/RSPEC-666/")]
-        [DataRow("S666", "vbnet", "S666", null, "https://rules.sonarsource.com/vbnet/RSPEC-666/")]
-        [DataRow("S234", "vbnet", "S234", null, "https://rules.sonarsource.com/vbnet/RSPEC-234/")]
-        public void TryGetRuleIdFromSelectedRow_SingleSonarIssue_ErrorCodeReturned(string fullRuleKey, string expectedRepo, string expectedRule, string buildTool, string helpLink)
+    [TestMethod]
+    public void TryGetRuleIdFromSelectedRow_MultipleItemsSelected_ErrorCodeNotReturned()
+    {
+        var cppIssueHandle = CreateIssueHandle(111, new Dictionary<string, object>
         {
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, buildTool },
-                { StandardTableKeyNames.HelpLink, helpLink },
-                { StandardTableKeyNames.ErrorCode, fullRuleKey }
-            });
-
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
-
-            // Act
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRuleIdFromSelectedRow(out var ruleId);
-
-            // Assert
-            result.Should().BeTrue();
-            ruleId.RepoKey.Should().Be(expectedRepo);
-            ruleId.RuleKey.Should().Be(expectedRule);
-        }
-
-        [TestMethod]
-        [DataRow("S666", "csharpsquid", "S666", "SonarAnalyzer.CSharp", null)]
-        [DataRow("S666", "vbnet", "S666", "SonarAnalyzer.VisualBasic", null)]
-        [DataRow("S234", "vbnet", "S234", "SonarAnalyzer.VisualBasic", null)]
-        [DataRow("c:S111", "c", "S111", "SonarLint", null)]
-        [DataRow("cpp:S222", "cpp", "S222", "SonarLint", null)]
-        [DataRow("javascript:S333", "javascript", "S333", "SonarLint", null)]
-        [DataRow("typescript:S444", "typescript", "S444", "SonarLint", null)]
-        [DataRow("secrets:S555", "secrets", "S555", "SonarLint", null)]
-        [DataRow("foo:bar", "foo", "bar", "SonarLint", null)]
-        [DataRow("S666", "csharpsquid", "S666", null, "https://rules.sonarsource.com/csharp/RSPEC-666/")]
-        [DataRow("S666", "vbnet", "S666", null, "https://rules.sonarsource.com/vbnet/RSPEC-666/")]
-        [DataRow("S234", "vbnet", "S234", null, "https://rules.sonarsource.com/vbnet/RSPEC-234/")]
-        public void TryGetRuleId_FromHandle_ErrorCodeReturned(string fullRuleKey, string expectedRepo, string expectedRule, string buildTool, string helpLink)
+            { StandardTableKeyNames.BuildTool, "SonarLint" },
+            { StandardTableKeyNames.ErrorCode, "cpp:S222" }
+        });
+        var jsIssueHandle = CreateIssueHandle(222, new Dictionary<string, object>
         {
-            // Note: this is a copy of TryGetRuleIdFromSelectedRow_SingleSonarIssue_ErrorCodeReturned,
-            //       but without the serviceProvider and IErrorList setup
+            { StandardTableKeyNames.BuildTool, "SonarLint.CSharp" },
+            { StandardTableKeyNames.ErrorCode, "csharpsquid:S222" }
+        });
+        MockErrorList(cppIssueHandle, jsIssueHandle);
 
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, buildTool },
-                { StandardTableKeyNames.HelpLink, helpLink },
-                { StandardTableKeyNames.ErrorCode, fullRuleKey }
-            });
+        var result = testSubject.TryGetRuleIdFromSelectedRow(out var errorCode);
 
-            // Act
-            var testSubject = new ErrorListHelper(Mock.Of<IVsUIServiceOperation>());
-            bool result = testSubject.TryGetRuleId(issueHandle, out var ruleId);
+        result.Should().BeFalse();
+        errorCode.Should().BeNull();
+    }
 
-            // Assert
-            result.Should().BeTrue();
-            ruleId.RepoKey.Should().Be(expectedRepo);
-            ruleId.RuleKey.Should().Be(expectedRule);
-        }
-
-        [TestMethod]
-        public void TryGetRuleIdFromSelectedRow_NonStandardErrorCode_NoException_ErrorCodeNotReturned()
+    [TestMethod]
+    public void TryGetRuleIdFromSelectedRow_NotSonarLintIssue()
+    {
+        var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
         {
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, ":" } // should not happen
-            });
+            { StandardTableKeyNames.BuildTool, new object() },
+            { StandardTableKeyNames.ErrorCode, "cpp:S333" }
+        });
+        MockErrorList(issueHandle);
 
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        var result = testSubject.TryGetRuleIdFromSelectedRow(out var errorCode);
 
-            // Act
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRuleIdFromSelectedRow(out var errorCode);
+        result.Should().BeFalse();
+        errorCode.Should().BeNull();
+    }
 
-            // Assert
-            result.Should().BeFalse();
-            errorCode.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryGetRuleIdFromSelectedRow_MultipleItemsSelected_ErrorCodeNotReturned()
+    [TestMethod]
+    [DataRow("cpp:S333", "AnotherAnalyzer", null)]
+    [DataRow("S666", "AnotherAnalyzerWithSonarHelpLink", "https://rules.sonarsource.com/csharp/RSPEC-666/")]
+    [DataRow("S234", "SomeOtherAnalyzer", "https://rules.sonarsource.com/vbnet/RSPEC-234/")]
+    public void TryGetRuleId_FromHandle_NotSonarLintIssue(string fullRuleKey, object buildTool, string helpLink)
+    {
+        // Note: this is a copy of TryGetRuleIdFromSelectedRow_SingleSonarIssue_ErrorCodeReturned,
+        //       but without the serviceProvider and IErrorList setup
+        var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
         {
-            var cppIssueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "cpp:S222" }
-            });
-            var jsIssueHandle = CreateIssueHandle(222, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, "SonarLint.CSharp" },
-                { StandardTableKeyNames.ErrorCode, "csharpsquid:S222" }
-            });
+            { StandardTableKeyNames.BuildTool, buildTool },
+            { StandardTableKeyNames.HelpLink, helpLink },
+            { StandardTableKeyNames.ErrorCode, fullRuleKey }
+        });
 
-            var errorList = CreateErrorList(cppIssueHandle, jsIssueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        var result = testSubject.TryGetRuleId(issueHandle, out var errorCode);
 
-            // Act
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRuleIdFromSelectedRow(out var errorCode);
+        result.Should().BeFalse();
+        errorCode.Should().BeNull();
+    }
 
-            // Assert
-            result.Should().BeFalse();
-            errorCode.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryGetRuleIdFromSelectedRow_NotSonarLintIssue()
+    [TestMethod]
+    public void TryGetRuleIdAndSuppressionStateFromSelectedRow_NoSuppressionState_ReturnsIsNotSuppressed()
+    {
+        var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
         {
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, new object() },
-                { StandardTableKeyNames.ErrorCode, "cpp:S333" }
-            });
+            { StandardTableKeyNames.BuildTool, "SonarLint" },
+            { StandardTableKeyNames.ErrorCode, "cpp:S222" }
+        });
+        MockErrorList(issueHandle);
 
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        var result = testSubject.TryGetRuleIdAndSuppressionStateFromSelectedRow(out _, out var isSuppressed);
 
-            // Act
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRuleIdFromSelectedRow(out var errorCode);
+        result.Should().BeTrue();
+        isSuppressed.Should().BeFalse();
+    }
 
-            // Assert
-            result.Should().BeFalse();
-            errorCode.Should().BeNull();
-        }
-
-        [TestMethod]
-        [DataRow("cpp:S333", "AnotherAnalyzer", null)]
-        [DataRow("S666", "AnotherAnalyzerWithSonarHelpLink", "https://rules.sonarsource.com/csharp/RSPEC-666/")]
-        [DataRow("S234",  "SomeOtherAnalyzer", "https://rules.sonarsource.com/vbnet/RSPEC-234/")]
-        public void TryGetRuleId_FromHandle_NotSonarLintIssue(string fullRuleKey, object buildTool, string helpLink)
-        {
-            // Note: this is a copy of TryGetRuleIdFromSelectedRow_SingleSonarIssue_ErrorCodeReturned,
-            //       but without the serviceProvider and IErrorList setup
-
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, buildTool },
-                { StandardTableKeyNames.HelpLink, helpLink },
-                { StandardTableKeyNames.ErrorCode, fullRuleKey }
-            });
-
-            // Act
-            var testSubject = new ErrorListHelper(Mock.Of<IVsUIServiceOperation>());
-            bool result = testSubject.TryGetRuleId(issueHandle, out var errorCode);
-
-            // Assert
-            result.Should().BeFalse();
-            errorCode.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void TryGetRuleIdAndSuppressionStateFromSelectedRow_NoSuppressionState_ReturnsIsNotSuppressed()
-        {
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
-            {
-                { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "cpp:S222" }
-            });
-
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
-
-            // Act
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRuleIdAndSuppressionStateFromSelectedRow(out var ruleId, out var isSuppressed);
-
-            // Assert
-            result.Should().BeTrue();
-            isSuppressed.Should().BeFalse();
-        }
-
-        [DataTestMethod]
-        [DataRow(SuppressionState.Suppressed, true)]
-        [DataRow(SuppressionState.NotApplicable, false)]
-        [DataRow(SuppressionState.Active, false)]
-        public void TryGetRuleIdAndSuppressionStateFromSelectedRow_NoSuppressionState_ReturnsIsNotSuppressed(SuppressionState suppressionState, bool expectedSuppression)
-        {
-            // Arrange
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [DataTestMethod]
+    [DataRow(SuppressionState.Suppressed, true)]
+    [DataRow(SuppressionState.NotApplicable, false)]
+    [DataRow(SuppressionState.Active, false)]
+    public void TryGetRuleIdAndSuppressionStateFromSelectedRow_NoSuppressionState_ReturnsIsNotSuppressed(SuppressionState suppressionState, bool expectedSuppression)
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
                 { StandardTableKeyNames.ErrorCode, "cpp:S222" },
-                { StandardTableKeyNames.SuppressionState, suppressionState },
+                { StandardTableKeyNames.SuppressionState, suppressionState }
             });
+        MockErrorList(issueHandle);
 
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        var result = testSubject.TryGetRuleIdAndSuppressionStateFromSelectedRow(out _, out var isSuppressed);
 
-            // Act
-            var testSubject = new ErrorListHelper(serviceProvider);
-            bool result = testSubject.TryGetRuleIdAndSuppressionStateFromSelectedRow(out var ruleId, out var isSuppressed);
+        result.Should().BeTrue();
+        isSuppressed.Should().Be(expectedSuppression);
+    }
 
-            // Assert
-            result.Should().BeTrue();
-            isSuppressed.Should().Be(expectedSuppression);
-        }
-
-        [TestMethod]
-        public void TryGetFilterableIssue_SonarIssue_IssueReturned()
-        {
-            var issueMock = Mock.Of<IAnalysisIssueVisualization>();
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetFilterableIssue_SonarIssue_IssueReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
                 { SonarLintTableControlConstants.IssueVizColumnName, issueMock }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
-            var testSubject = new ErrorListHelper(serviceProvider);
+        MockErrorList(issueHandle);
 
-            bool result = testSubject.TryGetFilterableIssue(issueHandle, out var issue);
+        var result = testSubject.TryGetFilterableIssue(issueHandle, out var issue);
 
-            result.Should().BeTrue();
-            issue.Should().BeSameAs(issueMock);
-        }
+        result.Should().BeTrue();
+        issue.Should().BeSameAs(issueMock);
+    }
 
-        [TestMethod]
-        public void TryGetFilterableIssue_NoAnalysisIssue_IssueNotReturned()
-        {
-            var issueHandle = CreateIssueHandle(111, new Dictionary<string, object>
+    [TestMethod]
+    public void TryGetFilterableIssue_NoAnalysisIssue_IssueNotReturned()
+    {
+        var issueHandle = CreateIssueHandle(111,
+            new Dictionary<string, object>
             {
                 { StandardTableKeyNames.BuildTool, "SonarLint" },
-                { StandardTableKeyNames.ErrorCode, "javascript:S333"},
+                { StandardTableKeyNames.ErrorCode, "javascript:S333" },
                 { SonarLintTableControlConstants.IssueVizColumnName, null }
             });
-            var errorList = CreateErrorList(issueHandle);
-            var serviceProvider = CreateServiceOperation(errorList);
+        MockErrorList(issueHandle);
 
-            var testSubject = new ErrorListHelper(serviceProvider);
-            var result = testSubject.TryGetFilterableIssue(issueHandle,out _);
+        var result = testSubject.TryGetFilterableIssue(issueHandle, out _);
 
-            result.Should().BeFalse();
-        }
-
-        private IVsUIServiceOperation CreateServiceOperation(IErrorList svcToPassToCallback)
-        {
-            var serviceOp = new Mock<IVsUIServiceOperation>();
-
-            // Set up the mock to invoke the operation with the supplied VS service
-            serviceOp.Setup(x => x.Execute<SVsErrorList, IErrorList, bool>(It.IsAny<Func<IErrorList, bool>>()))
-                .Returns<Func<IErrorList, bool>>(op => op(svcToPassToCallback));
-
-            return serviceOp.Object;
-        }
-
-        private static IErrorList CreateErrorList(params ITableEntryHandle[] entries)
-        {
-            var mockWpfTable = new Mock<IWpfTableControl>();
-            mockWpfTable.Setup(x => x.SelectedEntries).Returns(entries);
-
-            var mockErrorList = new Mock<IErrorList>();
-            mockErrorList.Setup(x => x.TableControl).Returns(mockWpfTable.Object);
-            return mockErrorList.Object;
-        }
-
-        private static ITableEntryHandle CreateIssueHandle(int index, IDictionary<string, object> issueProperties)
-        {
-            // Snapshots would normally have multiple versions; each version would have a unique
-            // index, with a corresponding handle.
-            // Here, just create a dummy snapshot with a single version using the specified index
-            var issueSnapshot = (ITableEntriesSnapshot)new DummySnapshot
-            {
-                Index = index,
-                Properties = issueProperties
-            };
-
-            var mockHandle = new Mock<ITableEntryHandle>();
-            mockHandle.Setup(x => x.TryGetSnapshot(out issueSnapshot, out index)).Returns(true);
-            return mockHandle.Object;
-        }
-
-        #region Helper classes
-
-        private sealed class DummySnapshot : ITableEntriesSnapshot
-        {
-            public int Index { get; set; }
-            public IDictionary<string, object> Properties { get; set; }
-
-            #region ITableEntriesSnapshot methods
-
-            public int Count => throw new NotImplementedException();
-            public int VersionNumber => throw new NotImplementedException();
-
-            public void Dispose() => throw new NotImplementedException();
-
-            public int IndexOf(int currentIndex, ITableEntriesSnapshot newSnapshot) => throw new NotImplementedException();
-
-            public void StartCaching() => throw new NotImplementedException();
-
-            public void StopCaching() => throw new NotImplementedException();
-
-            public bool TryGetValue(int index, string keyName, out object content)
-            {
-                if (index == Index)
-                {
-                    return Properties.TryGetValue(keyName, out content);
-                }
-                content = null;
-                return false;
-            }
-
-            #endregion ITableEntriesSnapshot methods
-        }
-
-        #endregion Helper classes
+        result.Should().BeFalse();
     }
+
+    private void MockErrorList(params ITableEntryHandle[] entries)
+    {
+        var errorList = CreateErrorList(entries);
+        // Set up the mock to invoke the operation with the supplied VS service
+        vsUiServiceOperation.Execute<SVsErrorList, IErrorList, bool>(Arg.Any<Func<IErrorList, bool>>())
+            .Returns(callInfo =>
+            {
+                var func = callInfo.Arg<Func<IErrorList, bool>>();
+                return func(errorList);
+            });
+    }
+
+    private static IErrorList CreateErrorList(params ITableEntryHandle[] entries)
+    {
+        var mockWpfTable = Substitute.For<IWpfTableControl>();
+        mockWpfTable.SelectedEntries.Returns(entries);
+
+        var mockErrorList = Substitute.For<IErrorList>();
+        mockErrorList.TableControl.Returns(mockWpfTable);
+        return mockErrorList;
+    }
+
+    private static ITableEntryHandle CreateIssueHandle(int index, IDictionary<string, object> issueProperties)
+    {
+        // Snapshots would normally have multiple versions; each version would have a unique
+        // index, with a corresponding handle.
+        // Here, just create a dummy snapshot with a single version using the specified index
+        var issueSnapshot = (ITableEntriesSnapshot)new DummySnapshot { Index = index, Properties = issueProperties };
+
+        var mockHandle = Substitute.For<ITableEntryHandle>();
+        mockHandle.TryGetSnapshot(out _, out _).Returns(callInfo =>
+        {
+            callInfo[0] = issueSnapshot;
+            callInfo[1] = index;
+            return true;
+        });
+        return mockHandle;
+    }
+
+    #region Helper classes
+
+    private sealed class DummySnapshot : ITableEntriesSnapshot
+    {
+        public int Index { get; set; }
+        public IDictionary<string, object> Properties { get; set; }
+
+        #region ITableEntriesSnapshot methods
+
+        public int Count => throw new NotImplementedException();
+        public int VersionNumber => throw new NotImplementedException();
+
+        public void Dispose() => throw new NotImplementedException();
+
+        public int IndexOf(int currentIndex, ITableEntriesSnapshot newSnapshot) => throw new NotImplementedException();
+
+        public void StartCaching() => throw new NotImplementedException();
+
+        public void StopCaching() => throw new NotImplementedException();
+
+        public bool TryGetValue(int index, string keyName, out object content)
+        {
+            if (index == Index)
+            {
+                return Properties.TryGetValue(keyName, out content);
+            }
+            content = null;
+            return false;
+        }
+
+        #endregion ITableEntriesSnapshot methods
+    }
+
+    #endregion Helper classes
 }

--- a/src/Infrastructure.VS/ErrorListHelper.cs
+++ b/src/Infrastructure.VS/ErrorListHelper.cs
@@ -26,209 +26,199 @@ using Microsoft.VisualStudio.Shell.TableManager;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Suppressions;
 
-namespace SonarLint.VisualStudio.Infrastructure.VS
+namespace SonarLint.VisualStudio.Infrastructure.VS;
+
+[Export(typeof(IErrorListHelper))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+[method: ImportingConstructor]
+public class ErrorListHelper(IVsUIServiceOperation vSServiceOperation) : IErrorListHelper
 {
-    [Export(typeof(IErrorListHelper))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
-    public class ErrorListHelper : IErrorListHelper
+    public bool TryGetRuleIdFromSelectedRow(out SonarCompositeRuleId ruleId)
     {
-        private readonly IVsUIServiceOperation vSServiceOperation;
+        SonarCompositeRuleId ruleIdOut = null;
+        var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(errorList =>
+            TryGetSelectedTableEntry(errorList, out var handle) && TryGetRuleId(handle, out ruleIdOut));
 
-        [ImportingConstructor]
-        public ErrorListHelper(IVsUIServiceOperation vSServiceOperation)
+        ruleId = ruleIdOut;
+
+        return result;
+    }
+
+    public bool TryGetRuleId(ITableEntryHandle handle, out SonarCompositeRuleId ruleId)
+    {
+        ruleId = null;
+        if (!handle.TryGetSnapshot(out var snapshot, out var index))
         {
-            this.vSServiceOperation = vSServiceOperation;
+            return false;
         }
 
-        public bool TryGetRuleIdFromSelectedRow(out SonarCompositeRuleId ruleId)
+        var errorCode = FindErrorCodeForEntry(snapshot, index);
+        return SonarCompositeRuleId.TryParse(errorCode, out ruleId);
+    }
+
+    public bool TryGetRuleIdAndSuppressionStateFromSelectedRow(out SonarCompositeRuleId ruleId, out bool isSuppressed)
+    {
+        SonarCompositeRuleId ruleIdOut = null;
+        var isSuppressedOut = false;
+        var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(errorList =>
         {
-            SonarCompositeRuleId ruleIdOut = null;
-            var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(errorList =>
-                TryGetSelectedTableEntry(errorList, out var handle) && TryGetRuleId(handle, out ruleIdOut));
-
-            ruleId = ruleIdOut;
-
-            return result;
-        }
-
-        public bool TryGetRuleId(ITableEntryHandle handle, out SonarCompositeRuleId ruleId)
-        {
-            ruleId = null;
-            if (!handle.TryGetSnapshot(out var snapshot, out var index))
+            if (!TryGetSelectedTableEntry(errorList, out var handle) || !TryGetRuleId(handle, out ruleIdOut))
             {
                 return false;
             }
 
-            var errorCode = FindErrorCodeForEntry(snapshot, index);
-            return SonarCompositeRuleId.TryParse(errorCode, out ruleId);
-        }
+            isSuppressedOut = IsSuppressed(handle);
+            return true;
+        });
 
-        public bool TryGetRuleIdAndSuppressionStateFromSelectedRow(out SonarCompositeRuleId ruleId, out bool isSuppressed)
+        ruleId = ruleIdOut;
+        isSuppressed = isSuppressedOut;
+
+        return result;
+    }
+
+    public bool TryGetIssueFromSelectedRow(out IFilterableIssue issue)
+    {
+        IFilterableIssue issueOut = null;
+        var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(
+            errorList => TryGetSelectedTableEntry(errorList, out var handle) && TryGetFilterableIssue(handle, out issueOut));
+
+        issue = issueOut;
+
+        return result;
+    }
+
+    public bool TryGetFilterableIssue(ITableEntryHandle handle, out IFilterableIssue issue)
+    {
+        IFilterableIssue issueOut = null;
+        var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(
+            _ => handle.TryGetSnapshot(out var snapshot, out var index)
+                 && TryGetValue(snapshot, index, SonarLintTableControlConstants.IssueVizColumnName, out issueOut));
+
+        issue = issueOut;
+
+        return result;
+    }
+
+    public bool TryGetRoslynIssueFromSelectedRow(out IFilterableRoslynIssue filterableRoslynIssue)
+    {
+        IFilterableRoslynIssue outIssue = null;
+
+        var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(errorList =>
         {
-            SonarCompositeRuleId ruleIdOut = null;
-            var isSuppressedOut = false;
-            var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(errorList =>
+            string errorCode;
+            if (TryGetSelectedSnapshotAndIndex(errorList, out var snapshot, out var index)
+                && (errorCode = FindErrorCodeForEntry(snapshot, index)) != null
+                && TryGetValue(snapshot, index, StandardTableKeyNames.DocumentName, out string filePath)
+                && TryGetValue(snapshot, index, StandardTableKeyNames.Line, out int line)
+                && TryGetValue(snapshot, index, StandardTableKeyNames.Column, out int column))
             {
-                if (!TryGetSelectedTableEntry(errorList, out var handle) || !TryGetRuleId(handle, out ruleIdOut))
-                {
-                    return false;
-                }
-
-                isSuppressedOut = IsSuppressed(handle);
-                return true;
-            });
-
-            ruleId = ruleIdOut;
-            isSuppressed = isSuppressedOut;
-
-            return result;
-        }
-
-        public bool TryGetIssueFromSelectedRow(out IFilterableIssue issue)
-        {
-            IFilterableIssue issueOut = null;
-            var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(
-                errorList => TryGetSelectedTableEntry(errorList, out var handle) && TryGetFilterableIssue(handle, out issueOut));
-
-            issue = issueOut;
-
-            return result;
-        }
-
-        public bool TryGetFilterableIssue(ITableEntryHandle handle, out IFilterableIssue issue)
-        {
-            IFilterableIssue issueOut = null;
-            var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(
-                _ => handle.TryGetSnapshot(out var snapshot, out var index)
-                     && TryGetValue(snapshot, index, SonarLintTableControlConstants.IssueVizColumnName, out issueOut));
-
-            issue = issueOut;
-
-            return result;
-        }
-
-        public bool TryGetRoslynIssueFromSelectedRow(out IFilterableRoslynIssue filterableRoslynIssue)
-        {
-            IFilterableRoslynIssue outIssue = null;
-
-            var result = vSServiceOperation.Execute<SVsErrorList, IErrorList, bool>(errorList =>
-            {
-                string errorCode;
-                if (TryGetSelectedSnapshotAndIndex(errorList, out var snapshot, out var index)
-                    && (errorCode = FindErrorCodeForEntry(snapshot, index)) != null
-                    && TryGetValue(snapshot, index, StandardTableKeyNames.DocumentName, out string filePath)
-                    && TryGetValue(snapshot, index, StandardTableKeyNames.Line, out int line)
-                    && TryGetValue(snapshot, index, StandardTableKeyNames.Column, out int column))
-                {
-                    outIssue = new FilterableRoslynIssue(errorCode, filePath, line + 1, column + 1 /* error list issues are 0-based and we use 1-based line & column numbers */);
-                }
-
-                return outIssue != null;
-            });
-
-            filterableRoslynIssue = outIssue;
-
-            return result;
-        }
-
-        private static bool IsSuppressed(ITableEntryHandle handle)
-        {
-            return handle.TryGetSnapshot(out var snapshot, out var index)
-                   && TryGetValue(snapshot, index, StandardTableKeyNames.SuppressionState, out SuppressionState suppressionState)
-                   && suppressionState == SuppressionState.Suppressed;
-        }
-
-        private static string FindErrorCodeForEntry(ITableEntriesSnapshot snapshot, int index)
-        {
-            if (!TryGetValue(snapshot, index, StandardTableKeyNames.ErrorCode, out string errorCode))
-            {
-                return null;
+                outIssue = new FilterableRoslynIssue(errorCode, filePath, line + 1, column + 1 /* error list issues are 0-based and we use 1-based line & column numbers */);
             }
 
-            if (TryGetValue(snapshot, index, StandardTableKeyNames.BuildTool, out string buildTool))
-            {
-                // For CSharp and VisualBasic the buildTool returns the name of the analyzer package.
-                // The prefix is required for roslyn languages as the error code is in style "S111" meaning
-                // unlike other languages it has no repository prefix.
-                return buildTool switch
-                {
-                    "SonarAnalyzer.CSharp" => $"{SonarRuleRepoKeys.CSharpRules}:{errorCode}",
-                    "SonarAnalyzer.VisualBasic" => $"{SonarRuleRepoKeys.VBNetRules}:{errorCode}",
-                    "SonarLint" => errorCode,
-                    _ => null
-                };
-            }
+            return outIssue != null;
+        });
 
-            if (TryGetValue(snapshot, index, StandardTableKeyNames.HelpLink, out string helpLink))
-            {
-                if (helpLink.Contains("rules.sonarsource.com/csharp/"))
-                {
-                    return $"{SonarRuleRepoKeys.CSharpRules}:{errorCode}";
-                }
+        filterableRoslynIssue = outIssue;
 
-                if (helpLink.Contains("rules.sonarsource.com/vbnet/"))
-                {
-                    return $"{SonarRuleRepoKeys.VBNetRules}:{errorCode}";
-                }
-            }
+        return result;
+    }
 
+    private static bool IsSuppressed(ITableEntryHandle handle) =>
+        handle.TryGetSnapshot(out var snapshot, out var index)
+        && TryGetValue(snapshot, index, StandardTableKeyNames.SuppressionState, out SuppressionState suppressionState)
+        && suppressionState == SuppressionState.Suppressed;
+
+    private static string FindErrorCodeForEntry(ITableEntriesSnapshot snapshot, int index)
+    {
+        if (!TryGetValue(snapshot, index, StandardTableKeyNames.ErrorCode, out string errorCode))
+        {
             return null;
         }
 
-        private static bool TryGetSelectedSnapshotAndIndex(IErrorList errorList, out ITableEntriesSnapshot snapshot, out int index)
+        if (TryGetValue(snapshot, index, StandardTableKeyNames.BuildTool, out string buildTool))
         {
-            snapshot = default;
-            index = default;
-
-            return TryGetSelectedTableEntry(errorList, out var handle) && handle.TryGetSnapshot(out snapshot, out index);
+            // For CSharp and VisualBasic the buildTool returns the name of the analyzer package.
+            // The prefix is required for roslyn languages as the error code is in style "S111" meaning
+            // unlike other languages it has no repository prefix.
+            return buildTool switch
+            {
+                "SonarAnalyzer.CSharp" => $"{SonarRuleRepoKeys.CSharpRules}:{errorCode}",
+                "SonarAnalyzer.VisualBasic" => $"{SonarRuleRepoKeys.VBNetRules}:{errorCode}",
+                "SonarLint" => errorCode,
+                _ => null
+            };
         }
 
-        private static bool TryGetSelectedTableEntry(IErrorList errorList, out ITableEntryHandle handle)
+        if (TryGetValue(snapshot, index, StandardTableKeyNames.HelpLink, out string helpLink))
         {
-            handle = null;
+            if (helpLink.Contains("rules.sonarsource.com/csharp/"))
+            {
+                return $"{SonarRuleRepoKeys.CSharpRules}:{errorCode}";
+            }
 
-            var selectedItems = errorList?.TableControl?.SelectedEntries;
+            if (helpLink.Contains("rules.sonarsource.com/vbnet/"))
+            {
+                return $"{SonarRuleRepoKeys.VBNetRules}:{errorCode}";
+            }
+        }
 
-            if (selectedItems == null)
+        return null;
+    }
+
+    private static bool TryGetSelectedSnapshotAndIndex(IErrorList errorList, out ITableEntriesSnapshot snapshot, out int index)
+    {
+        snapshot = default;
+        index = default;
+
+        return TryGetSelectedTableEntry(errorList, out var handle) && handle.TryGetSnapshot(out snapshot, out index);
+    }
+
+    private static bool TryGetSelectedTableEntry(IErrorList errorList, out ITableEntryHandle handle)
+    {
+        handle = null;
+
+        var selectedItems = errorList?.TableControl?.SelectedEntries;
+
+        if (selectedItems == null)
+        {
+            return false;
+        }
+
+        foreach (var tableEntryHandle in selectedItems)
+        {
+            if (handle != null)
+            {
+                return false; // more than one selected is not supported
+            }
+
+            handle = tableEntryHandle;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetValue<T>(
+        ITableEntriesSnapshot snapshot,
+        int index,
+        string columnName,
+        out T value)
+    {
+        value = default;
+
+        try
+        {
+            if (!snapshot.TryGetValue(index, columnName, out var objValue) || objValue == null)
             {
                 return false;
             }
 
-            foreach (var tableEntryHandle in selectedItems)
-            {
-                if (handle != null)
-                {
-                    return false; // more than one selected is not supported
-                }
-
-                handle = tableEntryHandle;
-            }
-
+            value = (T)objValue;
             return true;
         }
-
-        private static bool TryGetValue<T>(
-            ITableEntriesSnapshot snapshot,
-            int index,
-            string columnName,
-            out T value)
+        catch (InvalidCastException)
         {
-            value = default;
-
-            try
-            {
-                if (!snapshot.TryGetValue(index, columnName, out var objValue) || objValue == null)
-                {
-                    return false;
-                }
-
-                value = (T)objValue;
-                return true;
-            }
-            catch (InvalidCastException)
-            {
-                return false;
-            }
+            return false;
         }
     }
 }

--- a/src/IssueViz/Models/AnalysisIssueVisualization.cs
+++ b/src/IssueViz/Models/AnalysisIssueVisualization.cs
@@ -18,134 +18,126 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.Text;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Suppressions;
 
-namespace SonarLint.VisualStudio.IssueVisualization.Models
+namespace SonarLint.VisualStudio.IssueVisualization.Models;
+
+public interface IAnalysisIssueVisualization : IAnalysisIssueLocationVisualization, IFilterableIssue
 {
-    public interface IAnalysisIssueVisualization : IAnalysisIssueLocationVisualization, IFilterableIssue
+    IReadOnlyList<IAnalysisIssueFlowVisualization> Flows { get; }
+
+    IAnalysisIssueBase Issue { get; }
+
+    IReadOnlyList<IQuickFixVisualization> QuickFixes { get; }
+
+    bool IsSuppressed { get; set; }
+}
+
+internal class AnalysisIssueVisualization : IAnalysisIssueVisualization
+{
+    private static readonly SnapshotSpan EmptySpan = new();
+    private string currentFilePath;
+    private bool isSuppressed;
+    private SnapshotSpan? span;
+
+    public AnalysisIssueVisualization(
+        IReadOnlyList<IAnalysisIssueFlowVisualization> flows,
+        IAnalysisIssueBase issue,
+        SnapshotSpan? span,
+        IReadOnlyList<IQuickFixVisualization> quickFixes)
     {
-        IReadOnlyList<IAnalysisIssueFlowVisualization> Flows { get; }
-
-        IAnalysisIssueBase Issue { get; }
-
-        IReadOnlyList<IQuickFixVisualization> QuickFixes { get; }
-
-        bool IsSuppressed { get; set; }
+        Flows = flows;
+        Issue = issue;
+        CurrentFilePath = issue.PrimaryLocation.FilePath;
+        Span = span;
+        QuickFixes = quickFixes;
     }
 
-    internal class AnalysisIssueVisualization : IAnalysisIssueVisualization
+    public IReadOnlyList<IAnalysisIssueFlowVisualization> Flows { get; }
+    public IReadOnlyList<IQuickFixVisualization> QuickFixes { get; }
+    public IAnalysisIssueBase Issue { get; }
+    public int StepNumber => 0;
+    public IAnalysisIssueLocation Location => Issue.PrimaryLocation;
+
+    public SnapshotSpan? Span
     {
-        private static readonly SnapshotSpan EmptySpan = new SnapshotSpan();
-        private string currentFilePath;
-        private SnapshotSpan? span;
-        private bool isSuppressed;
-
-        public AnalysisIssueVisualization(IReadOnlyList<IAnalysisIssueFlowVisualization> flows,
-            IAnalysisIssueBase issue, 
-            SnapshotSpan? span,
-            IReadOnlyList<IQuickFixVisualization> quickFixes)
+        get => span;
+        set
         {
-            Flows = flows;
-            Issue = issue;
-            CurrentFilePath = issue.PrimaryLocation.FilePath;
-            Span = span;
-            QuickFixes = quickFixes;
+            span = value;
+            NotifyPropertyChanged();
         }
-
-        public IReadOnlyList<IAnalysisIssueFlowVisualization> Flows { get; }
-        public IReadOnlyList<IQuickFixVisualization> QuickFixes { get; }
-        public IAnalysisIssueBase Issue { get; }
-        public int StepNumber => 0;
-        public IAnalysisIssueLocation Location => Issue.PrimaryLocation;
-
-        public SnapshotSpan? Span
-        {
-            get => span;
-            set
-            {
-                span = value;
-                NotifyPropertyChanged();
-            }
-        }
-
-        public bool IsSuppressed
-        {
-            get => isSuppressed;
-            set
-            {
-                isSuppressed = value;
-                NotifyPropertyChanged();
-            }
-        }
-
-        public string CurrentFilePath
-        {
-            get => currentFilePath;
-            set
-            {
-                currentFilePath = value;
-
-                if (string.IsNullOrEmpty(currentFilePath))
-                {
-                    Span = EmptySpan;
-                }
-            
-                NotifyPropertyChanged();
-            }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected virtual void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        public Guid? IssueId => Issue.Id;
-        string IFilterableIssue.RuleId => Issue.RuleKey;
-
-        string IFilterableIssue.FilePath => CurrentFilePath;
-
-        string IFilterableIssue.LineHash => Issue.PrimaryLocation.TextRange.LineHash;
-
-        int? IFilterableIssue.StartLine => Issue.PrimaryLocation.TextRange.StartLine;
     }
 
-    public static class AnalysisIssueVisualizationExtensions
+    public bool IsSuppressed
     {
-        /// <summary>
-        /// Returns primary and all secondary locations of the given <see cref="issueVisualization"/>
-        /// </summary>
-        public static IEnumerable<IAnalysisIssueLocationVisualization> GetAllLocations(this IAnalysisIssueVisualization issueVisualization)
+        get => isSuppressed;
+        set
         {
-            var primaryLocation = issueVisualization;
-            var secondaryLocations = issueVisualization.GetSecondaryLocations();
-
-            var allLocations = new List<IAnalysisIssueLocationVisualization> {primaryLocation};
-            allLocations.AddRange(secondaryLocations);
-
-            return allLocations;
-        }
-
-        /// <summary>
-        /// Returns all secondary locations of the given <see cref="issueVisualization"/>
-        /// </summary>
-        public static IEnumerable<IAnalysisIssueLocationVisualization> GetSecondaryLocations(this IAnalysisIssueVisualization issueVisualization)
-        {
-            var secondaryLocations = issueVisualization.Flows.SelectMany(x => x.Locations);
-
-            return secondaryLocations;
-        }
-
-        public static bool IsFileLevel(this IAnalysisIssueVisualization issueVisualization)
-        {
-            return issueVisualization.Issue.IsFileLevel();
+            isSuppressed = value;
+            NotifyPropertyChanged();
         }
     }
+
+    public string CurrentFilePath
+    {
+        get => currentFilePath;
+        set
+        {
+            currentFilePath = value;
+
+            if (string.IsNullOrEmpty(currentFilePath))
+            {
+                Span = EmptySpan;
+            }
+
+            NotifyPropertyChanged();
+        }
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public Guid? IssueId => Issue.Id;
+    string IFilterableIssue.RuleId => Issue.RuleKey;
+
+    string IFilterableIssue.FilePath => CurrentFilePath;
+
+    string IFilterableIssue.LineHash => Issue.PrimaryLocation.TextRange.LineHash;
+
+    int? IFilterableIssue.StartLine => Issue.PrimaryLocation.TextRange.StartLine;
+
+    protected virtual void NotifyPropertyChanged([CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+
+public static class AnalysisIssueVisualizationExtensions
+{
+    /// <summary>
+    ///     Returns primary and all secondary locations of the given <see cref="issueVisualization" />
+    /// </summary>
+    public static IEnumerable<IAnalysisIssueLocationVisualization> GetAllLocations(this IAnalysisIssueVisualization issueVisualization)
+    {
+        var primaryLocation = issueVisualization;
+        var secondaryLocations = issueVisualization.GetSecondaryLocations();
+
+        var allLocations = new List<IAnalysisIssueLocationVisualization> { primaryLocation };
+        allLocations.AddRange(secondaryLocations);
+
+        return allLocations;
+    }
+
+    /// <summary>
+    ///     Returns all secondary locations of the given <see cref="issueVisualization" />
+    /// </summary>
+    public static IEnumerable<IAnalysisIssueLocationVisualization> GetSecondaryLocations(this IAnalysisIssueVisualization issueVisualization)
+    {
+        var secondaryLocations = issueVisualization.Flows.SelectMany(x => x.Locations);
+
+        return secondaryLocations;
+    }
+
+    public static bool IsFileLevel(this IAnalysisIssueVisualization issueVisualization) => issueVisualization.Issue.IsFileLevel();
 }


### PR DESCRIPTION
[SLVS-1625](https://sonarsource.atlassian.net/browse/SLVS-1625)

As part of CaYC, replace Moq with Nsubstitute in the touched test classes of [this PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/5830) and clean up the test classes
Also reformat code and execute Resharper’s code cleanup both in the test classes and in the classes under test

[SLVS-1625]: https://sonarsource.atlassian.net/browse/SLVS-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ