### PR TITLE
SLVS-1668 Include header file language in the VCX command

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
@@ -314,14 +314,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
             cmdBuilder.AddOptFromProperties(settingsMock.Object);
 
             cmdBuilder.GetFullCmd().Should().Be(cmd);
-            cmdBuilder.HeaderFileLang.Should().Be("");
         }
 
         [TestMethod]
-        [DataRow("Default", "cpp", "")]
-        [DataRow("CompileAsC", "c", "/TC ")]
-        [DataRow("CompileAsCpp", "cpp", "/TP ")]
-        public void HeaderFileLang(string compileAs, string lang, string cmd)
+        [DataRow("Default", "")]
+        [DataRow("CompileAsC", "/TC ")]
+        [DataRow("CompileAsCpp", "/TP ")]
+        public void HeaderFileLang(string compileAs, string cmd)
         {
             var cmdBuilder = new CmdBuilder(true);
             var settingsMock = new Mock<IVCRulePropertyStorage>();
@@ -330,7 +329,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
             cmdBuilder.AddOptFromProperties(settingsMock.Object);
 
             cmdBuilder.GetFullCmd().Should().Be(cmd);
-            cmdBuilder.HeaderFileLang.Should().Be(lang);
         }
 
         [TestMethod]
@@ -391,7 +389,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
 
             cmdBuilder.AddOptFromProperties(settingsMock.Object);
             cmdBuilder.GetFullCmd().Should().Be("/Yc\"C:\\pch.h\" ");
-            cmdBuilder.HeaderFileLang.Should().Be("");
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
@@ -318,10 +318,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
         }
 
         [TestMethod]
-        [DataRow("Default", "cpp")]
-        [DataRow("CompileAsC", "c")]
-        [DataRow("CompileAsCpp", "cpp")]
-        public void HeaderFileLang(string compileAs, string lang)
+        [DataRow("Default", "cpp", "")]
+        [DataRow("CompileAsC", "c", "/TC ")]
+        [DataRow("CompileAsCpp", "cpp", "/TP ")]
+        public void HeaderFileLang(string compileAs, string lang, string cmd)
         {
             var cmdBuilder = new CmdBuilder(true);
             var settingsMock = new Mock<IVCRulePropertyStorage>();
@@ -329,7 +329,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
 
             cmdBuilder.AddOptFromProperties(settingsMock.Object);
 
-            cmdBuilder.GetFullCmd().Should().Be("");
+            cmdBuilder.GetFullCmd().Should().Be(cmd);
             cmdBuilder.HeaderFileLang.Should().Be(lang);
         }
 

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
@@ -185,8 +185,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             request = FileConfig.TryGet(testLogger, projectItemMock.Object, "c:\\dummy\\file.h");
 
             // Assert
-            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TC \"c:\\dummy\\file.h\"", request.CDCommand);
             Assert.AreEqual("c", request.HeaderFileLanguage);
+
+            // Arrange
+            projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsCpp";
+
+            // Act
+            request = FileConfig.TryGet(testLogger, projectItemMock.Object, "c:\\dummy\\file.h");
+
+            // Assert
+            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TP \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("cpp", request.HeaderFileLanguage);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
@@ -139,7 +139,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             // Assert
             request.Should().NotBeNull();
             Assert.AreEqual("\"C:\\path\\cl.exe\" /permissive- /std:c++17 /EHsc /arch:AVX512 /MT /RTCu /Zp8 /TP /DA \"c:\\dummy\\file.cpp\"", request.CDCommand);
-            Assert.AreEqual("", request.HeaderFileLanguage);
             Assert.AreEqual("C:\\path\\includeDir1;C:\\path\\includeDir2;C:\\path\\includeDir3;", request.EnvInclude);
             Assert.AreEqual("c:\\dummy\\file.cpp", request.CDFile);
             Assert.AreEqual("c:\\foo", request.CDDirectory);
@@ -175,7 +174,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             // Assert
             request.Should().NotBeNull();
             Assert.AreEqual("\"C:\\path\\cl.exe\" /Yu\"pch.h\" /FI\"pch.h\" /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
-            Assert.AreEqual("cpp", request.HeaderFileLanguage);
 
             // Arrange
             projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsC";
@@ -186,7 +184,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TC \"c:\\dummy\\file.h\"", request.CDCommand);
-            Assert.AreEqual("c", request.HeaderFileLanguage);
 
             // Arrange
             projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsCpp";
@@ -196,7 +193,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TP \"c:\\dummy\\file.h\"", request.CDCommand);
-            Assert.AreEqual("cpp", request.HeaderFileLanguage);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
@@ -174,7 +174,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             // Assert
             request.Should().NotBeNull();
             Assert.AreEqual("\"C:\\path\\cl.exe\" /Yu\"pch.h\" /FI\"pch.h\" /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
-            Assert.AreEqual("non_existent_file", request.CDFile);
+            Assert.AreEqual("c:\\dummy\\file.h", request.CDFile);
 
             // Arrange
             projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsC";
@@ -185,7 +185,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TC \"c:\\dummy\\file.h\"", request.CDCommand);
-            Assert.AreEqual("non_existent_file", request.CDFile);
+            Assert.AreEqual("c:\\dummy\\file.h", request.CDFile);
 
             // Arrange
             projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsCpp";
@@ -195,7 +195,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TP \"c:\\dummy\\file.h\"", request.CDCommand);
-            Assert.AreEqual("non_existent_file", request.CDFile);
+            Assert.AreEqual("c:\\dummy\\file.h", request.CDFile);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
@@ -174,6 +174,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             // Assert
             request.Should().NotBeNull();
             Assert.AreEqual("\"C:\\path\\cl.exe\" /Yu\"pch.h\" /FI\"pch.h\" /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("non_existent_file", request.CDFile);
 
             // Arrange
             projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsC";
@@ -184,6 +185,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TC \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("non_existent_file", request.CDFile);
 
             // Arrange
             projectItemConfig.FileConfigProperties["CompileAs"] = "CompileAsCpp";
@@ -193,6 +195,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TP \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("non_existent_file", request.CDFile);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
@@ -39,7 +39,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
 
         StringBuilder Cmd { get; set; } = new StringBuilder();
         bool IsHeader { get; set; }
-        public string HeaderFileLang { get; set; } = "";
 
         public CmdBuilder(bool isHeader)
         {
@@ -167,10 +166,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
             AddCmdOpt(ConvertStructMemberAlignment(structMemberAlignment));
 
             var compileAs = properties.GetEvaluatedPropertyValue("CompileAs");
-            if (IsHeader)
-            {
-                HeaderFileLang = (compileAs == "CompileAsC") ? "c" : "cpp";
-            }
             AddCmdOpt(ConvertCompileAsAndGetLanguage(compileAs));
 
             // Additional options

--- a/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
@@ -171,10 +171,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
             {
                 HeaderFileLang = (compileAs == "CompileAsC") ? "c" : "cpp";
             }
-            else
-            {
-                AddCmdOpt(ConvertCompileAsAndGetLanguage(compileAs));
-            }
+            AddCmdOpt(ConvertCompileAsAndGetLanguage(compileAs));
 
             // Additional options
             var additionalOptions = properties.GetEvaluatedPropertyValue("AdditionalOptions");

--- a/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
@@ -45,6 +45,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
                 // Not supported
                 return null;
             }
+
             CmdBuilder cmdBuilder = new CmdBuilder(vcFile.ItemType == "ClInclude");
 
             var compilerPath = vcConfig.GetEvaluatedPropertyValue("ClCompilerPath");
@@ -76,7 +77,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
                 CDCommand = cmdBuilder.GetFullCmd(),
                 CDFile = absoluteFilePath,
                 EnvInclude = envINCLUDE,
-                HeaderFileLanguage = cmdBuilder.HeaderFileLang,
             };
         }
 
@@ -134,7 +134,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
         public string CDCommand { get; set; }
         public string CDFile { get; set; }
         public string EnvInclude { get; set; }
-        public string HeaderFileLanguage { get; set; }
+
         #endregion
 
     }

--- a/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
@@ -46,7 +46,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
                 return null;
             }
 
-            CmdBuilder cmdBuilder = new CmdBuilder(vcFile.ItemType == "ClInclude");
+            var isHeader = vcFile.ItemType == "ClInclude";
+            CmdBuilder cmdBuilder = new CmdBuilder(isHeader);
 
             var compilerPath = vcConfig.GetEvaluatedPropertyValue("ClCompilerPath");
             if (string.IsNullOrEmpty(compilerPath))
@@ -75,7 +76,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
             {
                 CDDirectory = Path.GetDirectoryName(vcProject.ProjectFile),
                 CDCommand = cmdBuilder.GetFullCmd(),
-                CDFile = absoluteFilePath,
+                // A hack to communicate with the CFamily analyzer that this is a header file.
+                // A long-term solution should be investigated in CPP-5898.
+                CDFile = isHeader ? "non_existent_file" : absoluteFilePath,
                 EnvInclude = envINCLUDE,
             };
         }

--- a/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
@@ -46,8 +46,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
                 return null;
             }
 
-            var isHeader = vcFile.ItemType == "ClInclude";
-            CmdBuilder cmdBuilder = new CmdBuilder(isHeader);
+            CmdBuilder cmdBuilder = new CmdBuilder(vcFile.ItemType == "ClInclude");
 
             var compilerPath = vcConfig.GetEvaluatedPropertyValue("ClCompilerPath");
             if (string.IsNullOrEmpty(compilerPath))
@@ -76,9 +75,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
             {
                 CDDirectory = Path.GetDirectoryName(vcProject.ProjectFile),
                 CDCommand = cmdBuilder.GetFullCmd(),
-                // A hack to communicate with the CFamily analyzer that this is a header file.
-                // A long-term solution should be investigated in CPP-5898.
-                CDFile = isHeader ? "non_existent_file" : absoluteFilePath,
+                CDFile = absoluteFilePath,
                 EnvInclude = envINCLUDE,
             };
         }

--- a/src/Integration.Vsix/CFamily/VcxProject/IFileConfig.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/IFileConfig.cs
@@ -26,6 +26,5 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
         string CDCommand { get; }
         string CDFile { get; }
         string EnvInclude { get; }
-        string HeaderFileLanguage { get; }
     }
 }


### PR DESCRIPTION
[SLVS-1668](https://sonarsource.atlassian.net/browse/SLVS-1668)

Part of SLVS-1637

See the linked ticket for details about the problems we identified. This PR introduces the following changes:

- To communicate the header file language, I am adding the relevant switches to the generated command in the header case as well. This helps analyze C headers as such when they are located inside C VCX projects.
- Since `HeaderFileLanguage` is no longer needed, I am removing it from `FileConfig`.

[SLVS-1668]: https://sonarsource.atlassian.net/browse/SLVS-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ