### PR TITLE
SLVS-1712 Fix QG caused by "parameter being captured into the state of the enclosing type and its value is also used to initialize a field"

### DIFF
--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsViewModel.cs
@@ -171,7 +171,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 
         private bool DeleteBindings(List<string> connectionReferences)
         {
-            var currentSolutionName = connectedModeBindingServices.SolutionInfoProvider.GetSolutionName();
+            var currentSolutionName = ConnectedModeBindingServices.SolutionInfoProvider.GetSolutionName();
             foreach (var connectionReference in connectionReferences)
             {
                 var bindingDeleted = currentSolutionName == connectionReference ? ConnectedModeBindingServices.BindingController.Unbind(connectionReference) : ConnectedModeBindingServices.SolutionBindingRepository.DeleteBinding(connectionReference);


### PR DESCRIPTION
[SLVS-1712](https://sonarsource.atlassian.net/browse/SLVS-1712)

Fix QG caused by "parameter being captured into the state of the enclosing type and its value is also used to initialize a field"


[SLVS-1712]: https://sonarsource.atlassian.net/browse/SLVS-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ