### PR TITLE
SLVS-1647 On taint update with changed id, fallback to match by server key

### DIFF
--- a/src/IssueViz.Security.UnitTests/Taint/TaintStoreTests.cs
+++ b/src/IssueViz.Security.UnitTests/Taint/TaintStoreTests.cs
@@ -332,18 +332,18 @@ public class TaintStoreTests
         const string serverKey = "taint-1";
         var taintWithChangedId = SetupIssueViz(issueKey: serverKey);
         List<IAnalysisIssueVisualization> analysisIssueVisualizations = [taintWithChangedId, SetupIssueViz(), SetupIssueViz()];
-        var updated1 = SetupIssueViz(issueKey: serverKey);
+        var updated = SetupIssueViz(issueKey: serverKey);
         testSubject.Set(analysisIssueVisualizations, "some config scope");
         var receivedEventGetter = CaptureIssuesChangedEventArgs();
 
         using (new AssertIgnoreScope())
         {
-            testSubject.Update(new TaintVulnerabilitiesUpdate("some config scope", [], [updated1], []));
+            testSubject.Update(new TaintVulnerabilitiesUpdate("some config scope", [], [updated], []));
         }
 
         testSubject.GetAll().Should().NotContain(taintWithChangedId);
-        testSubject.GetAll().Should().Contain(updated1);
-        receivedEventGetter().Should().BeEquivalentTo(new IssuesChangedEventArgs([updated1], [taintWithChangedId]));
+        testSubject.GetAll().Should().Contain(updated);
+        receivedEventGetter().Should().BeEquivalentTo(new IssuesChangedEventArgs([taintWithChangedId], [updated]));
     }
 
     [TestMethod]

--- a/src/IssueViz.Security/Taint/TaintStore.cs
+++ b/src/IssueViz.Security/Taint/TaintStore.cs
@@ -149,9 +149,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
                     return;
                 }
 
-                HandleClosed(taintVulnerabilitiesUpdate.Closed, diffAdded);
+                HandleClosed(taintVulnerabilitiesUpdate.Closed, diffRemoved);
                 HandleUpdated(taintVulnerabilitiesUpdate.Updated, diffRemoved, diffAdded);
-                HandleAdded(taintVulnerabilitiesUpdate.Added, diffRemoved);
+                HandleAdded(taintVulnerabilitiesUpdate.Added, diffAdded);
             }
 
             NotifyIfIssuesChanged(diffAdded, diffRemoved);
@@ -161,7 +161,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
         {
             if (diffAdded.Count != 0 || diffRemoved.Count != 0)
             {
-                NotifyIssuesChanged(diffAdded, diffRemoved);
+                NotifyIssuesChanged(diffRemoved, diffAdded);
             }
         }
 
@@ -234,7 +234,8 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
                 return outdatedVulnerabilityByIssueId;
             }
 
-            var outdatedVulnerabilityByServerKey = MatchByServerKey(taintVulnerability);
+            var issueKey = ((ITaintIssue) taintVulnerability.Issue).IssueKey;
+            var outdatedVulnerabilityByServerKey = MatchByServerKey(issueKey);
             if (outdatedVulnerabilityByServerKey != null)
             {
                 // Taint was not found by issue id, but was found by server key
@@ -248,9 +249,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
             return null;
         }
 
-        private IAnalysisIssueVisualization MatchByServerKey(IAnalysisIssueVisualization taintVulnerability) =>
+        private IAnalysisIssueVisualization MatchByServerKey(string issueKey) =>
             taintVulnerabilities
-                .Where(x => ((ITaintIssue) x.Value.Issue).IssueKey == ((ITaintIssue) taintVulnerability.Issue).IssueKey)
+                .Where(x => ((ITaintIssue) x.Value.Issue).IssueKey == issueKey)
                 .Select(x => x.Value)
                 .FirstOrDefault();
     }

--- a/src/IssueViz.Security/Taint/TaintStore.cs
+++ b/src/IssueViz.Security/Taint/TaintStore.cs
@@ -140,8 +140,8 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
         {
             ValidateUpdate(taintVulnerabilitiesUpdate);
 
-            List<IAnalysisIssueVisualization> diffAdded = [];
             List<IAnalysisIssueVisualization> diffRemoved = [];
+            List<IAnalysisIssueVisualization> diffAdded = [];
             lock (locker)
             {
                 if (taintVulnerabilitiesUpdate.ConfigurationScope != configurationScope)
@@ -154,12 +154,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Taint
                 HandleAdded(taintVulnerabilitiesUpdate.Added, diffAdded);
             }
 
-            NotifyIfIssuesChanged(diffAdded, diffRemoved);
-        }
-
-        private void NotifyIfIssuesChanged(List<IAnalysisIssueVisualization> diffAdded, List<IAnalysisIssueVisualization> diffRemoved)
-        {
-            if (diffAdded.Count != 0 || diffRemoved.Count != 0)
+            if (diffRemoved.Count != 0 || diffAdded.Count != 0)
             {
                 NotifyIssuesChanged(diffRemoved, diffAdded);
             }


### PR DESCRIPTION
[SLVS-1647](https://sonarsource.atlassian.net/browse/SLVS-1647)



[SLVS-1647]: https://sonarsource.atlassian.net/browse/SLVS-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ