### PR TITLE
SLVS-1717 Fix C++ Language standard recognition when a C language standard is also specified

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CFamilyTestUtility.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CFamilyTestUtility.cs
@@ -55,7 +55,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
 
         private static readonly ProjectItemConfig DefaultSetting = new ProjectItemConfig();
 
-        internal static Mock<ProjectItem> CreateMockProjectItem(string projectName, ProjectItemConfig projectItemConfig = null)
+        internal static Mock<ProjectItem> CreateMockProjectItem(string projectName, ProjectItemConfig projectItemConfig = null, string contentType = null)
         {
             projectItemConfig ??= DefaultSetting;
 
@@ -70,6 +70,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.UnitTests
 
             var vcFileMock = new Mock<VCFile>();
             vcFileMock.SetupGet(x => x.ItemType).Returns(projectItemConfig.ItemType);
+            vcFileMock.SetupGet(x => x.ContentType).Returns(contentType);
             vcFileMock.Setup(x => x.GetFileConfigurationForProjectConfiguration(vcConfig)).Returns(vcFileConfigMock.Object);
 
             var projectMock = new ProjectMock(projectName) { Project = vcProjectMock.Object };

--- a/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
@@ -13,6 +13,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -235,12 +236,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
         [DataTestMethod]
         [DataRow(false, "", "", "")]
         [DataRow(true, "", "", "")]
-        [DataRow(false, "1", "", "1 ")]
-        [DataRow(true, "1", "", "1 ")]
-        [DataRow(false, "", "2", "2 ")]
-        [DataRow(true, "", "2", "2 ")]
-        [DataRow(false, "1", "2", "1 2 ")]
-        [DataRow(true, "1", "2", "1 2 ")]
+        [DataRow(false, "compileAsFlagValue", "", "compileAsFlagValue ")]
+        [DataRow(true, "compileAsFlagValue", "", "compileAsFlagValue ")]
+        [DataRow(false, "", "languageStandardFlagValue", "languageStandardFlagValue ")]
+        [DataRow(true, "", "languageStandardFlagValue", "languageStandardFlagValue ")]
+        [DataRow(false, "compileAsFlagValue", "compileAsFlagValue", "compileAsFlagValue compileAsFlagValue ")]
+        [DataRow(true, "compileAsFlagValue", "compileAsFlagValue", "compileAsFlagValue compileAsFlagValue ")]
         public void AddOptFromProperties_DelegatesToLanguageFlagsProvider_AddsAvailableLanguageFlags(bool isHeader, string compileAsFlag, string languageStandardFlag, string expectedCmd)
         {
             var languageFlagsProvider = Substitute.For<ILanguageFlagsProvider>();

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/CompileAsValueConverterTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/CompileAsValueConverterTests.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject;
+
+[TestClass]
+public class CompileAsValueConverterTests
+{
+    [TestMethod]
+    [DataRow("", "")]
+    [DataRow("Default", "")]
+    [DataRow("CompileAsC", "/TC")]
+    [DataRow("CompileAsCpp", "/TP")]
+    public void GetFlagValue_ConvertsToCorrectFlagValue(string input, string output) =>
+        CompileAsValueConverter.GetFlagValue(input).Should().Be(output);
+
+    [TestMethod]
+    public void GetFlagValue_UnsupportedPropertyValue_Throws()
+    {
+        var act = () => CompileAsValueConverter.GetFlagValue("INVALID");
+
+        act.Should().Throw<ArgumentException>().WithMessage("Unsupported CompileAs: INVALID");
+    }
+}

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
@@ -130,21 +130,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             var projectItemConfig = new ProjectItemConfig
             {
                 ItemType = "ClCompile",
-                FileConfigProperties = new Dictionary<string, string>
+                FileConfigProperties = CreateDefaultClCompileFileProperties(new Dictionary<string, string>
                 {
-                    ["PrecompiledHeader"] = "NotUsing",
-                    ["CompileAs"] = "CompileAsCpp",
-                    ["CompileAsManaged"] = "false",
-                    ["EnableEnhancedInstructionSet"] = "AdvancedVectorExtensions512",
-                    ["RuntimeLibrary"] = "MultiThreaded",
-                    ["LanguageStandard"] = "stdcpp17",
-                    ["LanguageStandard_C"] = "stdc17",
-                    ["ExceptionHandling"] = "Sync",
-                    ["BasicRuntimeChecks"] = "UninitializedLocalUsageCheck",
-                    ["ConformanceMode"] = "true",
-                    ["StructMemberAlignment"] = "8Bytes",
-                    ["AdditionalOptions"] = "/DA",
-                }
+                    ["CompileAs"] = "CompileAsCpp"
+                })
             };
 
             var projectItemMock = CreateMockProjectItem("c:\\foo\\xxx.vcxproj", projectItemConfig);
@@ -168,21 +157,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             var projectItemConfig = new ProjectItemConfig
             {
                 ItemType = "ClCompile",
-                FileConfigProperties = new Dictionary<string, string>
+                FileConfigProperties = CreateDefaultClCompileFileProperties(new Dictionary<string, string>
                 {
-                    ["PrecompiledHeader"] = "NotUsing",
-                    ["CompileAs"] = "CompileAsC",
-                    ["CompileAsManaged"] = "false",
-                    ["EnableEnhancedInstructionSet"] = "AdvancedVectorExtensions512",
-                    ["RuntimeLibrary"] = "MultiThreaded",
-                    ["LanguageStandard"] = "stdcpp17",
-                    ["LanguageStandard_C"] = "stdc17",
-                    ["ExceptionHandling"] = "Sync",
-                    ["BasicRuntimeChecks"] = "UninitializedLocalUsageCheck",
-                    ["ConformanceMode"] = "true",
-                    ["StructMemberAlignment"] = "8Bytes",
-                    ["AdditionalOptions"] = "/DA",
-                }
+                    ["CompileAs"] = "CompileAsC"
+                })
             };
 
             var projectItemMock = CreateMockProjectItem("c:\\foo\\xxx.vcxproj", projectItemConfig);
@@ -207,20 +185,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             var projectItemConfig = new ProjectItemConfig
             {
                 ItemType = "ClCompile",
-                FileConfigProperties = new Dictionary<string, string>
+                FileConfigProperties = CreateDefaultClCompileFileProperties(new Dictionary<string, string>
                 {
-                    ["PrecompiledHeader"] = "NotUsing",
-                    ["CompileAsManaged"] = "false",
-                    ["EnableEnhancedInstructionSet"] = "AdvancedVectorExtensions512",
-                    ["RuntimeLibrary"] = "MultiThreaded",
-                    ["LanguageStandard"] = "stdcpp17",
-                    ["LanguageStandard_C"] = "stdc17",
-                    ["ExceptionHandling"] = "Sync",
-                    ["BasicRuntimeChecks"] = "UninitializedLocalUsageCheck",
-                    ["ConformanceMode"] = "true",
-                    ["StructMemberAlignment"] = "8Bytes",
-                    ["AdditionalOptions"] = "/DA",
-                }
+                    ["CompileAs"] = "Default"
+                })
             };
 
             var projectItemMock = CreateMockProjectItem("c:\\foo\\xxx.vcxproj", projectItemConfig, "ANY_NON_CCODE");
@@ -244,20 +212,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             var projectItemConfig = new ProjectItemConfig
             {
                 ItemType = "ClCompile",
-                FileConfigProperties = new Dictionary<string, string>
+                FileConfigProperties = CreateDefaultClCompileFileProperties(new Dictionary<string, string>
                 {
-                    ["PrecompiledHeader"] = "NotUsing",
-                    ["CompileAsManaged"] = "false",
-                    ["EnableEnhancedInstructionSet"] = "AdvancedVectorExtensions512",
-                    ["RuntimeLibrary"] = "MultiThreaded",
                     ["LanguageStandard"] = "stdcpp17",
                     ["LanguageStandard_C"] = "stdc17",
-                    ["ExceptionHandling"] = "Sync",
-                    ["BasicRuntimeChecks"] = "UninitializedLocalUsageCheck",
-                    ["ConformanceMode"] = "true",
-                    ["StructMemberAlignment"] = "8Bytes",
-                    ["AdditionalOptions"] = "/DA",
-                }
+                })
             };
 
             var projectItemMock = CreateMockProjectItem("c:\\foo\\xxx.vcxproj", projectItemConfig, "CCode");
@@ -455,6 +414,31 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             // Assert
             request.Should().NotBeNull();
             Assert.IsTrue(request.CDCommand.StartsWith("\"C:\\path\\cl.exe\""));
+        }
+
+        private Dictionary<string, string> CreateDefaultClCompileFileProperties(Dictionary<string, string> overrides)
+        {
+            var defaultProperties = new Dictionary<string, string>
+            {
+                ["PrecompiledHeader"] = "NotUsing",
+                ["CompileAsManaged"] = "false",
+                ["EnableEnhancedInstructionSet"] = "AdvancedVectorExtensions512",
+                ["RuntimeLibrary"] = "MultiThreaded",
+                ["LanguageStandard"] = "stdcpp17",
+                ["LanguageStandard_C"] = "stdc17",
+                ["ExceptionHandling"] = "Sync",
+                ["BasicRuntimeChecks"] = "UninitializedLocalUsageCheck",
+                ["ConformanceMode"] = "true",
+                ["StructMemberAlignment"] = "8Bytes",
+                ["AdditionalOptions"] = "/DA",
+            };
+
+            foreach (var overrideProperties in overrides)
+            {
+                defaultProperties[overrideProperties.Key] = overrideProperties.Value;
+            }
+
+            return defaultProperties;
         }
 
     }

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/FileConfigTests.cs
@@ -153,7 +153,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             request.Should().NotBeNull();
-            Assert.AreEqual("\"C:\\path\\cl.exe\" /permissive- /std:c++17 /EHsc /arch:AVX512 /MT /RTCu /Zp8 /TP /DA \"c:\\dummy\\file.cpp\"", request.CDCommand);
+            Assert.AreEqual("\"C:\\path\\cl.exe\" /permissive- /TP /std:c++17 /EHsc /arch:AVX512 /MT /RTCu /Zp8 /DA \"c:\\dummy\\file.cpp\"", request.CDCommand);
             Assert.AreEqual("C:\\path\\includeDir1;C:\\path\\includeDir2;C:\\path\\includeDir3;", request.EnvInclude);
             Assert.AreEqual("c:\\dummy\\file.cpp", request.CDFile);
             Assert.AreEqual("c:\\foo", request.CDDirectory);
@@ -189,7 +189,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
 
             // Assert
             request.Should().NotBeNull();
-            Assert.AreEqual("\"C:\\path\\cl.exe\" /Yu\"pch.h\" /FI\"pch.h\" /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("\"C:\\path\\cl.exe\" /Yu\"pch.h\" /FI\"pch.h\" /TP /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
             Assert.AreEqual("c:\\dummy\\file.h", request.CDFile);
             Assert.IsTrue(request.IsHeaderFile);
 
@@ -201,7 +201,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             request = FileConfig.TryGet(testLogger, projectItemMock.Object, "c:\\dummy\\file.h", CreateFileSystemWithClCompiler());
 
             // Assert
-            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TC \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /TC /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
             Assert.AreEqual("c:\\dummy\\file.h", request.CDFile);
             Assert.IsTrue(request.IsHeaderFile);
 
@@ -212,7 +212,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject
             request = FileConfig.TryGet(testLogger, projectItemMock.Object, "c:\\dummy\\file.h", CreateFileSystemWithClCompiler());
 
             // Assert
-            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /EHsc /RTCu /TP \"c:\\dummy\\file.h\"", request.CDCommand);
+            Assert.AreEqual("\"C:\\path\\cl.exe\" /FI\"FHeader.h\" /Yu\"pch.h\" /TP /EHsc /RTCu \"c:\\dummy\\file.h\"", request.CDCommand);
             Assert.AreEqual("c:\\dummy\\file.h", request.CDFile);
             Assert.IsTrue(request.IsHeaderFile);
         }

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/LanguageFlagsProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/LanguageFlagsProviderTests.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject;
+
+[TestClass]
+public class LanguageFlagsProviderTests
+{
+    [TestMethod]
+    public void GetLanguageConfiguration_DefaultCompileAs_NoContentType_ReturnsCpp() =>
+        new LanguageFlagsProvider("unknown")
+            .GetLanguageConfiguration("Default", "stdc23", "stdcpp20")
+            .Should().Be(("/TP", "/std:c++20"));
+
+    [TestMethod]
+    public void GetLanguageConfiguration_DefaultCompileAs_ContentTypeCppCode_ReturnsCpp() =>
+        new LanguageFlagsProvider("CppCode")
+            .GetLanguageConfiguration("Default", "stdc23", "stdcpp20")
+            .Should().Be(("/TP", "/std:c++20"));
+
+    [TestMethod]
+    public void GetLanguageConfiguration_DefaultCompileAs_ContentTypeCppHeader_ReturnsCpp() =>
+        new LanguageFlagsProvider("CppHeader")
+            .GetLanguageConfiguration("Default", "stdc23", "stdcpp20")
+            .Should().Be(("/TP", "/std:c++20"));
+
+    [TestMethod]
+    public void GetLanguageConfiguration_DefaultCompileAs_ContentTypeCCode_ReturnsC() =>
+        new LanguageFlagsProvider("CCode")
+            .GetLanguageConfiguration("Default", "stdc23", "stdcpp20")
+            .Should().Be(("/TC", "/std:c23"));
+
+    [DataTestMethod]
+    [DataRow("CppCode")]
+    [DataRow("CCode")]
+    [DataRow("Default")]
+    public void GetLanguageConfiguration_CompileAsC_AnyContentType_ReturnsC(string contentType) =>
+        new LanguageFlagsProvider(contentType)
+            .GetLanguageConfiguration("CompileAsC", "stdc23", "stdcpp20")
+            .Should().Be(("/TC", "/std:c23"));
+
+    [DataTestMethod]
+    [DataRow("CppCode")]
+    [DataRow("CCode")]
+    [DataRow("Default")]
+    public void GetLanguageConfiguration_CompileAsCpp_AnyContentType_ReturnsCpp(string contentType) =>
+        new LanguageFlagsProvider(contentType)
+            .GetLanguageConfiguration("CompileAsCpp", "stdc23", "stdcpp20")
+            .Should().Be(("/TP", "/std:c++20"));
+}

--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/LanguageStandardConverterTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/LanguageStandardConverterTests.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily.VcxProject;
+
+[TestClass]
+public class LanguageStandardConverterTests
+{
+
+    [TestMethod]
+    [DataRow("", "")]
+    [DataRow("Default", "")]
+    [DataRow(null, "")]
+    [DataRow("stdcpplatest", "/std:c++latest")]
+    [DataRow("stdcpp20", "/std:c++20")]
+    [DataRow("stdcpp17", "/std:c++17")]
+    [DataRow("stdcpp14", "/std:c++14")]
+    public void GetCppStandardFlagValue(string input, string output) =>
+        LanguageStandardConverter.GetCppStandardFlagValue(input).Should().Be(output);
+
+    [TestMethod]
+    public void GetCppStandardFlagValue_UnsupportedValue_Throws()
+    {
+        var act = () => LanguageStandardConverter.GetCppStandardFlagValue("INVALID");
+
+        act.Should().Throw<ArgumentException>().WithMessage("Unsupported LanguageStandard: INVALID");
+    }
+
+    [TestMethod]
+    [DataRow("", "")]
+    [DataRow("Default", "")]
+    [DataRow(null, "")]
+    [DataRow("stdclatest", "/std:clatest")]
+    [DataRow("stdc23", "/std:c23")]
+    [DataRow("stdc17", "/std:c17")]
+    [DataRow("stdc11", "/std:c11")]
+    public void GetCStandardFlagValue(string input, string output) =>
+        LanguageStandardConverter.GetCStandardFlagValue(input).Should().Be(output);
+
+    [TestMethod]
+    public void GetCStandardFlagValue_UnsupportedValue_Throws()
+    {
+        var act = () => LanguageStandardConverter.GetCStandardFlagValue("INVALID");
+
+        act.Should().Throw<ArgumentException>().WithMessage("Unsupported LanguageStandard_C: INVALID");
+    }
+}

--- a/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
@@ -172,9 +172,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
         private void AddLanguageFlags(IVCRulePropertyStorage properties)
         {
             var (compileAsFlag, languageStandardFlag) = languageFlagsProvider.GetLanguageConfiguration(
-                GetPotentiallyUnsupportedPropertyValue(properties, "CompileAs", ""),
-                GetPotentiallyUnsupportedPropertyValue(properties, "LanguageStandard_C", ""),
-                GetPotentiallyUnsupportedPropertyValue(properties, "LanguageStandard", ""));
+                GetPotentiallyUnsupportedPropertyValue(properties, "CompileAs", string.Empty),
+                GetPotentiallyUnsupportedPropertyValue(properties, "LanguageStandard_C", string.Empty),
+                GetPotentiallyUnsupportedPropertyValue(properties, "LanguageStandard", string.Empty));
 
             AddCmdOpt(compileAsFlag);
             AddCmdOpt(languageStandardFlag);

--- a/src/Integration.Vsix/CFamily/VcxProject/CompileAsValueConverter.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/CompileAsValueConverter.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject;
+
+internal static class CompileAsValueConverter
+{
+    internal /* for testing */ static string GetFlagValue(string value) =>
+        value switch
+        {
+            // https://github.com/SonarSource/sonarlint-visualstudio/issues/738
+            "" or "Default" => "",
+            "CompileAsC" => "/TC",
+            "CompileAsCpp" => "/TP",
+            _ => throw new ArgumentException($"Unsupported CompileAs: {value}")
+        };
+}

--- a/src/Integration.Vsix/CFamily/VcxProject/CompileAsValueConverter.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/CompileAsValueConverter.cs
@@ -26,7 +26,7 @@ internal static class CompileAsValueConverter
         value switch
         {
             // https://github.com/SonarSource/sonarlint-visualstudio/issues/738
-            "" or "Default" => "",
+            "" or "Default" => string.Empty,
             "CompileAsC" => "/TC",
             "CompileAsCpp" => "/TP",
             _ => throw new ArgumentException($"Unsupported CompileAs: {value}")

--- a/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/FileConfig.cs
@@ -48,7 +48,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
             }
 
             bool isHeaderFile = vcFile.ItemType == "ClInclude";
-            CmdBuilder cmdBuilder = new CmdBuilder(isHeaderFile);
+            CmdBuilder cmdBuilder = new CmdBuilder(isHeaderFile, new LanguageFlagsProvider(vcFile.ContentType));
 
             if (!GetCompilerPath(logger, vcConfig, fileSystem, out var compilerPath))
             {
@@ -65,10 +65,14 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
             cmdBuilder.AddFile(absoluteFilePath);
             var envINCLUDE = vcConfig.GetEvaluatedPropertyValue("IncludePath");
 
+            var cdCommand = cmdBuilder.GetFullCmd();
+
+            logger.LogVerbose("Compile command: " + cdCommand);
+
             return new FileConfig
             {
                 CDDirectory = Path.GetDirectoryName(vcProject.ProjectFile),
-                CDCommand = cmdBuilder.GetFullCmd(),
+                CDCommand = cdCommand,
                 CDFile = absoluteFilePath,
                 EnvInclude = envINCLUDE,
                 IsHeaderFile = isHeaderFile,

--- a/src/Integration.Vsix/CFamily/VcxProject/LanguageFlagsProvider.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/LanguageFlagsProvider.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject;
+
+internal interface ILanguageFlagsProvider
+{
+    (string compileAsFlag, string languageStandardFlag) GetLanguageConfiguration(string compileAs, string cStandard, string cppStandard);
+}
+
+internal class LanguageFlagsProvider : ILanguageFlagsProvider
+{
+    private readonly string vcFileContentType;
+    private const string CompileAsCFlag = "/TC";
+    private const string CompileAsCppFlag = "/TP";
+    private const string ContentTypeCCode = "CCode";
+
+    public LanguageFlagsProvider(string vcFileContentType)
+    {
+        this.vcFileContentType = vcFileContentType;
+    }
+
+    public (string compileAsFlag, string languageStandardFlag) GetLanguageConfiguration(string compileAs, string cStandard, string cppStandard)
+    {
+        var compileAsFlag = CompileAsValueConverter.GetFlagValue(compileAs);
+
+        return compileAsFlag == CompileAsCFlag || (compileAsFlag != CompileAsCppFlag && vcFileContentType == ContentTypeCCode)
+            ? (CompileAsCFlag, LanguageStandardConverter.GetCStandardFlagValue(cStandard))
+            : (CompileAsCppFlag, LanguageStandardConverter.GetCppStandardFlagValue(cppStandard));
+    }
+}

--- a/src/Integration.Vsix/CFamily/VcxProject/LanguageFlagsProvider.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/LanguageFlagsProvider.cs
@@ -41,6 +41,7 @@ internal class LanguageFlagsProvider : ILanguageFlagsProvider
     {
         var compileAsFlag = CompileAsValueConverter.GetFlagValue(compileAs);
 
+        // if a C/CPP language file has no file-specific override for the CompileAs option in vsxproj, the property storage returns a non-lanugage-specific "Default" value.
         return compileAsFlag == CompileAsCFlag || (compileAsFlag != CompileAsCppFlag && vcFileContentType == ContentTypeCCode)
             ? (CompileAsCFlag, LanguageStandardConverter.GetCStandardFlagValue(cStandard))
             : (CompileAsCppFlag, LanguageStandardConverter.GetCppStandardFlagValue(cppStandard));

--- a/src/Integration.Vsix/CFamily/VcxProject/LanguageStandardConverter.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/LanguageStandardConverter.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject;
+
+internal static class LanguageStandardConverter
+{
+    public static string GetCppStandardFlagValue(string value) =>
+        value switch
+        {
+            null or "" or "Default" => "",
+            "stdcpplatest" => "/std:c++latest",
+            "stdcpp20" => "/std:c++20",
+            "stdcpp17" => "/std:c++17",
+            "stdcpp14" => "/std:c++14",
+            _ => throw new ArgumentException($"Unsupported LanguageStandard: {value}")
+        };
+
+    public static string GetCStandardFlagValue(string value) =>
+        value switch
+        {
+            null or "" or "Default" => "",
+            "stdclatest" => "/std:clatest",
+            "stdc23" => "/std:c23",
+            "stdc17" => "/std:c17",
+            "stdc11" => "/std:c11",
+            _ => throw new ArgumentException($"Unsupported LanguageStandard_C: {value}")
+        };
+}

--- a/src/Integration.Vsix/CFamily/VcxProject/LanguageStandardConverter.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/LanguageStandardConverter.cs
@@ -25,7 +25,7 @@ internal static class LanguageStandardConverter
     public static string GetCppStandardFlagValue(string value) =>
         value switch
         {
-            null or "" or "Default" => "",
+            null or "" or "Default" => string.Empty,
             "stdcpplatest" => "/std:c++latest",
             "stdcpp20" => "/std:c++20",
             "stdcpp17" => "/std:c++17",
@@ -36,7 +36,7 @@ internal static class LanguageStandardConverter
     public static string GetCStandardFlagValue(string value) =>
         value switch
         {
-            null or "" or "Default" => "",
+            null or "" or "Default" => string.Empty,
             "stdclatest" => "/std:clatest",
             "stdc23" => "/std:c23",
             "stdc17" => "/std:c17",


### PR DESCRIPTION
* Only set one language standard for the file
* Always set either `/TC` or `/TP` flag for the file (`/TC` for C and `/TP` for CPP)
* Assume the file is C if `CompileAsC `or if not `CompileAsCpp` and `vcFile.ContentType` is `CCode`
* Assume the file is CPP otherwise

Note: it's entirely possible to have a file with `CompileAsCpp` and `CCode`, `CompileAsC` and `CppCode`, `Default` and `CppHeader` or any other combination of these values by manually setting the overrides in vcxproj. For consistency, `CompileAs` is chosen as the primary indicator for the language, `vcFile.ContentType` is only used if `CompileAs` is not set to `CompileAsCpp`
