### PR TITLE
SLVS-1826 Introduce ILanguageProvider

### DIFF
--- a/src/ConnectedMode.UnitTests/Binding/NonRoslynDummyBindingConfigProviderTests.cs
+++ b/src/ConnectedMode.UnitTests/Binding/NonRoslynDummyBindingConfigProviderTests.cs
@@ -26,10 +26,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Binding;
 [TestClass]
 public class NonRoslynDummyBindingConfigProviderTests
 {
-    private static IEnumerable<Language> SupportedLanguages { get; } = Language.KnownLanguages.Where(l => l != Language.CSharp && l != Language.VBNET);
+    private static IEnumerable<Language> SupportedLanguages { get; } = LanguageProvider.Instance.AllKnownLanguages.Where(l => l != Language.CSharp && l != Language.VBNET);
     private static IEnumerable<Language> RoslynLanguages { get; } = [Language.CSharp, Language.VBNET];
 
     public static IEnumerable<object[]> GetSupportedLanguages() => SupportedLanguages.Select(l => new object[] { l });
+
     public static IEnumerable<object[]> GetRoslynLanguages() => RoslynLanguages.Select(l => new object[] { l });
 
     public static IEnumerable<object[]> GetLanguagesWithSupport()

--- a/src/ConnectedMode.UnitTests/QualityProfiles/QualityProfileDownloaderTests.cs
+++ b/src/ConnectedMode.UnitTests/QualityProfiles/QualityProfileDownloaderTests.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.ConnectedMode.QualityProfiles;
 using SonarLint.VisualStudio.Core;
@@ -65,7 +61,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             var testSubject = CreateTestSubject(outOfDateQualityProfileFinderMock.Object,
                 bindingConfigProvider.Object,
                 logger: logger,
-                languagesToBind: Language.KnownLanguages.ToArray());
+                languagesToBind: LanguageProvider.Instance.AllKnownLanguages.ToArray());
 
             var result = await testSubject.UpdateAsync(boundSonarQubeProject, null, CancellationToken.None);
 
@@ -82,13 +78,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             var logger = new TestLogger(logToConsole: true);
             var boundProject = CreateBoundProject();
 
-            var languagesToBind = new[]
-            {
-                Language.Cpp,
-                Language.CSharp,
-                Language.Secrets,
-                Language.VBNET
-            };
+            var languagesToBind = new[] { Language.Cpp, Language.CSharp, Language.Secrets, Language.VBNET };
 
             SetupLanguagesToUpdate(out var outOfDateQualityProfileFinderMock,
                 boundProject,
@@ -130,8 +120,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 notifications.AssertProgressMessages(expected);
             }
 
-            static string GetDownloadProgressMessages(Language language)
-                => string.Format(QualityProfilesStrings.DownloadingQualityProfileProgressMessage, language.Name);
+            static string GetDownloadProgressMessages(Language language) => string.Format(QualityProfilesStrings.DownloadingQualityProfileProgressMessage, language.Name);
         }
 
         [TestMethod]
@@ -143,8 +132,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             var languagesToBind = new[]
             {
                 Language.Cpp, // unavailable
-                Language.CSharp,
-                Language.Secrets, // unavailable
+                Language.CSharp, Language.Secrets, // unavailable
                 Language.VBNET
             };
 
@@ -277,7 +265,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 configurationPersister ?? new DummyConfigPersister(),
                 outOfDateQualityProfileFinder ?? Mock.Of<IOutOfDateQualityProfileFinder>(),
                 logger ?? new TestLogger(logToConsole: true),
-                languagesToBind ?? Language.KnownLanguages);
+                languagesToBind ?? LanguageProvider.Instance.AllKnownLanguages);
         }
 
         private static SonarQubeQualityProfile CreateQualityProfile(string key = "key", DateTime timestamp = default)
@@ -307,7 +295,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 .ReturnsAsync(qps);
         }
 
-        private static Mock<IBindingConfig> SetupConfigProvider(Mock<IBindingConfigProvider> bindingConfigProvider,
+        private static Mock<IBindingConfig> SetupConfigProvider(
+            Mock<IBindingConfigProvider> bindingConfigProvider,
             Language language)
         {
             var bindingConfig = new Mock<IBindingConfig>();
@@ -321,18 +310,17 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             return bindingConfig;
         }
 
-        private static BoundServerProject CreateBoundProject(string projectKey = "key",
-            Uri uri = null)
-            => new BoundServerProject(
+        private static BoundServerProject CreateBoundProject(
+            string projectKey = "key",
+            Uri uri = null) =>
+            new BoundServerProject(
                 "solution",
                 projectKey,
                 new ServerConnection.SonarQube(uri ?? new Uri("http://localhost/")));
 
-        private static void CheckRuleConfigSaved(Mock<IBindingConfig> bindingConfig)
-            => bindingConfig.Verify(x => x.Save(), Times.Once);
+        private static void CheckRuleConfigSaved(Mock<IBindingConfig> bindingConfig) => bindingConfig.Verify(x => x.Save(), Times.Once);
 
-        private static void CheckRuleConfigNotSaved(Mock<IBindingConfig> bindingConfig)
-            => bindingConfig.Verify(x => x.Save(), Times.Never);
+        private static void CheckRuleConfigNotSaved(Mock<IBindingConfig> bindingConfig) => bindingConfig.Verify(x => x.Save(), Times.Never);
 
         private class DummyConfigPersister : IConfigurationPersister
         {

--- a/src/ConnectedMode/Binding/NonRoslynDummyBindingConfigProvider.cs
+++ b/src/ConnectedMode/Binding/NonRoslynDummyBindingConfigProvider.cs
@@ -26,23 +26,13 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding;
 
 internal class NonRoslynDummyBindingConfigProvider : IBindingConfigProvider
 {
-    // List of languages that use this type of configuration file (all non-Roslyn languages)
-    private static readonly Language[] SupportedLanguages =
-    [
-        Language.C,
-        Language.Cpp,
-        Language.Js,
-        Language.Ts,
-        Language.Secrets,
-        Language.Css,
-        Language.Html,
-        Language.TSql
-    ];
+    public bool IsLanguageSupported(Language language) => LanguageProvider.Instance.SlCoreLanguages.Contains(language);
 
-    public bool IsLanguageSupported(Language language) => SupportedLanguages.Contains(language);
-
-    public Task<IBindingConfig> GetConfigurationAsync(SonarQubeQualityProfile qualityProfile, Language language,
-        BindingConfiguration bindingConfiguration, CancellationToken cancellationToken)
+    public Task<IBindingConfig> GetConfigurationAsync(
+        SonarQubeQualityProfile qualityProfile,
+        Language language,
+        BindingConfiguration bindingConfiguration,
+        CancellationToken cancellationToken)
     {
         if (!IsLanguageSupported(language))
         {

--- a/src/ConnectedMode/QualityProfiles/OutOfDateQualityProfileFinder.cs
+++ b/src/ConnectedMode/QualityProfiles/OutOfDateQualityProfileFinder.cs
@@ -18,12 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarQube.Client;
@@ -31,13 +26,13 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
 {
-
     internal interface IOutOfDateQualityProfileFinder
     {
         /// <summary>
         /// Gives the list of outdated quality profiles based on the existing ones from <see cref="BoundSonarQubeProject.Profiles"/>
         /// </summary>
-        Task<IReadOnlyCollection<(Language language, SonarQubeQualityProfile qualityProfile)>> GetAsync(BoundServerProject sonarQubeProject,
+        Task<IReadOnlyCollection<(Language language, SonarQubeQualityProfile qualityProfile)>> GetAsync(
+            BoundServerProject sonarQubeProject,
             CancellationToken cancellationToken);
     }
 
@@ -64,14 +59,16 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
 
             return sonarQubeQualityProfiles
                 .Select(serverQualityProfile =>
-                    (language: Language.GetLanguageFromLanguageKey(serverQualityProfile.Language),
-                    qualityProfile: serverQualityProfile))
+                    (language: LanguageProvider.Instance.GetLanguageFromLanguageKey(serverQualityProfile.Language),
+                        qualityProfile: serverQualityProfile))
                 .Where(languageAndQp =>
                     IsLocalQPOutOfDate(sonarQubeProject, languageAndQp.language, languageAndQp.qualityProfile))
                 .ToArray();
         }
 
-        private static bool IsLocalQPOutOfDate(BoundServerProject sonarQubeProject, Language language,
+        private static bool IsLocalQPOutOfDate(
+            BoundServerProject sonarQubeProject,
+            Language language,
             SonarQubeQualityProfile serverQualityProfile)
         {
             if (language == default)

--- a/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
+++ b/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
@@ -18,11 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
@@ -63,8 +59,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
                 configurationPersister,
                 outOfDateQualityProfileFinder,
                 logger,
-                Language.KnownLanguages)
-        { }
+                LanguageProvider.Instance.AllKnownLanguages)
+        {
+        }
 
         internal /* for testing */ QualityProfileDownloader(
             IBindingConfigProvider bindingConfigProvider,
@@ -80,7 +77,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             this.outOfDateQualityProfileFinder = outOfDateQualityProfileFinder;
         }
 
-        public async Task<bool> UpdateAsync(BoundServerProject boundProject, IProgress<FixedStepsProgress> progress,
+        public async Task<bool> UpdateAsync(
+            BoundServerProject boundProject,
+            IProgress<FixedStepsProgress> progress,
             CancellationToken cancellationToken)
         {
             var isChanged = false;
@@ -152,24 +151,16 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             {
                 if (!boundProject.Profiles.ContainsKey(language))
                 {
-                    boundProject.Profiles[language] = new ApplicableQualityProfile
-                    {
-                        ProfileKey = null,
-                        ProfileTimestamp = DateTime.MinValue,
-                    };
+                    boundProject.Profiles[language] = new ApplicableQualityProfile { ProfileKey = null, ProfileTimestamp = DateTime.MinValue, };
                 }
             }
         }
 
         private static void UpdateProfile(BoundServerProject boundSonarQubeProject, Language language, SonarQubeQualityProfile serverProfile)
         {
-            boundSonarQubeProject.Profiles[language] = new ApplicableQualityProfile
-            {
-                ProfileKey = serverProfile.Key, ProfileTimestamp = serverProfile.TimeStamp
-            };
+            boundSonarQubeProject.Profiles[language] = new ApplicableQualityProfile { ProfileKey = serverProfile.Key, ProfileTimestamp = serverProfile.TimeStamp };
         }
 
-        private void LogWithBindingPrefix(string text)
-            => logger.WriteLine(QualityProfilesStrings.QPMessagePrefix + text);
+        private void LogWithBindingPrefix(string text) => logger.WriteLine(QualityProfilesStrings.QPMessagePrefix + text);
     }
 }

--- a/src/Core.UnitTests/CSharpVB/SonarLintConfigGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/SonarLintConfigGeneratorTests.cs
@@ -339,6 +339,6 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         private static SonarQubeRule CreateRule(string ruleKey, string repoKey, IDictionary<string, string> parameters = null) =>
             new SonarQubeRule(ruleKey, repoKey, isActive: false, SonarQubeIssueSeverity.Blocker, null, null, parameters, SonarQubeIssueType.Unknown);
 
-        private Language ToLanguage(string sqLanguageKey) => Language.GetLanguageFromLanguageKey(sqLanguageKey);
+        private Language ToLanguage(string sqLanguageKey) => LanguageProvider.Instance.GetLanguageFromLanguageKey(sqLanguageKey);
     }
 }

--- a/src/Core.UnitTests/LanguageProviderTests.cs
+++ b/src/Core.UnitTests/LanguageProviderTests.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.TestInfrastructure;
+
+namespace SonarLint.VisualStudio.Core.UnitTests;
+
+[TestClass]
+public class LanguageProviderTests
+{
+    private LanguageProvider testSubject;
+
+    [TestInitialize]
+    public void TestInitialize() => testSubject = new LanguageProvider();
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<LanguageProvider, ILanguageProvider>();
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<LanguageProvider>();
+
+    [TestMethod]
+    public void AllKnownLanguages_ShouldBeExpected()
+    {
+        var expected = new[] { Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
+
+        testSubject.AllKnownLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void RoslynLanguages_ShouldBeExpected()
+    {
+        var expected = new[] { Language.CSharp, Language.VBNET };
+
+        testSubject.RoslynLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void SlCoreLanguages_ShouldBeExpected()
+    {
+        var expected = new[] { Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
+
+        testSubject.SlCoreLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void LanguagesInStandaloneMode_ShouldBeExpected()
+    {
+        var expected = new[] { Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html };
+
+        testSubject.LanguagesInStandaloneMode.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void ExtraLanguagesInConnectedMode_ShouldBeExpected()
+    {
+        var expected = new[] { Language.TSql };
+
+        testSubject.ExtraLanguagesInConnectedMode.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void GetLanguageFromLanguageKey_GetsCorrectLanguage()
+    {
+        var cs = testSubject.GetLanguageFromLanguageKey("cs");
+        var vbnet = testSubject.GetLanguageFromLanguageKey("vbnet");
+        var cpp = testSubject.GetLanguageFromLanguageKey("cpp");
+        var c = testSubject.GetLanguageFromLanguageKey("c");
+        var js = testSubject.GetLanguageFromLanguageKey("js");
+        var ts = testSubject.GetLanguageFromLanguageKey("ts");
+        var css = testSubject.GetLanguageFromLanguageKey("css");
+        var html = testSubject.GetLanguageFromLanguageKey("Web");
+        var tsql = testSubject.GetLanguageFromLanguageKey("tsql");
+        var unknown = testSubject.GetLanguageFromLanguageKey("unknown");
+
+        cs.Should().Be(Language.CSharp);
+        vbnet.Should().Be(Language.VBNET);
+        cpp.Should().Be(Language.Cpp);
+        c.Should().Be(Language.C);
+        js.Should().Be(Language.Js);
+        ts.Should().Be(Language.Ts);
+        css.Should().Be(Language.Css);
+        html.Should().Be(Language.Html);
+        tsql.Should().Be(Language.TSql);
+        unknown.Should().Be(null);
+    }
+}

--- a/src/Core.UnitTests/LanguageProviderTests.cs
+++ b/src/Core.UnitTests/LanguageProviderTests.cs
@@ -101,4 +101,31 @@ public class LanguageProviderTests
         tsql.Should().Be(Language.TSql);
         unknown.Should().Be(null);
     }
+
+    [TestMethod]
+    public void Verify_ConnectedAndStandaloneLanguagesAreKnown()
+    {
+        var connectedAndStandaloneLanguages = testSubject.LanguagesInStandaloneMode
+            .Union(testSubject.ExtraLanguagesInConnectedMode).ToList();
+
+        connectedAndStandaloneLanguages.Should().BeEquivalentTo(testSubject.AllKnownLanguages);
+        connectedAndStandaloneLanguages.Should().NotContain(Language.Unknown);
+    }
+
+    [TestMethod]
+    public void Verify_RoslynAndSlCoreLanguagesAreKnown()
+    {
+        var roslynAndSlCore = testSubject.RoslynLanguages
+            .Union(testSubject.SlCoreLanguages).ToList();
+
+        roslynAndSlCore.Should().BeEquivalentTo(testSubject.AllKnownLanguages);
+        roslynAndSlCore.Should().NotContain(Language.Unknown);
+    }
+
+    [TestMethod]
+    public void Verify_AllConfiguredLanguagesHaveKnownPluginKeys()
+    {
+        testSubject.AllKnownLanguages.Should().NotContainNulls();
+        testSubject.AllKnownLanguages.Should().NotContain(Language.Unknown);
+    }
 }

--- a/src/Core.UnitTests/LanguageTests.cs
+++ b/src/Core.UnitTests/LanguageTests.cs
@@ -66,29 +66,6 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         }
 
         [TestMethod]
-        public void Language_IsSupported_SupportedLanguage_IsTrue()
-        {
-            // Act + Assert
-            Language.CSharp.IsSupported.Should().BeTrue();
-            Language.VBNET.IsSupported.Should().BeTrue();
-            Language.Cpp.IsSupported.Should().BeTrue();
-            Language.C.IsSupported.Should().BeTrue();
-            Language.Js.IsSupported.Should().BeTrue();
-            Language.Ts.IsSupported.Should().BeTrue();
-            Language.Css.IsSupported.Should().BeTrue();
-            Language.Secrets.IsSupported.Should().BeTrue();
-            Language.Html.IsSupported.Should().BeTrue();
-            Language.TSql.IsSupported.Should().BeTrue();
-        }
-
-        [TestMethod]
-        public void Language_ISupported_UnsupportedLanguage_IsFalse()
-        {
-            var other = new Language("foo", "Foo language", new SonarQubeLanguage("server key", "server name"), pluginInfo, repoInfo);
-            other.IsSupported.Should().BeFalse();
-        }
-
-        [TestMethod]
         public void Language_Equality()
         {
             // Arrange
@@ -102,101 +79,37 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         }
 
         [TestMethod]
-        public void GetLanguageFromLanguageKey_GetsCorrectLanguage()
+        public void Language_HasExpectedRepoInfo()
         {
-            var cs = Language.GetLanguageFromLanguageKey("cs");
-            var vbnet = Language.GetLanguageFromLanguageKey("vbnet");
-            var cpp = Language.GetLanguageFromLanguageKey("cpp");
-            var c = Language.GetLanguageFromLanguageKey("c");
-            var js = Language.GetLanguageFromLanguageKey("js");
-            var ts = Language.GetLanguageFromLanguageKey("ts");
-            var css = Language.GetLanguageFromLanguageKey("css");
-            var html = Language.GetLanguageFromLanguageKey("Web");
-            var tsql = Language.GetLanguageFromLanguageKey("tsql");
-            var unknown = Language.GetLanguageFromLanguageKey("unknown");
+            LanguageHasExpectedRepoInfo(Language.CSharp, "csharpsquid", "csharp");
+            LanguageHasExpectedRepoInfo(Language.VBNET, "vbnet", "vbnet");
+            LanguageHasExpectedRepoInfo(Language.Cpp, "cpp", "cpp");
+            LanguageHasExpectedRepoInfo(Language.C, "c", "c");
+            LanguageHasExpectedRepoInfo(Language.Js, "javascript", "javascript");
+            LanguageHasExpectedRepoInfo(Language.Ts, "typescript", "typescript");
+            LanguageHasExpectedRepoInfo(Language.Css, "css", "css");
+            LanguageHasExpectedRepoInfo(Language.Html, "Web", "html");
+            LanguageHasExpectedRepoInfo(Language.Secrets, "secrets", "secrets");
+            LanguageHasExpectedRepoInfo(Language.TSql, "tsql", "tsql");
 
-            cs.Should().Be(Language.CSharp);
-            vbnet.Should().Be(Language.VBNET);
-            cpp.Should().Be(Language.Cpp);
-            c.Should().Be(Language.C);
-            js.Should().Be(Language.Js);
-            ts.Should().Be(Language.Ts);
-            css.Should().Be(Language.Css);
-            html.Should().Be(Language.Html);
-            tsql.Should().Be(Language.TSql);
-            unknown.Should().Be(null);
+            DoesNotHaveRepoInfo(Language.Unknown.RepoInfo);
         }
 
         [TestMethod]
-        public void GetLanguageFromRepositoryKey_GetsCorrectLanguage()
+        public void Language_HasExpectedSecurityRepoInfo()
         {
-            var cs = Language.GetLanguageFromRepositoryKey("csharpsquid");
-            var vbnet = Language.GetLanguageFromRepositoryKey("vbnet");
-            var cpp = Language.GetLanguageFromRepositoryKey("cpp");
-            var c = Language.GetLanguageFromRepositoryKey("c");
-            var js = Language.GetLanguageFromRepositoryKey("javascript");
-            var ts = Language.GetLanguageFromRepositoryKey("typescript");
-            var css = Language.GetLanguageFromRepositoryKey("css");
-            var html = Language.GetLanguageFromRepositoryKey("Web");
-            var secrets = Language.GetLanguageFromRepositoryKey("secrets");
-            var tsql = Language.GetLanguageFromRepositoryKey("tsql");
-            var unknown = Language.GetLanguageFromRepositoryKey("unknown");
+            LanguageHasExpectedSecurityRepoInfo(Language.CSharp, "roslyn.sonaranalyzer.security.cs", "csharp");
+            LanguageHasExpectedSecurityRepoInfo(Language.Js, "jssecurity", "javascript");
+            LanguageHasExpectedSecurityRepoInfo(Language.Ts, "tssecurity", "typescript");
 
-            var csSecurity = Language.GetLanguageFromRepositoryKey("roslyn.sonaranalyzer.security.cs");
-            var jsSecurity = Language.GetLanguageFromRepositoryKey("jssecurity");
-            var tsSecurity = Language.GetLanguageFromRepositoryKey("tssecurity");
-
-            cs.Should().Be(Language.CSharp);
-            vbnet.Should().Be(Language.VBNET);
-            cpp.Should().Be(Language.Cpp);
-            c.Should().Be(Language.C);
-            js.Should().Be(Language.Js);
-            ts.Should().Be(Language.Ts);
-            css.Should().Be(Language.Css);
-            html.Should().Be(Language.Html);
-            secrets.Should().Be(Language.Secrets);
-            tsql.Should().Be(Language.TSql);
-            unknown.Should().Be(null);
-
-            csSecurity.Should().Be(Language.CSharp);
-            jsSecurity.Should().Be(Language.Js);
-            tsSecurity.Should().Be(Language.Ts);
-        }
-
-        [TestMethod]
-        public void GetSonarRepoKeyFromLanguageKey_GetsCorrectRepoKey()
-        {
-            Language.GetSonarRepoKeyFromLanguage(Language.CSharp).Should().Be("csharpsquid");
-            Language.GetSonarRepoKeyFromLanguage(Language.VBNET).Should().Be("vbnet");
-            Language.GetSonarRepoKeyFromLanguage(Language.C).Should().Be("c");
-            Language.GetSonarRepoKeyFromLanguage(Language.Cpp).Should().Be("cpp");
-            Language.GetSonarRepoKeyFromLanguage(Language.Js).Should().Be("javascript");
-            Language.GetSonarRepoKeyFromLanguage(Language.Ts).Should().Be("typescript");
-            Language.GetSonarRepoKeyFromLanguage(Language.Css).Should().Be("css");
-            Language.GetSonarRepoKeyFromLanguage(Language.Html).Should().Be("Web");
-            Language.GetSonarRepoKeyFromLanguage(Language.TSql).Should().Be("tsql");
-
-            Language.GetSonarRepoKeyFromLanguage(Language.Unknown).Should().BeNull();
-
-            var language = new Language("xxx", "dummy language", new SonarQubeLanguage("xxx", "LanguageX"), pluginInfo, repoInfo);
-            Language.GetSonarRepoKeyFromLanguage(language).Should().BeNull();
-        }
-
-        [TestMethod]
-        public void SanityCheck_RoundTripFromLanguageToRepoKey_AndBack()
-        {
-            // Sanity check that we've remembered to define the necessary mappings
-            // for all known languages.
-            // Regression test to avoid bugs like #3973.
-
-            foreach (var item in Language.KnownLanguages)
-            {
-                var actualRepoKey = Language.GetSonarRepoKeyFromLanguage(item);
-                actualRepoKey.Should().NotBeNull();
-
-                var actualLanguage = Language.GetLanguageFromRepositoryKey(actualRepoKey);
-                actualLanguage.Should().BeSameAs(item);
-            }
+            DoesNotHaveRepoInfo(Language.VBNET.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Cpp.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.C.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Css.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Html.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Secrets.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.TSql.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Unknown.SecurityRepoInfo);
         }
 
         [TestMethod]
@@ -241,6 +154,19 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         {
             language.PluginInfo.Key.Should().Be(pluginKey);
             language.PluginInfo.FilePattern.Should().Be(filePattern);
+        }
+
+        private static void LanguageHasExpectedRepoInfo(Language language, string repoKey, string folderName) => HasExpectedRepoInfo(language.RepoInfo, repoKey, folderName);
+
+        private static void LanguageHasExpectedSecurityRepoInfo(Language language, string repoKey, string folderName) => HasExpectedRepoInfo(language.SecurityRepoInfo, repoKey, folderName);
+
+        private static void DoesNotHaveRepoInfo(RepoInfo repoInfo) => repoInfo.Should().BeNull();
+
+        private static void HasExpectedRepoInfo(RepoInfo repoInfo, string repoKey, string folderName)
+        {
+            repoInfo.Should().NotBeNull();
+            repoInfo.Key.Should().Be(repoKey);
+            repoInfo.FolderName.Should().Be(folderName);
         }
     }
 }

--- a/src/Core/ILanguageProvider.cs
+++ b/src/Core/ILanguageProvider.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+
+namespace SonarLint.VisualStudio.Core;
+
+public interface ILanguageProvider
+{
+    IReadOnlyList<Language> AllKnownLanguages { get; }
+
+    IReadOnlyList<Language> SlCoreLanguages { get; }
+
+    IReadOnlyList<Language> RoslynLanguages { get; }
+
+    IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
+
+    IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; }
+
+    /// <summary>
+    /// Returns the language for the specified language key, or null if it does not match a known language
+    /// </summary>
+    Language GetLanguageFromLanguageKey(string languageKey);
+}
+
+[Export(typeof(ILanguageProvider))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+public class LanguageProvider : ILanguageProvider
+{
+    [ImportingConstructor]
+    public LanguageProvider()
+    {
+        SlCoreLanguages = AllKnownLanguages.Except(RoslynLanguages).ToList();
+        LanguagesInStandaloneMode = AllKnownLanguages.Except(ExtraLanguagesInConnectedMode).ToList();
+    }
+
+    public IReadOnlyList<Language> SlCoreLanguages { get; }
+    public IReadOnlyList<Language> RoslynLanguages { get; } = [Language.CSharp, Language.VBNET];
+    public IReadOnlyList<Language> AllKnownLanguages { get; } =
+        [Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql];
+    public IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
+    public IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; } = [Language.TSql];
+
+    public Language GetLanguageFromLanguageKey(string languageKey) => AllKnownLanguages.FirstOrDefault(l => languageKey.Equals(l.ServerLanguage.Key, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Core/ILanguageProvider.cs
+++ b/src/Core/ILanguageProvider.cs
@@ -44,6 +44,10 @@ public interface ILanguageProvider
 [PartCreationPolicy(CreationPolicy.Shared)]
 public class LanguageProvider : ILanguageProvider
 {
+#pragma warning disable S4277
+    public static readonly ILanguageProvider Instance = new LanguageProvider();
+#pragma warning restore S4277
+
     [ImportingConstructor]
     public LanguageProvider()
     {

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Core
     /// This class is safe for use as a key in collection classes. E.g., <seealso cref="IDictionary{TKey, TValue}"/>.
     /// </para>
     /// </remarks>
-    [DebuggerDisplay("{Name} (ID: {Id}, IsSupported: {IsSupported})")]
+    [DebuggerDisplay("{Name} (ID: {Id})")]
     [TypeConverter(typeof(LanguageConverter))]
     public sealed class Language : IEquatable<Language>
     {

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -75,21 +75,6 @@ namespace SonarLint.VisualStudio.Core
         public static readonly Language TSql = new("TSql", "T-SQL", SonarQubeLanguage.TSql, TsqlPlugin, TsqlRepo);
 
         /// <summary>
-        /// Returns the language for the specified language key, or null if it does not match a known language
-        /// </summary>
-        public static Language GetLanguageFromLanguageKey(string languageKey) => KnownLanguages.FirstOrDefault(l => languageKey.Equals(l.ServerLanguage.Key, StringComparison.OrdinalIgnoreCase));
-
-        /// <summary>
-        /// Returns the language for the specified repository key, or null if it does not match a known language
-        /// </summary>
-        public static Language GetLanguageFromRepositoryKey(string repoKey) => KnownLanguages.SingleOrDefault(lang => lang.HasRepoKey(repoKey));
-
-        /// <summary>
-        /// Returns the Sonar analyzer repository for the specified language key, or null if one could not be found
-        /// </summary>
-        public static string GetSonarRepoKeyFromLanguage(Language language) => KnownLanguages.FirstOrDefault(x => x.Id == language.Id)?.RepoInfo.Key;
-
-        /// <summary>
         /// A stable identifier for this language.
         /// </summary>
         public string Id { get; }
@@ -121,22 +106,6 @@ namespace SonarLint.VisualStudio.Core
         /// Nullable, the repository info for the security rules (i.e. hotspots) for this language
         /// </summary>
         public RepoInfo SecurityRepoInfo { get; }
-
-        /// <summary>
-        /// Returns whether or not this language is a supported project language.
-        /// </summary>
-        public bool IsSupported => KnownLanguages.Contains(this);
-
-        /// <summary>
-        /// All known languages.
-        /// </summary>
-        public static IEnumerable<Language> KnownLanguages
-        {
-            get
-            {
-                return new[] { CSharp, VBNET, Cpp, C, Js, Ts, Css, Html, Secrets, TSql };
-            }
-        }
 
         /// <summary>
         /// Private constructor reserved for the <seealso cref="Unknown"/>.

--- a/src/Core/LanguageConverter.cs
+++ b/src/Core/LanguageConverter.cs
@@ -18,11 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 
 namespace SonarLint.VisualStudio.Core
 {
@@ -54,8 +51,8 @@ namespace SonarLint.VisualStudio.Core
 
             if (languageId != null)
             {
-                return Language.KnownLanguages.FirstOrDefault(x => StringComparer.OrdinalIgnoreCase.Equals(x.Id, languageId))
-                    ?? Language.Unknown;
+                return LanguageProvider.Instance.AllKnownLanguages.FirstOrDefault(x => StringComparer.OrdinalIgnoreCase.Equals(x.Id, languageId))
+                       ?? Language.Unknown;
             }
 
             Debug.Fail("Expected string input object");
@@ -76,7 +73,11 @@ namespace SonarLint.VisualStudio.Core
             return base.CanConvertFrom(context, destinationType);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
         {
             Debug.Assert(value is Language, $"Expected {nameof(Language)} input object");
             Debug.Assert(destinationType == typeof(string), "Expected string destination type");

--- a/src/Core/RuleHelpLinkProvider.cs
+++ b/src/Core/RuleHelpLinkProvider.cs
@@ -47,7 +47,7 @@ namespace SonarLint.VisualStudio.Core
 
         private static string GetWebsiteFolderName(string repoKey)
         {
-            var language = Language.KnownLanguages.FirstOrDefault(lang => lang.HasRepoKey(repoKey));
+            var language = LanguageProvider.Instance.AllKnownLanguages.FirstOrDefault(lang => lang.HasRepoKey(repoKey));
 
             if (language?.SecurityRepoInfo?.Key == repoKey)
             {

--- a/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
+++ b/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
@@ -23,8 +23,6 @@ using Newtonsoft.Json;
 using SonarLint.VisualStudio.Core.VsInfo;
 using SonarLint.VisualStudio.Integration.Service;
 using SonarLint.VisualStudio.Integration.SLCore;
-using SonarLint.VisualStudio.SLCore.Common.Helpers;
-using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Configuration;
 using SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models;
 using SonarLint.VisualStudio.TestInfrastructure;
@@ -117,103 +115,6 @@ public class SLCoreConstantsProviderTests
 
         var actual = testSubject.TelemetryConstants;
         actual.additionalAttributes["slvs_ide_info"].Should().BeNull();
-    }
-
-    [TestMethod]
-    public void StandaloneLanguages_ShouldBeExpected()
-    {
-        var testSubject = CreateTestSubject();
-        var expected = new[]
-        {
-            Language.JS,
-            Language.TS,
-            Language.CSS,
-            Language.HTML,
-            Language.C,
-            Language.CPP,
-            Language.CS,
-            Language.VBNET,
-            Language.SECRETS
-        };
-
-        var actual = testSubject.LanguagesInStandaloneMode;
-
-        actual.Should().BeEquivalentTo(expected);
-    }
-
-    [TestMethod]
-    public void ExtraLanguagesInConnectedMode_ShouldBeExpected()
-    {
-        var testSubject = CreateTestSubject();
-        var expected = new[]
-        {
-            Language.TSQL
-        };
-
-        var actual = testSubject.ExtraLanguagesInConnectedMode;
-
-        actual.Should().BeEquivalentTo(expected);
-    }
-
-    [TestMethod]
-    public void LanguagesWithDisabledAnalysis_ShouldBeExpected()
-    {
-        var testSubject = CreateTestSubject();
-        var expected = new[]
-        {
-            Language.CS,
-            Language.VBNET
-        };
-
-        var actual = testSubject.LanguagesWithDisabledAnalysis;
-
-        actual.Should().BeEquivalentTo(expected);
-    }
-
-
-    [TestMethod]
-    public void AllAnalyzableLanguages_ShouldBeExpected()
-    {
-        var testSubject = CreateTestSubject();
-        var expected = new[]
-        {
-            Language.JS,
-            Language.TS,
-            Language.HTML,
-            Language.CSS,
-            Language.C,
-            Language.CPP,
-            Language.SECRETS,
-            Language.TSQL
-        };
-
-        var actual = testSubject.AllAnalyzableLanguages;
-
-        actual.Should().BeEquivalentTo(expected);
-    }
-
-    [TestMethod]
-    public void Verify_AllConfiguredLanguagesAreKnown()
-    {
-        var slCoreConstantsProvider = CreateTestSubject();
-
-        var languages = slCoreConstantsProvider.LanguagesInStandaloneMode
-            .Concat(slCoreConstantsProvider.LanguagesWithDisabledAnalysis)
-            .Select(x => x.ConvertToCoreLanguage());
-
-        languages.Should().NotContain(Core.Language.Unknown);
-    }
-
-    [TestMethod]
-    public void Verify_AllConfiguredLanguagesHaveKnownPluginKeys()
-    {
-        var slCoreConstantsProvider = CreateTestSubject();
-
-        var languages = slCoreConstantsProvider.LanguagesInStandaloneMode
-            .Concat(slCoreConstantsProvider.LanguagesWithDisabledAnalysis)
-            .Select(x => x.GetPluginKey());
-
-        languages.Should().NotContainNulls();
     }
 
     private static SLCoreConstantsProvider CreateTestSubject(IVsInfoProvider infoProvider = null)

--- a/src/Integration.Vsix.UnitTests/Analysis/DisableRuleCommandTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/DisableRuleCommandTests.cs
@@ -44,21 +44,25 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = new Mock<IActiveSolutionBoundTracker>().Object;
             var logger = new TestLogger();
             var errorListHelper = Mock.Of<IErrorListHelper>();
+            var languageProvider = Mock.Of<ILanguageProvider>();
 
-            Action act = () => new DisableRuleCommand(null, userSettingsProvider, solutionTracker, logger, errorListHelper);
+            Action act = () => new DisableRuleCommand(null, userSettingsProvider, solutionTracker, logger, errorListHelper, languageProvider);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("menuCommandService");
 
-            act = () => new DisableRuleCommand(menuCommandService, null, solutionTracker, logger, errorListHelper);
+            act = () => new DisableRuleCommand(menuCommandService, null, solutionTracker, logger, errorListHelper, languageProvider);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("userSettingsProvider");
 
-            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, null, logger, errorListHelper);
+            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, null, logger, errorListHelper, languageProvider);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("activeSolutionBoundTracker");
 
-            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, solutionTracker, null, errorListHelper);
+            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, solutionTracker, null, errorListHelper, languageProvider);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
 
-            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, solutionTracker, logger, null);
+            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, solutionTracker, logger, null, languageProvider);
             act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("errorListHelper");
+
+            act = () => new DisableRuleCommand(menuCommandService, userSettingsProvider, solutionTracker, logger, errorListHelper, null);
+            act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("languageProvider");
         }
 
         [TestMethod]
@@ -70,13 +74,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
             // Act
-            var command = CreateDisableRuleMenuCommand(userSettingsProvider, solutionTracker, new TestLogger(), errorListHelper);
+            var command = CreateDisableRuleMenuCommand(userSettingsProvider, solutionTracker, new TestLogger(), errorListHelper, MockLanguageProvider());
 
             // Assert
             command.CommandID.ID.Should().Be(DisableRuleCommand.CommandId);
             command.CommandID.Guid.Should().Be(DisableRuleCommand.CommandSet);
         }
-
 
         [TestMethod]
         [DataRow("tsql:S222")]
@@ -89,7 +92,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
             // Act
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper, LanguageProvider.Instance);
 
             // 1. Trigger the query status check
             ThreadHelper.SetCurrentThreadAsUIThread();
@@ -116,7 +119,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
             // Act
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper, LanguageProvider.Instance);
 
             // 1. Trigger the query status check
             ThreadHelper.SetCurrentThreadAsUIThread();
@@ -145,14 +148,16 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
         [DataRow("css:S111", SonarLintMode.LegacyConnected, false)]
         [DataRow("Web:S111", SonarLintMode.Connected, false)]
         [DataRow("Web:S111", SonarLintMode.LegacyConnected, false)]
-        public void CheckStatus_SingleIssue_SupportedRepo_ConnectedMode_HasExpectedEnabledStatus(string errorCode, SonarLintMode bindingMode,
+        public void CheckStatus_SingleIssue_SupportedRepo_ConnectedMode_HasExpectedEnabledStatus(
+            string errorCode,
+            SonarLintMode bindingMode,
             bool expectedEnabled)
         {
             var mockUserSettingsProvider = new Mock<IUserSettingsProvider>();
             var solutionTracker = CreateSolutionTracker(bindingMode);
             var errorListHelper = CreateErrorListHelper(errorCode, ruleExists: true);
 
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper, LanguageProvider.Instance);
 
             // Act. Trigger the query status check
             ThreadHelper.SetCurrentThreadAsUIThread();
@@ -173,7 +178,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Connected);
             var errorListHelper = CreateErrorListHelper("secrets:S111", ruleExists: true);
 
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper, LanguageProvider.Instance);
 
             // Act. Trigger the query status check
             ThreadHelper.SetCurrentThreadAsUIThread();
@@ -197,7 +202,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = CreateSolutionTracker(mode);
 
             // Act
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, new TestLogger(), errorListHelper, LanguageProvider.Instance);
 
             // 1. Trigger the query status check
             var result = command.OleStatus;
@@ -220,7 +225,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
             // Act
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object, MockLanguageProvider());
 
             // Act - should not throw
             var _ = command.OleStatus;
@@ -240,7 +245,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var mockUserSettingsProvider = new Mock<IUserSettingsProvider>();
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object, MockLanguageProvider());
             Action act = () => _ = command.OleStatus;
 
             // Act
@@ -261,7 +266,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var mockUserSettingsProvider = new Mock<IUserSettingsProvider>();
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object, MockLanguageProvider());
 
             // Act - should not throw
             command.Invoke();
@@ -281,7 +286,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             var mockUserSettingsProvider = new Mock<IUserSettingsProvider>();
             var solutionTracker = CreateSolutionTracker(SonarLintMode.Standalone);
 
-            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object);
+            var command = CreateDisableRuleMenuCommand(mockUserSettingsProvider.Object, solutionTracker, testLogger, errorListHelper.Object, MockLanguageProvider());
             Action act = () => command.Invoke();
 
             // Act
@@ -290,11 +295,15 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             testLogger.AssertPartialOutputStringDoesNotExist("exception xxx");
         }
 
-        private static MenuCommand CreateDisableRuleMenuCommand(IUserSettingsProvider userSettingsProvider, IActiveSolutionBoundTracker solutionTracker, ILogger logger,
-            IErrorListHelper errorListHelper)
+        private static MenuCommand CreateDisableRuleMenuCommand(
+            IUserSettingsProvider userSettingsProvider,
+            IActiveSolutionBoundTracker solutionTracker,
+            ILogger logger,
+            IErrorListHelper errorListHelper,
+            ILanguageProvider languageProvider)
         {
             var dummyMenuService = new DummyMenuCommandService();
-            new DisableRuleCommand(dummyMenuService, userSettingsProvider, solutionTracker, logger, errorListHelper);
+            new DisableRuleCommand(dummyMenuService, userSettingsProvider, solutionTracker, logger, errorListHelper, languageProvider);
 
             dummyMenuService.AddedMenuCommands.Count.Should().Be(1);
             return dummyMenuService.AddedMenuCommands[0];
@@ -316,6 +325,13 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis.UnitTests
             errorListHelper.Setup(x => x.TryGetRuleIdFromSelectedRow(out ruleId)).Returns(ruleExists);
 
             return errorListHelper.Object;
+        }
+
+        private static ILanguageProvider MockLanguageProvider()
+        {
+            var languageProviderMock = new Mock<ILanguageProvider>();
+            languageProviderMock.Setup(m => m.LanguagesInStandaloneMode).Returns([]);
+            return languageProviderMock.Object;
         }
     }
 }

--- a/src/Integration.Vsix.UnitTests/Analysis/MuteIssueCommandTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/MuteIssueCommandTests.cs
@@ -354,7 +354,8 @@ public class MuteIssueCommandTests
         return issue;
     }
 
-    private static void SetUpIssueMuting(Mock<IServerIssueFinder> serverIssueFinderMock,
+    private static void SetUpIssueMuting(
+        Mock<IServerIssueFinder> serverIssueFinderMock,
         Mock<IMuteIssuesService> muteIssueServiceMock,
         MockSequence callSequence,
         IFilterableIssue issue,
@@ -367,7 +368,8 @@ public class MuteIssueCommandTests
             .Returns(Task.CompletedTask);
     }
 
-    private static void SetUpIssueFinder(Mock<IServerIssueFinder> serverIssueFinderMock,
+    private static void SetUpIssueFinder(
+        Mock<IServerIssueFinder> serverIssueFinderMock,
         MockSequence callSequence,
         IFilterableIssue issue,
         SonarQubeIssue sonarQubeIssue)
@@ -386,7 +388,8 @@ public class MuteIssueCommandTests
             .Returns((Func<Task<bool>> action) => action());
     }
 
-    private MenuCommand CreateTestSubject(out Mock<IErrorListHelper> errorListHelperMock,
+    private MenuCommand CreateTestSubject(
+        out Mock<IErrorListHelper> errorListHelperMock,
         out Mock<IRoslynIssueLineHashCalculator> roslynIssueLineHashCalculatorMock,
         out Mock<IServerIssueFinder> serverIssueFinderMock,
         out Mock<IMuteIssuesService> muteIssueServiceMock,
@@ -404,7 +407,8 @@ public class MuteIssueCommandTests
             (activeSolutionBoundTrackerMock = new Mock<IActiveSolutionBoundTracker>(MockBehavior.Strict)).Object,
             (threadHandlingMock = new Mock<IThreadHandling>(MockBehavior.Strict)).Object,
             (messeageBox = new Mock<IMessageBox>()).Object,
-            logger = new TestLogger());
+            logger = new TestLogger(),
+            LanguageProvider.Instance);
 
         dummyMenuService.AddedMenuCommands.Count.Should().Be(1);
         return dummyMenuService.AddedMenuCommands[0];

--- a/src/Integration.Vsix/Analysis/MuteIssueCommand.cs
+++ b/src/Integration.Vsix/Analysis/MuteIssueCommand.cs
@@ -45,6 +45,12 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
         private readonly ILogger logger;
         private readonly IMessageBox messageBox;
         private readonly IRoslynIssueLineHashCalculator roslynIssueLineHashCalculator;
+        // Strictly speaking we are allowing rules from known repos to be disabled,
+        // not "all rules for language X".  However, since we are in control of the
+        // rules/repos that are installed in  VSIX, checking the repo key is good
+        // enough.
+        private readonly IReadOnlyList<string> supportedRepos;
+
         // Command set guid and command id. Must match those in DaemonCommands.vsct
         public static readonly Guid CommandSet = new Guid("1F83EA11-3B07-45B3-BF39-307FD4F42194");
         public const int CommandId = 0x0400;
@@ -68,7 +74,8 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
                 await package.GetMefServiceAsync<IActiveSolutionBoundTracker>(),
                 await package.GetMefServiceAsync<IThreadHandling>(),
                 new MessageBox(),
-                logger);
+                logger,
+                await package.GetMefServiceAsync<ILanguageProvider>());
         }
 
         internal MuteIssueCommand(
@@ -80,11 +87,16 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             IActiveSolutionBoundTracker activeSolutionBoundTracker,
             IThreadHandling threadHandling,
             IMessageBox messageBox,
-            ILogger logger)
+            ILogger logger,
+            ILanguageProvider languageProvider)
         {
             if (menuCommandService == null)
             {
                 throw new ArgumentNullException(nameof(menuCommandService));
+            }
+            if (languageProvider == null)
+            {
+                throw new ArgumentNullException(nameof(languageProvider));
             }
 
             this.errorListHelper = errorListHelper ?? throw new ArgumentNullException(nameof(errorListHelper));
@@ -95,6 +107,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             this.threadHandling = threadHandling ?? throw new ArgumentNullException(nameof(threadHandling));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.messageBox = messageBox ?? throw new ArgumentNullException(nameof(messageBox));
+
+            // secrets should be enabled, but there is a bug, so it was on purpose disabled (See https://sonarsource.atlassian.net/browse/SLVS-1210)
+            supportedRepos = languageProvider.AllKnownLanguages.Except([Language.Secrets]).Select(x => x.RepoInfo.Key).ToList();
 
             var menuCommandID = new CommandID(CommandSet, CommandId);
             menuItem = new OleMenuCommand(Execute, null, QueryStatus, menuCommandID);
@@ -183,16 +198,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix.Analysis
             return true;
         }
 
-        // Strictly speaking we are allowing rules from known repos to be disabled,
-        // not "all rules for language X".  However, since we are in control of the
-        // rules/repos that are installed in  VSIX, checking the repo key is good
-        // enough.
-        private static readonly string[] SupportedRepos = new[]
-        {
-            Language.C.RepoInfo.Key, Language.Cpp.RepoInfo.Key, Language.Js.RepoInfo.Key, Language.Ts.RepoInfo.Key, Language.Css.RepoInfo.Key, Language.Html.RepoInfo.Key,
-            Language.CSharp.RepoInfo.Key, Language.VBNET.RepoInfo.Key, Language.TSql.RepoInfo.Key,
-        };
-
-        private static bool IsSupportedSonarRule(SonarCompositeRuleId rule) => SupportedRepos.Contains(rule.RepoKey);
+        private bool IsSupportedSonarRule(SonarCompositeRuleId rule) => supportedRepos.Contains(rule.RepoKey);
     }
 }

--- a/src/Integration/SLCore/SLCoreConstantsProvider.cs
+++ b/src/Integration/SLCore/SLCoreConstantsProvider.cs
@@ -22,7 +22,6 @@ using System.ComponentModel.Composition;
 using SonarLint.VisualStudio.Core.VsInfo;
 using SonarLint.VisualStudio.Integration.Service;
 using SonarLint.VisualStudio.Integration.Telemetry;
-using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Configuration;
 using SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models;
 
@@ -38,42 +37,15 @@ namespace SonarLint.VisualStudio.Integration.SLCore
         public SLCoreConstantsProvider(IVsInfoProvider vsInfoProvider)
         {
             this.vsInfoProvider = vsInfoProvider;
-            AllAnalyzableLanguages = LanguagesInStandaloneMode.Concat(ExtraLanguagesInConnectedMode).Except(LanguagesWithDisabledAnalysis).ToArray();
         }
 
         public ClientConstantsDto ClientConstants => new(vsInfoProvider.Name, $"SonarLint Visual Studio/{VersionHelper.SonarLintVersion}", Process.GetCurrentProcess().Id);
 
         public FeatureFlagsDto FeatureFlags => new(true, true, true, true, true, false, true, true, true);
 
-        public TelemetryClientConstantAttributesDto TelemetryConstants => new("visualstudio", "SonarLint Visual Studio", VersionHelper.SonarLintVersion, VisualStudioHelpers.VisualStudioVersion, new Dictionary<string, object>
-        {
-            { "slvs_ide_info", GetVsVersion(vsInfoProvider.Version) }
-        });
-
-        public IReadOnlyList<Language> LanguagesInStandaloneMode =>
-        [
-            Language.JS,
-            Language.TS,
-            Language.HTML,
-            Language.CSS,
-            Language.C,
-            Language.CPP,
-            Language.CS,
-            Language.VBNET,
-            Language.SECRETS,
-        ];
-        public IReadOnlyList<Language> ExtraLanguagesInConnectedMode =>
-        [
-            Language.TSQL
-        ];
-
-        public IReadOnlyList<Language> LanguagesWithDisabledAnalysis =>
-        [
-            Language.CS,
-            Language.VBNET,
-        ];
-
-        public IReadOnlyList<Language> AllAnalyzableLanguages { get; }
+        public TelemetryClientConstantAttributesDto TelemetryConstants =>
+            new("visualstudio", "SonarLint Visual Studio", VersionHelper.SonarLintVersion, VisualStudioHelpers.VisualStudioVersion,
+                new Dictionary<string, object> { { "slvs_ide_info", GetVsVersion(vsInfoProvider.Version) } });
 
         private static IdeVersionInformation GetVsVersion(IVsVersion vsVersion)
         {
@@ -82,12 +54,7 @@ namespace SonarLint.VisualStudio.Integration.SLCore
                 return null;
             }
 
-            return new IdeVersionInformation
-            {
-                DisplayName = vsVersion.DisplayName,
-                InstallationVersion = vsVersion.InstallationVersion,
-                DisplayVersion = vsVersion.DisplayVersion
-            };
+            return new IdeVersionInformation { DisplayName = vsVersion.DisplayName, InstallationVersion = vsVersion.InstallationVersion, DisplayVersion = vsVersion.DisplayVersion };
         }
     }
 }

--- a/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
+++ b/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
@@ -23,10 +23,8 @@ using System.IO.Abstractions;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.ConfigurationScope;
-using SonarLint.VisualStudio.Core.VsInfo;
 using SonarLint.VisualStudio.Integration;
 using SonarLint.VisualStudio.Integration.Service;
-using SonarLint.VisualStudio.Integration.SLCore;
 using SonarLint.VisualStudio.Integration.Vsix.Helpers;
 using SonarLint.VisualStudio.Integration.Vsix.SLCore;
 using SonarLint.VisualStudio.SLCore.Analysis;
@@ -91,13 +89,14 @@ public sealed class SLCoreTestRunner : IDisposable
             rootLocator.GetVsixRoot().Returns(DependencyLocator.SloopBasePath);
             var slCoreLocator = new SLCoreLocator(rootLocator, string.Empty, Substitute.For<ISonarLintSettings>(), logger, Substitute.For<IFileSystem>());
 
+            var sLCoreLanguageProvider = Substitute.For<ISLCoreLanguageProvider>();
             var constantsProvider = Substitute.For<ISLCoreConstantsProvider>();
             constantsProvider.ClientConstants.Returns(new ClientConstantsDto("SLVS_Integration_Tests",
                 $"SLVS_Integration_Tests/{VersionHelper.SonarLintVersion}", Process.GetCurrentProcess().Id));
             constantsProvider.FeatureFlags.Returns(new FeatureFlagsDto(true, true, false, true, false, false, true, false, false));
             constantsProvider.TelemetryConstants.Returns(new TelemetryClientConstantAttributesDto("slvs_integration_tests", "SLVS Integration Tests",
                 VersionHelper.SonarLintVersion, "17.0", new()));
-            SetLanguagesConfigurationToDefaults(constantsProvider);
+            SetLanguagesConfigurationToDefaults(sLCoreLanguageProvider);
 
             var foldersProvider = Substitute.For<ISLCoreFoldersProvider>();
             foldersProvider.GetWorkFolders().Returns(new SLCoreFolders(storageRoot, workDir, userHome));
@@ -121,6 +120,7 @@ public sealed class SLCoreTestRunner : IDisposable
                     new SLCoreServiceProvider(new NoOpThreadHandler(), logger),
                     new SLCoreListenerSetUp(listenersToSetUp)),
                 constantsProvider,
+                sLCoreLanguageProvider,
                 foldersProvider,
                 connectionProvider,
                 jarProvider,
@@ -138,11 +138,11 @@ public sealed class SLCoreTestRunner : IDisposable
         }
     }
 
-    private static void SetLanguagesConfigurationToDefaults(ISLCoreConstantsProvider constantsProvider)
+    private static void SetLanguagesConfigurationToDefaults(ISLCoreLanguageProvider languageProvider)
     {
-        var defaultConstantsProvider = new SLCoreConstantsProvider(Substitute.For<IVsInfoProvider>());
-        constantsProvider.LanguagesInStandaloneMode.Returns(defaultConstantsProvider.LanguagesInStandaloneMode);
-        constantsProvider.LanguagesWithDisabledAnalysis.Returns(defaultConstantsProvider.LanguagesWithDisabledAnalysis);
+        var defaultLanguageProvider = new SLCoreLanguageProvider(LanguageProvider.Instance);
+        languageProvider.LanguagesInStandaloneMode.Returns(defaultLanguageProvider.LanguagesInStandaloneMode);
+        languageProvider.LanguagesWithDisabledAnalysis.Returns(defaultLanguageProvider.LanguagesWithDisabledAnalysis);
     }
 
     public void Dispose()

--- a/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
+++ b/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
@@ -82,7 +82,7 @@ internal class RaisedFindingProcessor(
             var localPath = fileUri.LocalPath;
             var analysisStatusNotifier = analysisStatusNotifierFactory.Create(nameof(SLCoreAnalyzer), localPath, parameters.analysisId);
             var supportedRaisedIssues = GetSupportedLanguageFindings(fileAndIssues.Value ?? []);
-           findingsPublisher.Publish(localPath,
+            findingsPublisher.Publish(localPath,
                 parameters.analysisId!.Value,
                 raiseFindingToAnalysisIssueConverter.GetAnalysisIssues(fileUri, supportedRaisedIssues));
             analysisStatusNotifier.AnalysisProgressed(supportedRaisedIssues.Length, findingsPublisher.FindingsType, parameters.isIntermediatePublication);
@@ -95,7 +95,7 @@ internal class RaisedFindingProcessor(
     private static List<string> CalculateAnalyzableRulePrefixes(ISLCoreConstantsProvider slCoreConstantsProvider) =>
         slCoreConstantsProvider.AllAnalyzableLanguages?
             .Select(x => x.ConvertToCoreLanguage())
-            .Select(Language.GetSonarRepoKeyFromLanguage)
+            .Select(x => x.RepoInfo?.Key)
             .Where(r => r is not null)
             .ToList() ?? [];
 }

--- a/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
+++ b/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
@@ -38,13 +38,13 @@ internal interface IRaisedFindingProcessor
 [PartCreationPolicy(CreationPolicy.Shared)]
 [method: ImportingConstructor]
 internal class RaisedFindingProcessor(
-    ISLCoreConstantsProvider slCoreConstantsProvider,
+    ISLCoreLanguageProvider slCoreLanguageProvider,
     IRaiseFindingToAnalysisIssueConverter raiseFindingToAnalysisIssueConverter,
     IAnalysisStatusNotifierFactory analysisStatusNotifierFactory,
     ILogger logger)
     : IRaisedFindingProcessor
 {
-    private readonly List<string> analyzableLanguagesRuleKeyPrefixes = CalculateAnalyzableRulePrefixes(slCoreConstantsProvider);
+    private readonly List<string> analyzableLanguagesRuleKeyPrefixes = CalculateAnalyzableRulePrefixes(slCoreLanguageProvider);
 
     public void RaiseFinding<T>(RaiseFindingParams<T> parameters, IFindingsPublisher findingsPublisher) where T : RaisedFindingDto
     {
@@ -92,7 +92,7 @@ internal class RaisedFindingProcessor(
     private T[] GetSupportedLanguageFindings<T>(IEnumerable<T> findings) where T : RaisedFindingDto =>
         findings.Where(i => analyzableLanguagesRuleKeyPrefixes.Exists(languageRepo => i.ruleKey.StartsWith(languageRepo))).ToArray();
 
-    private static List<string> CalculateAnalyzableRulePrefixes(ISLCoreConstantsProvider slCoreConstantsProvider) =>
+    private static List<string> CalculateAnalyzableRulePrefixes(ISLCoreLanguageProvider slCoreConstantsProvider) =>
         slCoreConstantsProvider.AllAnalyzableLanguages?
             .Select(x => x.ConvertToCoreLanguage())
             .Select(x => x.RepoInfo?.Key)

--- a/src/SLCore.UnitTests/Common/Helpers/LanguageExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/LanguageExtensionsTests.cs
@@ -37,6 +37,7 @@ public class LanguageExtensionsTests
         VerifyConversionToCoreLanguage(Language.SECRETS, VisualStudio.Core.Language.Secrets);
         VerifyConversionToCoreLanguage(Language.TS, VisualStudio.Core.Language.Ts);
         VerifyConversionToCoreLanguage(Language.VBNET, VisualStudio.Core.Language.VBNET);
+        VerifyConversionToCoreLanguage(Language.HTML, VisualStudio.Core.Language.Html);
         VerifyConversionToCoreLanguage(Language.TSQL, VisualStudio.Core.Language.TSql);
         VerifyConversionToCoreLanguage(Language.ABAP, VisualStudio.Core.Language.Unknown);
         VerifyConversionToCoreLanguage(Language.JAVA, VisualStudio.Core.Language.Unknown);
@@ -62,11 +63,12 @@ public class LanguageExtensionsTests
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.C, Language.C);
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Cpp, Language.CPP);
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.CSharp, Language.CS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.VBNET, Language.VBNET);
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Css, Language.CSS);
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Js, Language.JS);
-        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Secrets, Language.SECRETS);
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Ts, Language.TS);
-        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.VBNET, Language.VBNET);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Secrets, Language.SECRETS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Html, Language.HTML);
         VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.TSql, Language.TSQL);
     }
 

--- a/src/SLCore.UnitTests/Common/Helpers/LanguageExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/LanguageExtensionsTests.cs
@@ -54,13 +54,31 @@ public class LanguageExtensionsTests
     [DataRow(Language.TSQL, "tsql")]
     [DataRow(Language.ABAP, null)]
     [DataRow(Language.JAVA, null)]
-    public void VerifyPluginKeys(Language language, string expectedPluginKey)
+    public void VerifyPluginKeys(Language language, string expectedPluginKey) => language.GetPluginKey().Should().BeEquivalentTo(expectedPluginKey);
+
+    [TestMethod]
+    public void VerifyConvertToSlCoreLanguage()
     {
-        language.GetPluginKey().Should().BeEquivalentTo(expectedPluginKey);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.C, Language.C);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Cpp, Language.CPP);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.CSharp, Language.CS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Css, Language.CSS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Js, Language.JS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Secrets, Language.SECRETS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.Ts, Language.TS);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.VBNET, Language.VBNET);
+        VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language.TSql, Language.TSQL);
     }
 
-    private static void VerifyConversionToCoreLanguage(Language language, VisualStudio.Core.Language coreLanguage)
+    [TestMethod]
+    public void ConvertToSlCoreLanguage_UnknownLanguage_Throws()
     {
-        language.ConvertToCoreLanguage().Should().BeSameAs(coreLanguage);
+        var act = () => VisualStudio.Core.Language.Unknown.ConvertToSlCoreLanguage();
+
+        act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("language");
     }
+
+    private static void VerifyConversionToCoreLanguage(Language language, VisualStudio.Core.Language coreLanguage) => language.ConvertToCoreLanguage().Should().BeSameAs(coreLanguage);
+
+    private static void VerifyConvertToSlCoreLanguage(VisualStudio.Core.Language coreLanguage, Language language) => coreLanguage.ConvertToSlCoreLanguage().Should().Be(language);
 }

--- a/src/SLCore.UnitTests/Configuration/SlCoreLanguageProviderTests.cs
+++ b/src/SLCore.UnitTests/Configuration/SlCoreLanguageProviderTests.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.SLCore.Common.Helpers;
+using SonarLint.VisualStudio.SLCore.Configuration;
+
+namespace SonarLint.VisualStudio.SLCore.UnitTests.Configuration;
+
+[TestClass]
+public class SlCoreLanguageProviderTests
+{
+    private SLCoreLanguageProvider testSubject;
+    private ILanguageProvider languageProvider;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        MockLanguageProvider();
+        testSubject = new SLCoreLanguageProvider(languageProvider);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<SLCoreLanguageProvider, ISLCoreLanguageProvider>(MefTestHelpers.CreateExport<ILanguageProvider>(languageProvider));
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<SLCoreLanguageProvider>();
+
+    [TestMethod]
+    public void StandaloneLanguages_ShouldBeExpected()
+    {
+        _ = languageProvider.Received(1).LanguagesInStandaloneMode;
+        testSubject.LanguagesInStandaloneMode.Should().BeEquivalentTo(languageProvider.LanguagesInStandaloneMode.Select(x => x.ConvertToSlCoreLanguage()));
+    }
+
+    [TestMethod]
+    public void ExtraLanguagesInConnectedMode_ShouldBeExpected()
+    {
+        _ = languageProvider.Received(1).ExtraLanguagesInConnectedMode;
+        testSubject.ExtraLanguagesInConnectedMode.Should().BeEquivalentTo(languageProvider.ExtraLanguagesInConnectedMode.Select(x => x.ConvertToSlCoreLanguage()));
+    }
+
+    [TestMethod]
+    public void LanguagesWithDisabledAnalysis_ShouldBeExpected()
+    {
+        _ = languageProvider.Received(1).RoslynLanguages;
+        testSubject.LanguagesWithDisabledAnalysis.Should().BeEquivalentTo(languageProvider.RoslynLanguages.Select(x => x.ConvertToSlCoreLanguage()));
+    }
+
+    [TestMethod]
+    public void AllAnalyzableLanguages_ShouldBeExpected()
+    {
+        var expected = testSubject.LanguagesInStandaloneMode.Concat(testSubject.ExtraLanguagesInConnectedMode).Except(testSubject.LanguagesWithDisabledAnalysis);
+
+        testSubject.AllAnalyzableLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    private void MockLanguageProvider()
+    {
+        languageProvider = Substitute.For<ILanguageProvider>();
+        // it doesn't have to be the real lists, just need to be different so the test can verify that the provider is using them
+        languageProvider.AllKnownLanguages.Returns([Language.C, Language.Js, Language.Ts, Language.TSql]);
+        languageProvider.RoslynLanguages.Returns([Language.C]);
+        languageProvider.SlCoreLanguages.Returns([Language.Js]);
+        languageProvider.LanguagesInStandaloneMode.Returns([Language.Ts]);
+        languageProvider.ExtraLanguagesInConnectedMode.Returns([Language.TSql]);
+    }
+}

--- a/src/SLCore.UnitTests/SLCoreInstanceFactoryTests.cs
+++ b/src/SLCore.UnitTests/SLCoreInstanceFactoryTests.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.ConfigurationScope;
@@ -38,6 +37,7 @@ public class SLCoreInstanceFactoryTests
         MefTestHelpers.CheckTypeCanBeImported<SLCoreInstanceFactory, ISLCoreInstanceFactory>(
             MefTestHelpers.CreateExport<ISLCoreRpcFactory>(),
             MefTestHelpers.CreateExport<ISLCoreConstantsProvider>(),
+            MefTestHelpers.CreateExport<ISLCoreLanguageProvider>(),
             MefTestHelpers.CreateExport<ISLCoreFoldersProvider>(),
             MefTestHelpers.CreateExport<IServerConnectionsProvider>(),
             MefTestHelpers.CreateExport<ISLCoreEmbeddedPluginJarLocator>(),
@@ -55,12 +55,12 @@ public class SLCoreInstanceFactoryTests
         MefTestHelpers.CheckIsSingletonMefComponent<SLCoreInstanceFactory>();
     }
 
-
     [TestMethod]
     public void CreateInstance_ReturnsNonNull()
     {
         var islCoreRpcFactory = Substitute.For<ISLCoreRpcFactory>();
         var islCoreConstantsProvider = Substitute.For<ISLCoreConstantsProvider>();
+        var slCoreLanguageProvider = Substitute.For<ISLCoreLanguageProvider>();
         var islCoreFoldersProvider = Substitute.For<ISLCoreFoldersProvider>();
         var serverConnectionsProvider = Substitute.For<IServerConnectionsProvider>();
         var islCoreEmbeddedPluginJarLocator = Substitute.For<ISLCoreEmbeddedPluginJarLocator>();
@@ -73,6 +73,7 @@ public class SLCoreInstanceFactoryTests
 
         var testSubject = new SLCoreInstanceFactory(islCoreRpcFactory,
             islCoreConstantsProvider,
+            slCoreLanguageProvider,
             islCoreFoldersProvider,
             serverConnectionsProvider,
             islCoreEmbeddedPluginJarLocator,

--- a/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
+++ b/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
@@ -55,9 +55,10 @@ public class SLCoreInstanceHandleTests
     private static readonly BoundServerProject Binding = new("solution", "projectKey", new ServerConnection.SonarQube(new Uri("http://localhost")));
 
     private static readonly List<string> JarList = new() { "jar1" };
-    private static readonly Dictionary<string, string> ConnectedModeJarList = new() { {"key", "jar1"} };
+    private static readonly Dictionary<string, string> ConnectedModeJarList = new() { { "key", "jar1" } };
     private ISLCoreRpcFactory slCoreRpcFactory;
     private ISLCoreConstantsProvider constantsProvider;
+    private ISLCoreLanguageProvider slCoreLanguageProvider;
     private ISLCoreFoldersProvider foldersProvider;
     private IServerConnectionsProvider connectionsProvider;
     private ISLCoreEmbeddedPluginJarLocator jarLocator;
@@ -74,6 +75,7 @@ public class SLCoreInstanceHandleTests
     {
         slCoreRpcFactory = Substitute.For<ISLCoreRpcFactory>();
         constantsProvider = Substitute.For<ISLCoreConstantsProvider>();
+        slCoreLanguageProvider = Substitute.For<ISLCoreLanguageProvider>();
         foldersProvider = Substitute.For<ISLCoreFoldersProvider>();
         connectionsProvider = Substitute.For<IServerConnectionsProvider>();
         jarLocator = Substitute.For<ISLCoreEmbeddedPluginJarLocator>();
@@ -86,6 +88,7 @@ public class SLCoreInstanceHandleTests
 
         testSubject = new SLCoreInstanceHandle(slCoreRpcFactory,
             constantsProvider,
+            slCoreLanguageProvider,
             foldersProvider,
             connectionsProvider,
             jarLocator,
@@ -114,7 +117,7 @@ public class SLCoreInstanceHandleTests
     [DataRow(null)]
     public void Initialize_SuccessfullyInitializesInCorrectOrder(string nodeJsPath)
     {
-        SetUpLanguages(constantsProvider, [], [], []);
+        SetUpLanguages(slCoreLanguageProvider, [], [], []);
         SetUpSuccessfulInitialization(out var lifecycleManagement, out _);
         nodeLocator.Get().Returns(nodeJsPath);
         var telemetryMigrationDto = new TelemetryMigrationDto(default, default, default);
@@ -152,7 +155,7 @@ public class SLCoreInstanceHandleTests
         List<Language> standalone = [Language.CS, Language.HTML];
         List<Language> connected = [Language.VBNET, Language.TSQL];
         List<Language> disabledAnalysis = [Language.CPP, Language.JS];
-        SetUpLanguages(constantsProvider, standalone, connected, disabledAnalysis);
+        SetUpLanguages(slCoreLanguageProvider, standalone, connected, disabledAnalysis);
         SetUpSuccessfulInitialization(out var lifecycleManagement, out _);
 
         testSubject.Initialize();
@@ -178,7 +181,7 @@ public class SLCoreInstanceHandleTests
     public void Dispose_Initialized_ShutsDownAndDisposesRpc()
     {
         SetUpThreadHandling(threadHandling);
-        SetUpLanguages(constantsProvider, [], [], []);
+        SetUpLanguages(slCoreLanguageProvider, [], [], []);
 
         SetUpSuccessfulInitialization(out var lifecycleManagement, out var rpc);
         testSubject.Initialize();
@@ -186,7 +189,6 @@ public class SLCoreInstanceHandleTests
         var serviceProvider = rpc.ServiceProvider;
         serviceProvider.ClearReceivedCalls();
         testSubject.Dispose();
-
 
         serviceProvider.Received().TryGetTransientService(out Arg.Any<ILifecycleManagementSLCoreService>());
         Received.InOrder(() =>
@@ -203,7 +205,7 @@ public class SLCoreInstanceHandleTests
     public void Dispose_IgnoresServiceProviderException()
     {
         SetUpThreadHandling(threadHandling);
-        SetUpLanguages(constantsProvider, [], [], []);
+        SetUpLanguages(slCoreLanguageProvider, [], [], []);
 
         SetUpSuccessfulInitialization(out var lifecycleManagement, out var rpc);
         lifecycleManagement.When(x => x.Shutdown()).Do(_ => throw new Exception());
@@ -222,7 +224,7 @@ public class SLCoreInstanceHandleTests
     public void Dispose_IgnoresShutdownException()
     {
         SetUpThreadHandling(threadHandling);
-        SetUpLanguages(constantsProvider, [], [], []);
+        SetUpLanguages(slCoreLanguageProvider, [], [], []);
 
         SetUpSuccessfulInitialization(out var lifecycleManagement, out var rpc);
         lifecycleManagement.When(x => x.Shutdown()).Do(_ => throw new Exception());
@@ -239,7 +241,7 @@ public class SLCoreInstanceHandleTests
     public void Dispose_ConnectionDied_DisposesRpc()
     {
         SetUpThreadHandling(threadHandling);
-        SetUpLanguages(constantsProvider, [], [], []);
+        SetUpLanguages(slCoreLanguageProvider, [], [], []);
 
         SetUpSuccessfulInitialization(out var lifecycleManagement, out var rpc);
         testSubject.Initialize();
@@ -281,9 +283,7 @@ public class SLCoreInstanceHandleTests
         foldersProvider.GetWorkFolders().Returns(new SLCoreFolders(StorageRoot, WorkDir, UserHome));
         connectionsProvider.GetServerConnections().Returns(new Dictionary<string, ServerConnectionConfiguration>
         {
-            { SonarQubeConnection1.connectionId, SonarQubeConnection1 },
-            { SonarQubeConnection2.connectionId, SonarQubeConnection2 },
-            { SonarCloudConnection.connectionId, SonarCloudConnection }
+            { SonarQubeConnection1.connectionId, SonarQubeConnection1 }, { SonarQubeConnection2.connectionId, SonarQubeConnection2 }, { SonarCloudConnection.connectionId, SonarCloudConnection }
         });
         jarLocator.ListJarFiles().Returns(JarList);
         jarLocator.ListConnectedModeEmbeddedPluginPathsByKey().Returns(ConnectedModeJarList);
@@ -291,14 +291,15 @@ public class SLCoreInstanceHandleTests
         slCoreRuleSettingsProvider.GetSLCoreRuleSettings().Returns(new Dictionary<string, StandaloneRuleConfigDto>());
     }
 
-    private void SetUpLanguages(ISLCoreConstantsProvider constantsProvider,
+    private void SetUpLanguages(
+        ISLCoreLanguageProvider slCoreLanguageProvider,
         List<Language> standalone,
         List<Language> connected,
         List<Language> disabledAnalysis)
     {
-        constantsProvider.LanguagesInStandaloneMode.Returns(standalone);
-        constantsProvider.ExtraLanguagesInConnectedMode.Returns(connected);
-        constantsProvider.LanguagesWithDisabledAnalysis.Returns(disabledAnalysis);
+        slCoreLanguageProvider.LanguagesInStandaloneMode.Returns(standalone);
+        slCoreLanguageProvider.ExtraLanguagesInConnectedMode.Returns(connected);
+        slCoreLanguageProvider.LanguagesWithDisabledAnalysis.Returns(disabledAnalysis);
     }
 
     #region RpcSetUp
@@ -315,7 +316,8 @@ public class SLCoreInstanceHandleTests
         slCoreRpc.ServiceProvider.Returns(slCoreServiceProvider);
     }
 
-    private void SetUpSLCoreServiceProvider(ISLCoreServiceProvider slCoreServiceProvider,
+    private void SetUpSLCoreServiceProvider(
+        ISLCoreServiceProvider slCoreServiceProvider,
         out ILifecycleManagementSLCoreService lifecycleManagementSlCoreService)
     {
         var managementService = Substitute.For<ILifecycleManagementSLCoreService>();

--- a/src/SLCore/Common/Helpers/LanguageExtensions.cs
+++ b/src/SLCore/Common/Helpers/LanguageExtensions.cs
@@ -19,6 +19,7 @@
  */
 
 using SonarLint.VisualStudio.SLCore.Common.Models;
+using static SonarLint.VisualStudio.Core.Language;
 
 namespace SonarLint.VisualStudio.SLCore.Common.Helpers;
 
@@ -27,18 +28,63 @@ internal static class LanguageExtensions
     public static VisualStudio.Core.Language ConvertToCoreLanguage(this Language language) =>
         language switch
         {
-            Language.C => VisualStudio.Core.Language.C,
-            Language.CPP => VisualStudio.Core.Language.Cpp,
-            Language.CS => VisualStudio.Core.Language.CSharp,
-            Language.CSS => VisualStudio.Core.Language.Css,
-            Language.HTML => VisualStudio.Core.Language.Html,
-            Language.JS => VisualStudio.Core.Language.Js,
-            Language.SECRETS => VisualStudio.Core.Language.Secrets,
-            Language.TS => VisualStudio.Core.Language.Ts,
-            Language.VBNET => VisualStudio.Core.Language.VBNET,
-            Language.TSQL => VisualStudio.Core.Language.TSql,
-            _ => VisualStudio.Core.Language.Unknown
+            Language.C => C,
+            Language.CPP => Cpp,
+            Language.CS => CSharp,
+            Language.CSS => Css,
+            Language.HTML => Html,
+            Language.JS => Js,
+            Language.SECRETS => Secrets,
+            Language.TS => Ts,
+            Language.VBNET => VBNET,
+            Language.TSQL => TSql,
+            _ => Unknown
         };
+
+    public static Language ConvertToSlCoreLanguage(this VisualStudio.Core.Language language)
+    {
+        if (language.Id == C.Id)
+        {
+            return Language.C;
+        }
+        if (language.Id == Cpp.Id)
+        {
+            return Language.CPP;
+        }
+        if (language.Id == CSharp.Id)
+        {
+            return Language.CS;
+        }
+        if (language.Id == Css.Id)
+        {
+            return Language.CSS;
+        }
+        if (language.Id == Html.Id)
+        {
+            return Language.HTML;
+        }
+        if (language.Id == Js.Id)
+        {
+            return Language.JS;
+        }
+        if (language.Id == Secrets.Id)
+        {
+            return Language.SECRETS;
+        }
+        if (language.Id == Ts.Id)
+        {
+            return Language.TS;
+        }
+        if (language.Id == VBNET.Id)
+        {
+            return Language.VBNET;
+        }
+        if (language.Id == TSql.Id)
+        {
+            return Language.TSQL;
+        }
+        throw new ArgumentOutOfRangeException(nameof(language), language, null);
+    }
 
     public static string GetPluginKey(this Language language) => language.ConvertToCoreLanguage().PluginInfo?.Key;
 }

--- a/src/SLCore/Configuration/ISLCoreConstantsProvider.cs
+++ b/src/SLCore/Configuration/ISLCoreConstantsProvider.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models;
 
 namespace SonarLint.VisualStudio.SLCore.Configuration;
@@ -28,9 +27,4 @@ public interface ISLCoreConstantsProvider
     ClientConstantsDto ClientConstants { get; }
     FeatureFlagsDto FeatureFlags { get; }
     TelemetryClientConstantAttributesDto TelemetryConstants { get; }
-
-    IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
-    IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; }
-    IReadOnlyList<Language> AllAnalyzableLanguages { get; }
-    IReadOnlyList<Language> LanguagesWithDisabledAnalysis { get; }
 }

--- a/src/SLCore/Configuration/ISLCoreLanguageProvider.cs
+++ b/src/SLCore/Configuration/ISLCoreLanguageProvider.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.SLCore.Common.Helpers;
+using Language = SonarLint.VisualStudio.SLCore.Common.Models.Language;
+
+namespace SonarLint.VisualStudio.SLCore.Configuration;
+
+public interface ISLCoreLanguageProvider
+{
+    IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
+    IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; }
+    IReadOnlyList<Language> AllAnalyzableLanguages { get; }
+    IReadOnlyList<Language> LanguagesWithDisabledAnalysis { get; }
+}
+
+[Export(typeof(ISLCoreLanguageProvider))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+public class SLCoreLanguageProvider : ISLCoreLanguageProvider
+{
+    [ImportingConstructor]
+    public SLCoreLanguageProvider(ILanguageProvider languageProvider)
+    {
+        LanguagesInStandaloneMode = languageProvider.LanguagesInStandaloneMode.Select(x => x.ConvertToSlCoreLanguage()).ToList();
+        ExtraLanguagesInConnectedMode = languageProvider.ExtraLanguagesInConnectedMode.Select(x => x.ConvertToSlCoreLanguage()).ToList();
+        LanguagesWithDisabledAnalysis = languageProvider.RoslynLanguages.Select(x => x.ConvertToSlCoreLanguage()).ToList();
+        AllAnalyzableLanguages = LanguagesInStandaloneMode.Concat(ExtraLanguagesInConnectedMode).Except(LanguagesWithDisabledAnalysis).ToArray();
+    }
+
+    public IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
+    public IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; }
+    public IReadOnlyList<Language> LanguagesWithDisabledAnalysis { get; }
+    public IReadOnlyList<Language> AllAnalyzableLanguages { get; }
+}

--- a/src/SLCore/ISLCoreInstanceFactory.cs
+++ b/src/SLCore/ISLCoreInstanceFactory.cs
@@ -40,6 +40,7 @@ internal class SLCoreInstanceFactory : ISLCoreInstanceFactory
 {
     private readonly ISLCoreRpcFactory slCoreRpcFactory;
     private readonly ISLCoreConstantsProvider constantsProvider;
+    private readonly ISLCoreLanguageProvider slCoreLanguageProvider;
     private readonly ISLCoreFoldersProvider slCoreFoldersProvider;
     private readonly IServerConnectionsProvider serverConnectionConfigurationProvider;
     private readonly ISLCoreEmbeddedPluginJarLocator slCoreEmbeddedPluginJarProvider;
@@ -51,8 +52,10 @@ internal class SLCoreInstanceFactory : ISLCoreInstanceFactory
     private readonly ISlCoreTelemetryMigrationProvider telemetryMigrationProvider;
 
     [ImportingConstructor]
-    public SLCoreInstanceFactory(ISLCoreRpcFactory slCoreRpcFactory,
+    public SLCoreInstanceFactory(
+        ISLCoreRpcFactory slCoreRpcFactory,
         ISLCoreConstantsProvider constantsProvider,
+        ISLCoreLanguageProvider slCoreLanguageProvider,
         ISLCoreFoldersProvider slCoreFoldersProvider,
         IServerConnectionsProvider serverConnectionConfigurationProvider,
         ISLCoreEmbeddedPluginJarLocator slCoreEmbeddedPluginJarProvider,
@@ -65,6 +68,7 @@ internal class SLCoreInstanceFactory : ISLCoreInstanceFactory
     {
         this.slCoreRpcFactory = slCoreRpcFactory;
         this.constantsProvider = constantsProvider;
+        this.slCoreLanguageProvider = slCoreLanguageProvider;
         this.slCoreFoldersProvider = slCoreFoldersProvider;
         this.serverConnectionConfigurationProvider = serverConnectionConfigurationProvider;
         this.slCoreEmbeddedPluginJarProvider = slCoreEmbeddedPluginJarProvider;
@@ -79,6 +83,7 @@ internal class SLCoreInstanceFactory : ISLCoreInstanceFactory
     public ISLCoreInstanceHandle CreateInstance() =>
         new SLCoreInstanceHandle(slCoreRpcFactory,
             constantsProvider,
+            slCoreLanguageProvider,
             slCoreFoldersProvider,
             serverConnectionConfigurationProvider,
             slCoreEmbeddedPluginJarProvider,


### PR DESCRIPTION
[SLVS-1826](https://sonarsource.atlassian.net/browse/SLVS-1826)

Reduce the number of places that have to be adapted when adding a new language by introducing a new service, LanguageProvider, and by using it in all the places where lists of Language instances were used.

[SLVS-1826]: https://sonarsource.atlassian.net/browse/SLVS-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ