### PR TITLE
URL slug rebranding update

### DIFF
--- a/src/Core/DocumentationLinks.cs
+++ b/src/Core/DocumentationLinks.cs
@@ -32,8 +32,8 @@ namespace SonarLint.VisualStudio.Core
         public const string MigrateToConnectedModeV7_NotesForTfvcUsers
             = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/team-features/migrate-connected-mode-to-v7/#notes-for-tfvc-users";
         public const string ConnectedMode = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/team-features/connected-mode/";
-        public const string TaintVulnerabilities = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/using-sonarlint/taint-vulnerabilities/";
-        public const string DisablingARule = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/using-sonarlint/rules/#disabling-a-rule";
+        public const string TaintVulnerabilities = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/using/taint-vulnerabilities/";
+        public const string DisablingARule = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/using/rules/#disabling-a-rule";
         public const string UseSharedBinding = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/team-features/connected-mode-setup/#bind-using-shared-configuration";
         public const string SetupSharedBinding = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/team-features/connected-mode-setup/#save-the-connection-binding";
         public const string CleanCode = "https://docs.sonarsource.com/sonarqube-for-ide/visual-studio/concepts/clean-code/introduction";


### PR DESCRIPTION
Part of the rebranding efforts necessitates the update of the URL structure on the Docs website.
This change reflects part of that update.
A redirect has been added to address links from outside the product.