### PR TITLE
SLVS-1648 Update Sonar CFamily to 6.61.0.77816

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <!-- Note: Guide on how to update the analyzers is on the xtranet! -->
     <EmbeddedSonarAnalyzerVersion>10.3.0.106239</EmbeddedSonarAnalyzerVersion>
-    <EmbeddedSonarCFamilyAnalyzerVersion>6.60.0.76379</EmbeddedSonarCFamilyAnalyzerVersion>
+    <EmbeddedSonarCFamilyAnalyzerVersion>6.61.0.77816</EmbeddedSonarCFamilyAnalyzerVersion>
     <EmbeddedSonarJSAnalyzerVersion>10.18.0.28572</EmbeddedSonarJSAnalyzerVersion>
     <EmbeddedSonarSecretsJarVersion>2.16.0.4008</EmbeddedSonarSecretsJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->

--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyEmbeddedSonarWayRulesTests.cs
@@ -46,12 +46,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
         // e.g. https://next.sonarqube.com/sonarqube/api/plugins/installed and https://sonarcloud.io/api/plugins/installed
         // Note - you need to be logged in.
 
-        // Rule data for C-Family plugin v6.57.0.73017
+        // Rule data for C-Family plugin v6.61.0.77816
 
-        private const int Active_C_Rules = 209;
+        private const int Active_C_Rules = 211;
         private const int Inactive_C_Rules = 130;
 
-        private const int Active_CPP_Rules = 445;
+        private const int Active_CPP_Rules = 453;
         private const int Inactive_CPP_Rules = 219;
 
         private readonly CFamilySonarWayRulesConfigProvider rulesMetadataCache = new CFamilySonarWayRulesConfigProvider(CFamilyShared.CFamilyFilesDirectory);


### PR DESCRIPTION
[SLVS-1648](https://sonarsource.atlassian.net/browse/SLVS-1648)



[SLVS-1648]: https://sonarsource.atlassian.net/browse/SLVS-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ