### PR TITLE
SLVS-1623 Move CleanCodeAttribute enum conversion from IRuleInfoConverter

### DIFF
--- a/src/Education/Rule/IRuleInfoConverter.cs
+++ b/src/Education/Rule/IRuleInfoConverter.cs
@@ -23,7 +23,6 @@ using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.SLCore.Common.Helpers;
 using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Service.Rules.Models;
-using CleanCodeAttribute = SonarLint.VisualStudio.Core.Analysis.CleanCodeAttribute;
 using IssueSeverity = SonarLint.VisualStudio.SLCore.Common.Models.IssueSeverity;
 using SoftwareQuality = SonarLint.VisualStudio.Core.Analysis.SoftwareQuality;
 
@@ -48,7 +47,7 @@ public class RuleInfoConverter : IRuleInfoConverter
             Convert(details.severityDetails.Left?.severity),
             Convert(details.severityDetails.Left?.type),
             details.description?.Right,
-            Convert(details.severityDetails.Right?.cleanCodeAttribute),
+            (details.severityDetails.Right?.cleanCodeAttribute).ToCleanCodeAttribute(),
             Convert(details.severityDetails.Right?.impacts));
 
     private static RuleIssueSeverity? Convert(IssueSeverity? issueSeverity) =>
@@ -72,27 +71,6 @@ public class RuleInfoConverter : IRuleInfoConverter
             RuleType.SECURITY_HOTSPOT => RuleIssueType.Hotspot,
             null => null,
             _ => throw new ArgumentOutOfRangeException(nameof(ruleType), ruleType, null)
-        };
-
-    private static CleanCodeAttribute? Convert(SLCore.Common.Models.CleanCodeAttribute? cleanCodeAttribute) =>
-        cleanCodeAttribute switch
-        {
-            SLCore.Common.Models.CleanCodeAttribute.CONVENTIONAL => CleanCodeAttribute.Conventional,
-            SLCore.Common.Models.CleanCodeAttribute.FORMATTED => CleanCodeAttribute.Formatted,
-            SLCore.Common.Models.CleanCodeAttribute.IDENTIFIABLE => CleanCodeAttribute.Identifiable,
-            SLCore.Common.Models.CleanCodeAttribute.CLEAR => CleanCodeAttribute.Clear,
-            SLCore.Common.Models.CleanCodeAttribute.COMPLETE => CleanCodeAttribute.Complete,
-            SLCore.Common.Models.CleanCodeAttribute.EFFICIENT => CleanCodeAttribute.Efficient,
-            SLCore.Common.Models.CleanCodeAttribute.LOGICAL => CleanCodeAttribute.Logical,
-            SLCore.Common.Models.CleanCodeAttribute.DISTINCT => CleanCodeAttribute.Distinct,
-            SLCore.Common.Models.CleanCodeAttribute.FOCUSED => CleanCodeAttribute.Focused,
-            SLCore.Common.Models.CleanCodeAttribute.MODULAR => CleanCodeAttribute.Modular,
-            SLCore.Common.Models.CleanCodeAttribute.TESTED => CleanCodeAttribute.Tested,
-            SLCore.Common.Models.CleanCodeAttribute.LAWFUL => CleanCodeAttribute.Lawful,
-            SLCore.Common.Models.CleanCodeAttribute.RESPECTFUL => CleanCodeAttribute.Respectful,
-            SLCore.Common.Models.CleanCodeAttribute.TRUSTWORTHY => CleanCodeAttribute.Trustworthy,
-            null => null,
-            _ => throw new ArgumentOutOfRangeException(nameof(cleanCodeAttribute), cleanCodeAttribute, null)
         };
 
     private static Dictionary<SoftwareQuality, SoftwareQualitySeverity> Convert(List<ImpactDto> cleanCodeAttribute) =>

--- a/src/SLCore.UnitTests/Common/Helpers/ModelConversionExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/ModelConversionExtensionsTests.cs
@@ -21,7 +21,9 @@
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.SLCore.Common.Helpers;
 using SonarLint.VisualStudio.SLCore.Common.Models;
+using SonarLint.VisualStudio.SLCore.Service.Rules.Models;
 using SoftwareQuality = SonarLint.VisualStudio.Core.Analysis.SoftwareQuality;
+using CleanCodeAttribute = SonarLint.VisualStudio.Core.Analysis.CleanCodeAttribute;
 
 namespace SonarLint.VisualStudio.SLCore.UnitTests.Common.Helpers;
 
@@ -190,6 +192,41 @@ public class ModelConversionExtensionsTests
         act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("""
                                                                       Unexpected enum value
                                                                       Parameter name: softwareQuality
+                                                                      Actual value was 1000.
+                                                                      """);
+    }
+
+    [TestMethod]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.CONVENTIONAL, CleanCodeAttribute.Conventional)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.FORMATTED, CleanCodeAttribute.Formatted)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.IDENTIFIABLE, CleanCodeAttribute.Identifiable)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.CLEAR, CleanCodeAttribute.Clear)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.COMPLETE, CleanCodeAttribute.Complete)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.EFFICIENT, CleanCodeAttribute.Efficient)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.LOGICAL, CleanCodeAttribute.Logical)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.DISTINCT, CleanCodeAttribute.Distinct)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.FOCUSED, CleanCodeAttribute.Focused)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.MODULAR, CleanCodeAttribute.Modular)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.TESTED, CleanCodeAttribute.Tested)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.LAWFUL, CleanCodeAttribute.Lawful)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.RESPECTFUL, CleanCodeAttribute.Respectful)]
+    [DataRow(SLCore.Common.Models.CleanCodeAttribute.TRUSTWORTHY, CleanCodeAttribute.Trustworthy)]
+    [DataRow(null, null)]
+    public void ToCleanCodeAttribute_ConvertsCorrectly(SLCore.Common.Models.CleanCodeAttribute? slCoreCleanCodeAttribute, CleanCodeAttribute? expected)
+    {
+        var result = slCoreCleanCodeAttribute.ToCleanCodeAttribute();
+
+        result.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void ToCleanCodeAttribute_ValueOutOfRange_Throws()
+    {
+        var act = () => ((SLCore.Common.Models.CleanCodeAttribute?)1000).ToCleanCodeAttribute();
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("""
+                                                                      Unexpected enum value
+                                                                      Parameter name: cleanCodeAttribute
                                                                       Actual value was 1000.
                                                                       """);
     }

--- a/src/SLCore/Common/Helpers/ModelConversionExtensions.cs
+++ b/src/SLCore/Common/Helpers/ModelConversionExtensions.cs
@@ -21,6 +21,7 @@
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.SLCore.Common.Models;
 using SoftwareQuality = SonarLint.VisualStudio.Core.Analysis.SoftwareQuality;
+using CleanCodeAttribute = SonarLint.VisualStudio.Core.Analysis.CleanCodeAttribute;
 
 namespace SonarLint.VisualStudio.SLCore.Common.Helpers;
 
@@ -75,6 +76,27 @@ public static class ModelConversionExtensions
             Models.SoftwareQuality.RELIABILITY => SoftwareQuality.Reliability,
             Models.SoftwareQuality.SECURITY => SoftwareQuality.Security,
             _ => throw new ArgumentOutOfRangeException(nameof(softwareQuality), softwareQuality, SLCoreStrings.ModelExtensions_UnexpectedValue)
+        };
+
+    public static CleanCodeAttribute? ToCleanCodeAttribute(this SLCore.Common.Models.CleanCodeAttribute? cleanCodeAttribute) =>
+        cleanCodeAttribute switch
+        {
+            SLCore.Common.Models.CleanCodeAttribute.CONVENTIONAL => CleanCodeAttribute.Conventional,
+            SLCore.Common.Models.CleanCodeAttribute.FORMATTED => CleanCodeAttribute.Formatted,
+            SLCore.Common.Models.CleanCodeAttribute.IDENTIFIABLE => CleanCodeAttribute.Identifiable,
+            SLCore.Common.Models.CleanCodeAttribute.CLEAR => CleanCodeAttribute.Clear,
+            SLCore.Common.Models.CleanCodeAttribute.COMPLETE => CleanCodeAttribute.Complete,
+            SLCore.Common.Models.CleanCodeAttribute.EFFICIENT => CleanCodeAttribute.Efficient,
+            SLCore.Common.Models.CleanCodeAttribute.LOGICAL => CleanCodeAttribute.Logical,
+            SLCore.Common.Models.CleanCodeAttribute.DISTINCT => CleanCodeAttribute.Distinct,
+            SLCore.Common.Models.CleanCodeAttribute.FOCUSED => CleanCodeAttribute.Focused,
+            SLCore.Common.Models.CleanCodeAttribute.MODULAR => CleanCodeAttribute.Modular,
+            SLCore.Common.Models.CleanCodeAttribute.TESTED => CleanCodeAttribute.Tested,
+            SLCore.Common.Models.CleanCodeAttribute.LAWFUL => CleanCodeAttribute.Lawful,
+            SLCore.Common.Models.CleanCodeAttribute.RESPECTFUL => CleanCodeAttribute.Respectful,
+            SLCore.Common.Models.CleanCodeAttribute.TRUSTWORTHY => CleanCodeAttribute.Trustworthy,
+            null => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(cleanCodeAttribute), cleanCodeAttribute, SLCoreStrings.ModelExtensions_UnexpectedValue)
         };
 
     public static Impact ToImpact(this ImpactDto impact) => new(impact.softwareQuality.ToSoftwareQuality(), impact.impactSeverity.ToSoftwareQualitySeverity());


### PR DESCRIPTION
[SLVS-1623](https://sonarsource.atlassian.net/browse/SLVS-1623)

The other enums RuleIssueType, RuleIssueSeverity can not be moved, because they are specific to the Education assembly 

[SLVS-1623]: https://sonarsource.atlassian.net/browse/SLVS-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ