### PR TITLE
SLVS-1735 Change mapping of SLCore INFO logs from verbose to regular

### DIFF
--- a/src/SLCore.Listeners.UnitTests/Logging/LoggerListenerTests.cs
+++ b/src/SLCore.Listeners.UnitTests/Logging/LoggerListenerTests.cs
@@ -42,7 +42,7 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.UnitTests.Logging
         [TestMethod]
         [DataRow(LogLevel.ERROR, false)]
         [DataRow(LogLevel.WARN, false)]
-        [DataRow(LogLevel.INFO, true)]
+        [DataRow(LogLevel.INFO, false)]
         [DataRow(LogLevel.TRACE, true)]
         [DataRow(LogLevel.DEBUG, true)]
         public void Log_LogInfoTraceAndDebugAsVerbose(LogLevel logLevel, bool verboseLogs)

--- a/src/SLCore.Listeners/Implementation/LoggerListener.cs
+++ b/src/SLCore.Listeners/Implementation/LoggerListener.cs
@@ -45,10 +45,10 @@ public class LoggerListener : ILoggerListener
         {
             case LogLevel.ERROR:
             case LogLevel.WARN:
+            case LogLevel.INFO:
                 logger.WriteLine(message);
                 break;
 
-            case LogLevel.INFO:
             case LogLevel.DEBUG:
             case LogLevel.TRACE:
                 logger.LogVerbose(message);


### PR DESCRIPTION
[SLVS-1735](https://sonarsource.atlassian.net/browse/SLVS-1735)

