### PR TITLE
SLVS-1721 Fix "Use shared configuration" button not shown after unbind

### DIFF
--- a/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
@@ -333,6 +333,42 @@ public class ManageBindingViewModelTests
     }
 
     [TestMethod]
+    public void IsUseSharedBindingButtonVisible_SharedBindingConfigExistsAndProjectIsBound_ReturnsFalse()
+    {
+        testSubject.SharedBindingConfigModel = new SharedBindingConfigModel();
+        testSubject.BoundProject = serverProject;
+
+        testSubject.IsUseSharedBindingButtonVisible.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void IsUseSharedBindingButtonVisible_SharedBindingConfigExistsAndProjectIsUnbound_ReturnsTrue()
+    {
+        testSubject.SharedBindingConfigModel = new SharedBindingConfigModel();
+        testSubject.BoundProject = null;
+
+        testSubject.IsUseSharedBindingButtonVisible.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void IsUseSharedBindingButtonVisible_SharedBindingConfigDoesNotExistAndProjectIsBound_ReturnsFalse()
+    {
+        testSubject.SharedBindingConfigModel = null;
+        testSubject.BoundProject = serverProject;
+
+        testSubject.IsUseSharedBindingButtonVisible.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void IsUseSharedBindingButtonVisible_SharedBindingConfigDoesNotExistAndProjectIsUnbound_ReturnsFalse()
+    {
+        testSubject.SharedBindingConfigModel = null;
+        testSubject.BoundProject = null;
+
+        testSubject.IsUseSharedBindingButtonVisible.Should().BeFalse();
+    }
+
+    [TestMethod]
     public void SharedBindingConfigModel_Set_RaisesEvents()
     {
         var eventHandler = Substitute.For<PropertyChangedEventHandler>();
@@ -584,13 +620,13 @@ public class ManageBindingViewModelTests
     }
     
     [TestMethod]
-    public async Task InitializeDataAsync_WhenBound_DoesNotChecksForSharedBindingAndReportsProgress()
+    public async Task InitializeDataAsync_WhenBound_ChecksForSharedBindingAndReportsProgress()
     {
         testSubject.BoundProject = serverProject;
         
         await testSubject.InitializeDataAsync();
 
-        await progressReporterViewModel.DidNotReceive()
+        await progressReporterViewModel.Received(1)
             .ExecuteTaskWithProgressAsync(
                 Arg.Is<TaskToPerformParams<AdapterResponse>>(x =>
                     x.TaskToPerform == testSubject.CheckForSharedBindingAsync &&

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
@@ -141,12 +141,10 @@ public sealed class ManageBindingViewModel : ViewModelBase, IDisposable
             UiResources.FetchingBindingStatusFailedText) { AfterProgressUpdated = OnProgressUpdated };
         await ProgressReporter.ExecuteTaskWithProgressAsync(displayBindStatus);
 
-        if (!IsCurrentProjectBound)
-        {
-            var detectSharedBinding = new TaskToPerformParams<AdapterResponse>(CheckForSharedBindingAsync, UiResources.CheckingForSharedBindingText,
-                UiResources.CheckingForSharedBindingFailedText) { AfterProgressUpdated = OnProgressUpdated };
-            await ProgressReporter.ExecuteTaskWithProgressAsync(detectSharedBinding);
-        }
+        var detectSharedBinding = new TaskToPerformParams<AdapterResponse>(CheckForSharedBindingAsync, UiResources.CheckingForSharedBindingText,
+                UiResources.CheckingForSharedBindingFailedText)
+            { AfterProgressUpdated = OnProgressUpdated };
+        await ProgressReporter.ExecuteTaskWithProgressAsync(detectSharedBinding);
     }
 
     public async Task BindWithProgressAsync()


### PR DESCRIPTION
[SLVS-1721](https://sonarsource.atlassian.net/browse/SLVS-1721)



[SLVS-1721]: https://sonarsource.atlassian.net/browse/SLVS-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ