### PR TITLE
SLVS-1764 Stop using ClientConstantInfoDto SLCORE deprecated APIs

### DIFF
--- a/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
+++ b/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
@@ -54,9 +54,7 @@ public class SLCoreConstantsProviderTests
         var infoProvider = Substitute.For<IVsInfoProvider>();
         infoProvider.Name.Returns(ideName);
         var testSubject = CreateTestSubject(infoProvider);
-        var expectedClientConstants = new ClientConstantsDto(ideName,
-            $"SonarLint Visual Studio/{VersionHelper.SonarLintVersion}",
-            Process.GetCurrentProcess().Id);
+        var expectedClientConstants = new ClientConstantInfoDto(ideName, $"SonarLint Visual Studio/{VersionHelper.SonarLintVersion}");
         var actual = testSubject.ClientConstants;
 
         actual.Should().BeEquivalentTo(expectedClientConstants);

--- a/src/Integration/SLCore/SLCoreConstantsProvider.cs
+++ b/src/Integration/SLCore/SLCoreConstantsProvider.cs
@@ -41,7 +41,7 @@ namespace SonarLint.VisualStudio.Integration.SLCore
             AllAnalyzableLanguages = LanguagesInStandaloneMode.Concat(ExtraLanguagesInConnectedMode).Except(LanguagesWithDisabledAnalysis).ToArray();
         }
 
-        public ClientConstantsDto ClientConstants => new(vsInfoProvider.Name, $"SonarLint Visual Studio/{VersionHelper.SonarLintVersion}", Process.GetCurrentProcess().Id);
+        public ClientConstantInfoDto ClientConstants => new(vsInfoProvider.Name, $"SonarLint Visual Studio/{VersionHelper.SonarLintVersion}");
 
         public FeatureFlagsDto FeatureFlags => new(true, true, true, true, true, false, true, true, true);
 

--- a/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
+++ b/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
@@ -92,8 +92,7 @@ public sealed class SLCoreTestRunner : IDisposable
             var slCoreLocator = new SLCoreLocator(rootLocator, string.Empty, Substitute.For<ISonarLintSettings>(), logger, Substitute.For<IFileSystem>());
 
             var constantsProvider = Substitute.For<ISLCoreConstantsProvider>();
-            constantsProvider.ClientConstants.Returns(new ClientConstantsDto("SLVS_Integration_Tests",
-                $"SLVS_Integration_Tests/{VersionHelper.SonarLintVersion}", Process.GetCurrentProcess().Id));
+            constantsProvider.ClientConstants.Returns(new ClientConstantInfoDto("SLVS_Integration_Tests", $"SLVS_Integration_Tests/{VersionHelper.SonarLintVersion}"));
             constantsProvider.FeatureFlags.Returns(new FeatureFlagsDto(true, true, false, true, false, false, true, false, false));
             constantsProvider.TelemetryConstants.Returns(new TelemetryClientConstantAttributesDto("slvs_integration_tests", "SLVS Integration Tests",
                 VersionHelper.SonarLintVersion, "17.0", new()));

--- a/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
+++ b/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
@@ -44,7 +44,7 @@ public class SLCoreInstanceHandleTests
     private const string WorkDir = "workDirSl";
     private const string UserHome = "userHomeSl";
 
-    private static readonly ClientConstantsDto ClientConstants = new(default, default, default);
+    private static readonly ClientConstantInfoDto ClientConstantInfo = new(default, default);
     private static readonly FeatureFlagsDto FeatureFlags = new(default, default, default, default, default, default, default, default, default);
     private static readonly TelemetryClientConstantAttributesDto TelemetryConstants = new(default, default, default, default, default);
 
@@ -127,7 +127,7 @@ public class SLCoreInstanceHandleTests
             threadHandling.ThrowIfOnUIThread();
             slCoreRpcFactory.StartNewRpcInstance();
             lifecycleManagement.Initialize(Arg.Is<InitializeParams>(parameters =>
-                parameters.clientConstantInfo == ClientConstants
+                parameters.clientConstantInfo == ClientConstantInfo
                 && parameters.featureFlags == FeatureFlags
                 && parameters.storageRoot == StorageRoot
                 && parameters.workDir == WorkDir
@@ -274,7 +274,7 @@ public class SLCoreInstanceHandleTests
         SetUpSLCoreRpcFactory(slCoreRpcFactory, out rpc);
         SetUpSLCoreRpc(rpc, out var serviceProvider);
         SetUpSLCoreServiceProvider(serviceProvider, out lifecycleManagement);
-        constantsProvider.ClientConstants.Returns(ClientConstants);
+        constantsProvider.ClientConstants.Returns(ClientConstantInfo);
         constantsProvider.FeatureFlags.Returns(FeatureFlags);
         constantsProvider.TelemetryConstants.Returns(TelemetryConstants);
 

--- a/src/SLCore.UnitTests/Service/Lifecycle/InitializeParamsTests.cs
+++ b/src/SLCore.UnitTests/Service/Lifecycle/InitializeParamsTests.cs
@@ -34,7 +34,7 @@ public class InitializeParamsTests
     public void Serialize_AsExpected()
     {
         var testSubject = new InitializeParams(
-            new ClientConstantsDto("TESTname", "TESTagent", 11223344),
+            new ClientConstantInfoDto("TESTname", "TESTagent"),
             new HttpConfigurationDto(new SslConfigurationDto()),
             new FeatureFlagsDto(false, true, false, true, false, true, false, false, false),
             "storageRoot",
@@ -62,8 +62,7 @@ public class InitializeParamsTests
                                 {
                                   "clientConstantInfo": {
                                     "name": "TESTname",
-                                    "userAgent": "TESTagent",
-                                    "pid": 11223344
+                                    "userAgent": "TESTagent"
                                   },
                                   "httpConfiguration": {
                                     "sslConfiguration": {}

--- a/src/SLCore/Configuration/ISLCoreConstantsProvider.cs
+++ b/src/SLCore/Configuration/ISLCoreConstantsProvider.cs
@@ -25,7 +25,7 @@ namespace SonarLint.VisualStudio.SLCore.Configuration;
 
 public interface ISLCoreConstantsProvider
 {
-    ClientConstantsDto ClientConstants { get; }
+    ClientConstantInfoDto ClientConstants { get; }
     FeatureFlagsDto FeatureFlags { get; }
     TelemetryClientConstantAttributesDto TelemetryConstants { get; }
 

--- a/src/SLCore/Service/Lifecycle/InitializeParams.cs
+++ b/src/SLCore/Service/Lifecycle/InitializeParams.cs
@@ -29,7 +29,7 @@ namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle
     /// SLCore initialization parameters
     /// </summary>
     public record InitializeParams(
-        ClientConstantsDto clientConstantInfo,
+        ClientConstantInfoDto clientConstantInfo,
         HttpConfigurationDto httpConfiguration,
         FeatureFlagsDto featureFlags,
         string storageRoot,

--- a/src/SLCore/Service/Lifecycle/Models/ClientConstantInfoDto.cs
+++ b/src/SLCore/Service/Lifecycle/Models/ClientConstantInfoDto.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models
-{
-    public record ClientConstantsDto(string name, string userAgent, long pid);
-}
+namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models;
+
+public record ClientConstantInfoDto(string name, string userAgent);


### PR DESCRIPTION
[SLVS-1764](https://sonarsource.atlassian.net/browse/SLVS-1764)

Additionally the DTO (ClientConstantsDto) was renamed to match the one in SLCore (ClientConstantInfoDto)

[SLVS-1764]: https://sonarsource.atlassian.net/browse/SLVS-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ