### PR TITLE
SLVS-1826 Introduce LanguageProvider

### DIFF
--- a/src/ConnectedMode.UnitTests/Binding/NonRoslynDummyBindingConfigProviderTests.cs
+++ b/src/ConnectedMode.UnitTests/Binding/NonRoslynDummyBindingConfigProviderTests.cs
@@ -26,10 +26,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.Binding;
 [TestClass]
 public class NonRoslynDummyBindingConfigProviderTests
 {
-    private static IEnumerable<Language> SupportedLanguages { get; } = Language.KnownLanguages.Where(l => l != Language.CSharp && l != Language.VBNET);
+    private static IEnumerable<Language> SupportedLanguages { get; } = LanguageProvider.Instance.AllKnownLanguages.Where(l => l != Language.CSharp && l != Language.VBNET);
     private static IEnumerable<Language> RoslynLanguages { get; } = [Language.CSharp, Language.VBNET];
 
     public static IEnumerable<object[]> GetSupportedLanguages() => SupportedLanguages.Select(l => new object[] { l });
+
     public static IEnumerable<object[]> GetRoslynLanguages() => RoslynLanguages.Select(l => new object[] { l });
 
     public static IEnumerable<object[]> GetLanguagesWithSupport()

--- a/src/ConnectedMode.UnitTests/QualityProfiles/QualityProfileDownloaderTests.cs
+++ b/src/ConnectedMode.UnitTests/QualityProfiles/QualityProfileDownloaderTests.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.ConnectedMode.QualityProfiles;
 using SonarLint.VisualStudio.Core;
@@ -65,7 +61,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             var testSubject = CreateTestSubject(outOfDateQualityProfileFinderMock.Object,
                 bindingConfigProvider.Object,
                 logger: logger,
-                languagesToBind: Language.KnownLanguages.ToArray());
+                languagesToBind: LanguageProvider.Instance.AllKnownLanguages.ToArray());
 
             var result = await testSubject.UpdateAsync(boundSonarQubeProject, null, CancellationToken.None);
 
@@ -82,13 +78,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             var logger = new TestLogger(logToConsole: true);
             var boundProject = CreateBoundProject();
 
-            var languagesToBind = new[]
-            {
-                Language.Cpp,
-                Language.CSharp,
-                Language.Secrets,
-                Language.VBNET
-            };
+            var languagesToBind = new[] { Language.Cpp, Language.CSharp, Language.Secrets, Language.VBNET };
 
             SetupLanguagesToUpdate(out var outOfDateQualityProfileFinderMock,
                 boundProject,
@@ -130,8 +120,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 notifications.AssertProgressMessages(expected);
             }
 
-            static string GetDownloadProgressMessages(Language language)
-                => string.Format(QualityProfilesStrings.DownloadingQualityProfileProgressMessage, language.Name);
+            static string GetDownloadProgressMessages(Language language) => string.Format(QualityProfilesStrings.DownloadingQualityProfileProgressMessage, language.Name);
         }
 
         [TestMethod]
@@ -143,8 +132,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             var languagesToBind = new[]
             {
                 Language.Cpp, // unavailable
-                Language.CSharp,
-                Language.Secrets, // unavailable
+                Language.CSharp, Language.Secrets, // unavailable
                 Language.VBNET
             };
 
@@ -277,7 +265,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 configurationPersister ?? new DummyConfigPersister(),
                 outOfDateQualityProfileFinder ?? Mock.Of<IOutOfDateQualityProfileFinder>(),
                 logger ?? new TestLogger(logToConsole: true),
-                languagesToBind ?? Language.KnownLanguages);
+                languagesToBind ?? LanguageProvider.Instance.AllKnownLanguages);
         }
 
         private static SonarQubeQualityProfile CreateQualityProfile(string key = "key", DateTime timestamp = default)
@@ -307,7 +295,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 .ReturnsAsync(qps);
         }
 
-        private static Mock<IBindingConfig> SetupConfigProvider(Mock<IBindingConfigProvider> bindingConfigProvider,
+        private static Mock<IBindingConfig> SetupConfigProvider(
+            Mock<IBindingConfigProvider> bindingConfigProvider,
             Language language)
         {
             var bindingConfig = new Mock<IBindingConfig>();
@@ -321,18 +310,17 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             return bindingConfig;
         }
 
-        private static BoundServerProject CreateBoundProject(string projectKey = "key",
-            Uri uri = null)
-            => new BoundServerProject(
+        private static BoundServerProject CreateBoundProject(
+            string projectKey = "key",
+            Uri uri = null) =>
+            new BoundServerProject(
                 "solution",
                 projectKey,
                 new ServerConnection.SonarQube(uri ?? new Uri("http://localhost/")));
 
-        private static void CheckRuleConfigSaved(Mock<IBindingConfig> bindingConfig)
-            => bindingConfig.Verify(x => x.Save(), Times.Once);
+        private static void CheckRuleConfigSaved(Mock<IBindingConfig> bindingConfig) => bindingConfig.Verify(x => x.Save(), Times.Once);
 
-        private static void CheckRuleConfigNotSaved(Mock<IBindingConfig> bindingConfig)
-            => bindingConfig.Verify(x => x.Save(), Times.Never);
+        private static void CheckRuleConfigNotSaved(Mock<IBindingConfig> bindingConfig) => bindingConfig.Verify(x => x.Save(), Times.Never);
 
         private class DummyConfigPersister : IConfigurationPersister
         {

--- a/src/ConnectedMode.UnitTests/QualityProfiles/QualityProfileDownloaderTests.cs
+++ b/src/ConnectedMode.UnitTests/QualityProfiles/QualityProfileDownloaderTests.cs
@@ -38,7 +38,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
                 MefTestHelpers.CreateExport<IBindingConfigProvider>(),
                 MefTestHelpers.CreateExport<IConfigurationPersister>(),
                 MefTestHelpers.CreateExport<IOutOfDateQualityProfileFinder>(),
-                MefTestHelpers.CreateExport<ILogger>());
+                MefTestHelpers.CreateExport<ILogger>(),
+                MefTestHelpers.CreateExport<ILanguageProvider>());
         }
 
         [TestMethod]
@@ -260,12 +261,15 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.QualityProfiles
             ILogger logger = null,
             Language[] languagesToBind = null)
         {
+            var languageProvider = new Mock<ILanguageProvider>();
+            languageProvider.Setup(x => x.AllKnownLanguages).Returns(languagesToBind ?? []);
+
             return new QualityProfileDownloader(
                 bindingConfigProvider ?? Mock.Of<IBindingConfigProvider>(),
                 configurationPersister ?? new DummyConfigPersister(),
                 outOfDateQualityProfileFinder ?? Mock.Of<IOutOfDateQualityProfileFinder>(),
                 logger ?? new TestLogger(logToConsole: true),
-                languagesToBind ?? LanguageProvider.Instance.AllKnownLanguages);
+                languageProvider.Object);
         }
 
         private static SonarQubeQualityProfile CreateQualityProfile(string key = "key", DateTime timestamp = default)

--- a/src/ConnectedMode/QualityProfiles/OutOfDateQualityProfileFinder.cs
+++ b/src/ConnectedMode/QualityProfiles/OutOfDateQualityProfileFinder.cs
@@ -18,12 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarQube.Client;
@@ -31,13 +26,13 @@ using SonarQube.Client.Models;
 
 namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
 {
-
     internal interface IOutOfDateQualityProfileFinder
     {
         /// <summary>
         /// Gives the list of outdated quality profiles based on the existing ones from <see cref="BoundSonarQubeProject.Profiles"/>
         /// </summary>
-        Task<IReadOnlyCollection<(Language language, SonarQubeQualityProfile qualityProfile)>> GetAsync(BoundServerProject sonarQubeProject,
+        Task<IReadOnlyCollection<(Language language, SonarQubeQualityProfile qualityProfile)>> GetAsync(
+            BoundServerProject sonarQubeProject,
             CancellationToken cancellationToken);
     }
 
@@ -64,14 +59,16 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
 
             return sonarQubeQualityProfiles
                 .Select(serverQualityProfile =>
-                    (language: Language.GetLanguageFromLanguageKey(serverQualityProfile.Language),
-                    qualityProfile: serverQualityProfile))
+                    (language: LanguageProvider.Instance.GetLanguageFromLanguageKey(serverQualityProfile.Language),
+                        qualityProfile: serverQualityProfile))
                 .Where(languageAndQp =>
                     IsLocalQPOutOfDate(sonarQubeProject, languageAndQp.language, languageAndQp.qualityProfile))
                 .ToArray();
         }
 
-        private static bool IsLocalQPOutOfDate(BoundServerProject sonarQubeProject, Language language,
+        private static bool IsLocalQPOutOfDate(
+            BoundServerProject sonarQubeProject,
+            Language language,
             SonarQubeQualityProfile serverQualityProfile)
         {
             if (language == default)

--- a/src/ConnectedMode/QualityProfiles/OutOfDateQualityProfileFinder.cs
+++ b/src/ConnectedMode/QualityProfiles/OutOfDateQualityProfileFinder.cs
@@ -41,11 +41,13 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
     internal class OutOfDateQualityProfileFinder : IOutOfDateQualityProfileFinder
     {
         private readonly ISonarQubeService sonarQubeService;
+        private readonly ILanguageProvider languageProvider;
 
         [ImportingConstructor]
-        public OutOfDateQualityProfileFinder(ISonarQubeService sonarQubeService)
+        public OutOfDateQualityProfileFinder(ISonarQubeService sonarQubeService, ILanguageProvider languageProvider)
         {
             this.sonarQubeService = sonarQubeService;
+            this.languageProvider = languageProvider;
         }
 
         public async Task<IReadOnlyCollection<(Language language, SonarQubeQualityProfile qualityProfile)>> GetAsync(
@@ -59,7 +61,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
 
             return sonarQubeQualityProfiles
                 .Select(serverQualityProfile =>
-                    (language: LanguageProvider.Instance.GetLanguageFromLanguageKey(serverQualityProfile.Language),
+                    (language: languageProvider.GetLanguageFromLanguageKey(serverQualityProfile.Language),
                         qualityProfile: serverQualityProfile))
                 .Where(languageAndQp =>
                     IsLocalQPOutOfDate(sonarQubeProject, languageAndQp.language, languageAndQp.qualityProfile))

--- a/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
+++ b/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
@@ -18,11 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.ConnectedMode.Binding;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
@@ -63,8 +59,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
                 configurationPersister,
                 outOfDateQualityProfileFinder,
                 logger,
-                Language.KnownLanguages)
-        { }
+                LanguageProvider.Instance.AllKnownLanguages)
+        {
+        }
 
         internal /* for testing */ QualityProfileDownloader(
             IBindingConfigProvider bindingConfigProvider,
@@ -80,7 +77,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             this.outOfDateQualityProfileFinder = outOfDateQualityProfileFinder;
         }
 
-        public async Task<bool> UpdateAsync(BoundServerProject boundProject, IProgress<FixedStepsProgress> progress,
+        public async Task<bool> UpdateAsync(
+            BoundServerProject boundProject,
+            IProgress<FixedStepsProgress> progress,
             CancellationToken cancellationToken)
         {
             var isChanged = false;
@@ -152,24 +151,16 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             {
                 if (!boundProject.Profiles.ContainsKey(language))
                 {
-                    boundProject.Profiles[language] = new ApplicableQualityProfile
-                    {
-                        ProfileKey = null,
-                        ProfileTimestamp = DateTime.MinValue,
-                    };
+                    boundProject.Profiles[language] = new ApplicableQualityProfile { ProfileKey = null, ProfileTimestamp = DateTime.MinValue, };
                 }
             }
         }
 
         private static void UpdateProfile(BoundServerProject boundSonarQubeProject, Language language, SonarQubeQualityProfile serverProfile)
         {
-            boundSonarQubeProject.Profiles[language] = new ApplicableQualityProfile
-            {
-                ProfileKey = serverProfile.Key, ProfileTimestamp = serverProfile.TimeStamp
-            };
+            boundSonarQubeProject.Profiles[language] = new ApplicableQualityProfile { ProfileKey = serverProfile.Key, ProfileTimestamp = serverProfile.TimeStamp };
         }
 
-        private void LogWithBindingPrefix(string text)
-            => logger.WriteLine(QualityProfilesStrings.QPMessagePrefix + text);
+        private void LogWithBindingPrefix(string text) => logger.WriteLine(QualityProfilesStrings.QPMessagePrefix + text);
     }
 }

--- a/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
+++ b/src/ConnectedMode/QualityProfiles/QualityProfileDownloader.cs
@@ -53,27 +53,13 @@ namespace SonarLint.VisualStudio.ConnectedMode.QualityProfiles
             IBindingConfigProvider bindingConfigProvider,
             IConfigurationPersister configurationPersister,
             IOutOfDateQualityProfileFinder outOfDateQualityProfileFinder,
-            ILogger logger) :
-            this(
-                bindingConfigProvider,
-                configurationPersister,
-                outOfDateQualityProfileFinder,
-                logger,
-                LanguageProvider.Instance.AllKnownLanguages)
-        {
-        }
-
-        internal /* for testing */ QualityProfileDownloader(
-            IBindingConfigProvider bindingConfigProvider,
-            IConfigurationPersister configurationPersister,
-            IOutOfDateQualityProfileFinder outOfDateQualityProfileFinder,
             ILogger logger,
-            IEnumerable<Language> languagesToBind)
+            ILanguageProvider languageProvider)
         {
             this.bindingConfigProvider = bindingConfigProvider;
             this.configurationPersister = configurationPersister;
             this.logger = logger;
-            this.languagesToBind = languagesToBind;
+            languagesToBind = languageProvider.AllKnownLanguages;
             this.outOfDateQualityProfileFinder = outOfDateQualityProfileFinder;
         }
 

--- a/src/Core.UnitTests/CSharpVB/SonarLintConfigGeneratorTests.cs
+++ b/src/Core.UnitTests/CSharpVB/SonarLintConfigGeneratorTests.cs
@@ -339,6 +339,6 @@ namespace SonarLint.VisualStudio.Core.UnitTests.CSharpVB
         private static SonarQubeRule CreateRule(string ruleKey, string repoKey, IDictionary<string, string> parameters = null) =>
             new SonarQubeRule(ruleKey, repoKey, isActive: false, SonarQubeIssueSeverity.Blocker, null, null, parameters, SonarQubeIssueType.Unknown);
 
-        private Language ToLanguage(string sqLanguageKey) => Language.GetLanguageFromLanguageKey(sqLanguageKey);
+        private Language ToLanguage(string sqLanguageKey) => LanguageProvider.Instance.GetLanguageFromLanguageKey(sqLanguageKey);
     }
 }

--- a/src/Core.UnitTests/LanguageProviderTests.cs
+++ b/src/Core.UnitTests/LanguageProviderTests.cs
@@ -53,11 +53,11 @@ public class LanguageProviderTests
     }
 
     [TestMethod]
-    public void SlCoreLanguages_ShouldBeExpected()
+    public void NonRoslynLanguages_ShouldBeExpected()
     {
         var expected = new[] { Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
 
-        testSubject.SlCoreLanguages.Should().BeEquivalentTo(expected);
+        testSubject.NonRoslynLanguages.Should().BeEquivalentTo(expected);
     }
 
     [TestMethod]

--- a/src/Core.UnitTests/LanguageProviderTests.cs
+++ b/src/Core.UnitTests/LanguageProviderTests.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.TestInfrastructure;
+
+namespace SonarLint.VisualStudio.Core.UnitTests;
+
+[TestClass]
+public class LanguageProviderTests
+{
+    private LanguageProvider testSubject;
+
+    [TestInitialize]
+    public void TestInitialize() => testSubject = new LanguageProvider();
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<LanguageProvider, ILanguageProvider>();
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<LanguageProvider>();
+
+    [TestMethod]
+    public void AllKnownLanguages_ShouldBeExpected()
+    {
+        var expected = new[] { Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
+
+        testSubject.AllKnownLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void RoslynLanguages_ShouldBeExpected()
+    {
+        var expected = new[] { Language.CSharp, Language.VBNET };
+
+        testSubject.RoslynLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void SlCoreLanguages_ShouldBeExpected()
+    {
+        var expected = new[] { Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
+
+        testSubject.SlCoreLanguages.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void LanguagesInStandaloneMode_ShouldBeExpected()
+    {
+        var expected = new[] { Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html };
+
+        testSubject.LanguagesInStandaloneMode.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void ExtraLanguagesInConnectedMode_ShouldBeExpected()
+    {
+        var expected = new[] { Language.TSql };
+
+        testSubject.ExtraLanguagesInConnectedMode.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void GetLanguageFromLanguageKey_GetsCorrectLanguage()
+    {
+        var cs = testSubject.GetLanguageFromLanguageKey("cs");
+        var vbnet = testSubject.GetLanguageFromLanguageKey("vbnet");
+        var cpp = testSubject.GetLanguageFromLanguageKey("cpp");
+        var c = testSubject.GetLanguageFromLanguageKey("c");
+        var js = testSubject.GetLanguageFromLanguageKey("js");
+        var ts = testSubject.GetLanguageFromLanguageKey("ts");
+        var css = testSubject.GetLanguageFromLanguageKey("css");
+        var html = testSubject.GetLanguageFromLanguageKey("Web");
+        var tsql = testSubject.GetLanguageFromLanguageKey("tsql");
+        var unknown = testSubject.GetLanguageFromLanguageKey("unknown");
+
+        cs.Should().Be(Language.CSharp);
+        vbnet.Should().Be(Language.VBNET);
+        cpp.Should().Be(Language.Cpp);
+        c.Should().Be(Language.C);
+        js.Should().Be(Language.Js);
+        ts.Should().Be(Language.Ts);
+        css.Should().Be(Language.Css);
+        html.Should().Be(Language.Html);
+        tsql.Should().Be(Language.TSql);
+        unknown.Should().Be(null);
+    }
+}

--- a/src/Core.UnitTests/LanguageTests.cs
+++ b/src/Core.UnitTests/LanguageTests.cs
@@ -66,29 +66,6 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         }
 
         [TestMethod]
-        public void Language_IsSupported_SupportedLanguage_IsTrue()
-        {
-            // Act + Assert
-            Language.CSharp.IsSupported.Should().BeTrue();
-            Language.VBNET.IsSupported.Should().BeTrue();
-            Language.Cpp.IsSupported.Should().BeTrue();
-            Language.C.IsSupported.Should().BeTrue();
-            Language.Js.IsSupported.Should().BeTrue();
-            Language.Ts.IsSupported.Should().BeTrue();
-            Language.Css.IsSupported.Should().BeTrue();
-            Language.Secrets.IsSupported.Should().BeTrue();
-            Language.Html.IsSupported.Should().BeTrue();
-            Language.TSql.IsSupported.Should().BeTrue();
-        }
-
-        [TestMethod]
-        public void Language_ISupported_UnsupportedLanguage_IsFalse()
-        {
-            var other = new Language("foo", "Foo language", new SonarQubeLanguage("server key", "server name"), pluginInfo, repoInfo);
-            other.IsSupported.Should().BeFalse();
-        }
-
-        [TestMethod]
         public void Language_Equality()
         {
             // Arrange
@@ -102,101 +79,37 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         }
 
         [TestMethod]
-        public void GetLanguageFromLanguageKey_GetsCorrectLanguage()
+        public void Language_HasExpectedRepoInfo()
         {
-            var cs = Language.GetLanguageFromLanguageKey("cs");
-            var vbnet = Language.GetLanguageFromLanguageKey("vbnet");
-            var cpp = Language.GetLanguageFromLanguageKey("cpp");
-            var c = Language.GetLanguageFromLanguageKey("c");
-            var js = Language.GetLanguageFromLanguageKey("js");
-            var ts = Language.GetLanguageFromLanguageKey("ts");
-            var css = Language.GetLanguageFromLanguageKey("css");
-            var html = Language.GetLanguageFromLanguageKey("Web");
-            var tsql = Language.GetLanguageFromLanguageKey("tsql");
-            var unknown = Language.GetLanguageFromLanguageKey("unknown");
+            LanguageHasExpectedRepoInfo(Language.CSharp, "csharpsquid", "csharp");
+            LanguageHasExpectedRepoInfo(Language.VBNET, "vbnet", "vbnet");
+            LanguageHasExpectedRepoInfo(Language.Cpp, "cpp", "cpp");
+            LanguageHasExpectedRepoInfo(Language.C, "c", "c");
+            LanguageHasExpectedRepoInfo(Language.Js, "javascript", "javascript");
+            LanguageHasExpectedRepoInfo(Language.Ts, "typescript", "typescript");
+            LanguageHasExpectedRepoInfo(Language.Css, "css", "css");
+            LanguageHasExpectedRepoInfo(Language.Html, "Web", "html");
+            LanguageHasExpectedRepoInfo(Language.Secrets, "secrets", "secrets");
+            LanguageHasExpectedRepoInfo(Language.TSql, "tsql", "tsql");
 
-            cs.Should().Be(Language.CSharp);
-            vbnet.Should().Be(Language.VBNET);
-            cpp.Should().Be(Language.Cpp);
-            c.Should().Be(Language.C);
-            js.Should().Be(Language.Js);
-            ts.Should().Be(Language.Ts);
-            css.Should().Be(Language.Css);
-            html.Should().Be(Language.Html);
-            tsql.Should().Be(Language.TSql);
-            unknown.Should().Be(null);
+            DoesNotHaveRepoInfo(Language.Unknown.RepoInfo);
         }
 
         [TestMethod]
-        public void GetLanguageFromRepositoryKey_GetsCorrectLanguage()
+        public void Language_HasExpectedSecurityRepoInfo()
         {
-            var cs = Language.GetLanguageFromRepositoryKey("csharpsquid");
-            var vbnet = Language.GetLanguageFromRepositoryKey("vbnet");
-            var cpp = Language.GetLanguageFromRepositoryKey("cpp");
-            var c = Language.GetLanguageFromRepositoryKey("c");
-            var js = Language.GetLanguageFromRepositoryKey("javascript");
-            var ts = Language.GetLanguageFromRepositoryKey("typescript");
-            var css = Language.GetLanguageFromRepositoryKey("css");
-            var html = Language.GetLanguageFromRepositoryKey("Web");
-            var secrets = Language.GetLanguageFromRepositoryKey("secrets");
-            var tsql = Language.GetLanguageFromRepositoryKey("tsql");
-            var unknown = Language.GetLanguageFromRepositoryKey("unknown");
+            LanguageHasExpectedSecurityRepoInfo(Language.CSharp, "roslyn.sonaranalyzer.security.cs", "csharp");
+            LanguageHasExpectedSecurityRepoInfo(Language.Js, "jssecurity", "javascript");
+            LanguageHasExpectedSecurityRepoInfo(Language.Ts, "tssecurity", "typescript");
 
-            var csSecurity = Language.GetLanguageFromRepositoryKey("roslyn.sonaranalyzer.security.cs");
-            var jsSecurity = Language.GetLanguageFromRepositoryKey("jssecurity");
-            var tsSecurity = Language.GetLanguageFromRepositoryKey("tssecurity");
-
-            cs.Should().Be(Language.CSharp);
-            vbnet.Should().Be(Language.VBNET);
-            cpp.Should().Be(Language.Cpp);
-            c.Should().Be(Language.C);
-            js.Should().Be(Language.Js);
-            ts.Should().Be(Language.Ts);
-            css.Should().Be(Language.Css);
-            html.Should().Be(Language.Html);
-            secrets.Should().Be(Language.Secrets);
-            tsql.Should().Be(Language.TSql);
-            unknown.Should().Be(null);
-
-            csSecurity.Should().Be(Language.CSharp);
-            jsSecurity.Should().Be(Language.Js);
-            tsSecurity.Should().Be(Language.Ts);
-        }
-
-        [TestMethod]
-        public void GetSonarRepoKeyFromLanguageKey_GetsCorrectRepoKey()
-        {
-            Language.GetSonarRepoKeyFromLanguage(Language.CSharp).Should().Be("csharpsquid");
-            Language.GetSonarRepoKeyFromLanguage(Language.VBNET).Should().Be("vbnet");
-            Language.GetSonarRepoKeyFromLanguage(Language.C).Should().Be("c");
-            Language.GetSonarRepoKeyFromLanguage(Language.Cpp).Should().Be("cpp");
-            Language.GetSonarRepoKeyFromLanguage(Language.Js).Should().Be("javascript");
-            Language.GetSonarRepoKeyFromLanguage(Language.Ts).Should().Be("typescript");
-            Language.GetSonarRepoKeyFromLanguage(Language.Css).Should().Be("css");
-            Language.GetSonarRepoKeyFromLanguage(Language.Html).Should().Be("Web");
-            Language.GetSonarRepoKeyFromLanguage(Language.TSql).Should().Be("tsql");
-
-            Language.GetSonarRepoKeyFromLanguage(Language.Unknown).Should().BeNull();
-
-            var language = new Language("xxx", "dummy language", new SonarQubeLanguage("xxx", "LanguageX"), pluginInfo, repoInfo);
-            Language.GetSonarRepoKeyFromLanguage(language).Should().BeNull();
-        }
-
-        [TestMethod]
-        public void SanityCheck_RoundTripFromLanguageToRepoKey_AndBack()
-        {
-            // Sanity check that we've remembered to define the necessary mappings
-            // for all known languages.
-            // Regression test to avoid bugs like #3973.
-
-            foreach (var item in Language.KnownLanguages)
-            {
-                var actualRepoKey = Language.GetSonarRepoKeyFromLanguage(item);
-                actualRepoKey.Should().NotBeNull();
-
-                var actualLanguage = Language.GetLanguageFromRepositoryKey(actualRepoKey);
-                actualLanguage.Should().BeSameAs(item);
-            }
+            DoesNotHaveRepoInfo(Language.VBNET.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Cpp.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.C.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Css.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Html.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Secrets.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.TSql.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Unknown.SecurityRepoInfo);
         }
 
         [TestMethod]
@@ -241,6 +154,19 @@ namespace SonarLint.VisualStudio.Core.UnitTests
         {
             language.PluginInfo.Key.Should().Be(pluginKey);
             language.PluginInfo.FilePattern.Should().Be(filePattern);
+        }
+
+        private static void LanguageHasExpectedRepoInfo(Language language, string repoKey, string folderName) => HasExpectedRepoInfo(language.RepoInfo, repoKey, folderName);
+
+        private static void LanguageHasExpectedSecurityRepoInfo(Language language, string repoKey, string folderName) => HasExpectedRepoInfo(language.SecurityRepoInfo, repoKey, folderName);
+
+        private static void DoesNotHaveRepoInfo(RepoInfo repoInfo) => repoInfo.Should().BeNull();
+
+        private static void HasExpectedRepoInfo(RepoInfo repoInfo, string repoKey, string folderName)
+        {
+            repoInfo.Should().NotBeNull();
+            repoInfo.Key.Should().Be(repoKey);
+            repoInfo.FolderName.Should().Be(folderName);
         }
     }
 }

--- a/src/Core/ILanguageProvider.cs
+++ b/src/Core/ILanguageProvider.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+
+namespace SonarLint.VisualStudio.Core;
+
+public interface ILanguageProvider
+{
+    IReadOnlyList<Language> AllKnownLanguages { get; }
+
+    IReadOnlyList<Language> SlCoreLanguages { get; }
+
+    IReadOnlyList<Language> RoslynLanguages { get; }
+
+    IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
+
+    IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; }
+
+    /// <summary>
+    /// Returns the language for the specified language key, or null if it does not match a known language
+    /// </summary>
+    Language GetLanguageFromLanguageKey(string languageKey);
+}
+
+[Export(typeof(ILanguageProvider))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+public class LanguageProvider : ILanguageProvider
+{
+    [ImportingConstructor]
+    public LanguageProvider()
+    {
+        SlCoreLanguages = AllKnownLanguages.Except(RoslynLanguages).ToList();
+        LanguagesInStandaloneMode = AllKnownLanguages.Except(ExtraLanguagesInConnectedMode).ToList();
+    }
+
+    public IReadOnlyList<Language> SlCoreLanguages { get; }
+    public IReadOnlyList<Language> RoslynLanguages { get; } = [Language.CSharp, Language.VBNET];
+    public IReadOnlyList<Language> AllKnownLanguages { get; } =
+        [Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql];
+    public IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
+    public IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; } = [Language.TSql];
+
+    public Language GetLanguageFromLanguageKey(string languageKey) => AllKnownLanguages.FirstOrDefault(l => languageKey.Equals(l.ServerLanguage.Key, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Core/ILanguageProvider.cs
+++ b/src/Core/ILanguageProvider.cs
@@ -44,6 +44,10 @@ public interface ILanguageProvider
 [PartCreationPolicy(CreationPolicy.Shared)]
 public class LanguageProvider : ILanguageProvider
 {
+#pragma warning disable S4277
+    public static readonly ILanguageProvider Instance = new LanguageProvider();
+#pragma warning restore S4277
+
     [ImportingConstructor]
     public LanguageProvider()
     {

--- a/src/Core/ILanguageProvider.cs
+++ b/src/Core/ILanguageProvider.cs
@@ -26,7 +26,7 @@ public interface ILanguageProvider
 {
     IReadOnlyList<Language> AllKnownLanguages { get; }
 
-    IReadOnlyList<Language> SlCoreLanguages { get; }
+    IReadOnlyList<Language> NonRoslynLanguages { get; }
 
     IReadOnlyList<Language> RoslynLanguages { get; }
 
@@ -51,14 +51,13 @@ public class LanguageProvider : ILanguageProvider
     [ImportingConstructor]
     public LanguageProvider()
     {
-        SlCoreLanguages = AllKnownLanguages.Except(RoslynLanguages).ToList();
+        AllKnownLanguages = NonRoslynLanguages.Union(RoslynLanguages).ToList();
         LanguagesInStandaloneMode = AllKnownLanguages.Except(ExtraLanguagesInConnectedMode).ToList();
     }
 
-    public IReadOnlyList<Language> SlCoreLanguages { get; }
+    public IReadOnlyList<Language> NonRoslynLanguages { get; } = [Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql];
     public IReadOnlyList<Language> RoslynLanguages { get; } = [Language.CSharp, Language.VBNET];
-    public IReadOnlyList<Language> AllKnownLanguages { get; } =
-        [Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql];
+    public IReadOnlyList<Language> AllKnownLanguages { get; }
     public IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
     public IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; } = [Language.TSql];
 

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Core
     /// This class is safe for use as a key in collection classes. E.g., <seealso cref="IDictionary{TKey, TValue}"/>.
     /// </para>
     /// </remarks>
-    [DebuggerDisplay("{Name} (ID: {Id}, IsSupported: {IsSupported})")]
+    [DebuggerDisplay("{Name} (ID: {Id})")]
     [TypeConverter(typeof(LanguageConverter))]
     public sealed class Language : IEquatable<Language>
     {

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -75,21 +75,6 @@ namespace SonarLint.VisualStudio.Core
         public static readonly Language TSql = new("TSql", "T-SQL", SonarQubeLanguage.TSql, TsqlPlugin, TsqlRepo);
 
         /// <summary>
-        /// Returns the language for the specified language key, or null if it does not match a known language
-        /// </summary>
-        public static Language GetLanguageFromLanguageKey(string languageKey) => KnownLanguages.FirstOrDefault(l => languageKey.Equals(l.ServerLanguage.Key, StringComparison.OrdinalIgnoreCase));
-
-        /// <summary>
-        /// Returns the language for the specified repository key, or null if it does not match a known language
-        /// </summary>
-        public static Language GetLanguageFromRepositoryKey(string repoKey) => KnownLanguages.SingleOrDefault(lang => lang.HasRepoKey(repoKey));
-
-        /// <summary>
-        /// Returns the Sonar analyzer repository for the specified language key, or null if one could not be found
-        /// </summary>
-        public static string GetSonarRepoKeyFromLanguage(Language language) => KnownLanguages.FirstOrDefault(x => x.Id == language.Id)?.RepoInfo.Key;
-
-        /// <summary>
         /// A stable identifier for this language.
         /// </summary>
         public string Id { get; }
@@ -121,22 +106,6 @@ namespace SonarLint.VisualStudio.Core
         /// Nullable, the repository info for the security rules (i.e. hotspots) for this language
         /// </summary>
         public RepoInfo SecurityRepoInfo { get; }
-
-        /// <summary>
-        /// Returns whether or not this language is a supported project language.
-        /// </summary>
-        public bool IsSupported => KnownLanguages.Contains(this);
-
-        /// <summary>
-        /// All known languages.
-        /// </summary>
-        public static IEnumerable<Language> KnownLanguages
-        {
-            get
-            {
-                return new[] { CSharp, VBNET, Cpp, C, Js, Ts, Css, Html, Secrets, TSql };
-            }
-        }
 
         /// <summary>
         /// Private constructor reserved for the <seealso cref="Unknown"/>.

--- a/src/Core/LanguageConverter.cs
+++ b/src/Core/LanguageConverter.cs
@@ -18,11 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 
 namespace SonarLint.VisualStudio.Core
 {
@@ -54,8 +51,8 @@ namespace SonarLint.VisualStudio.Core
 
             if (languageId != null)
             {
-                return Language.KnownLanguages.FirstOrDefault(x => StringComparer.OrdinalIgnoreCase.Equals(x.Id, languageId))
-                    ?? Language.Unknown;
+                return LanguageProvider.Instance.AllKnownLanguages.FirstOrDefault(x => StringComparer.OrdinalIgnoreCase.Equals(x.Id, languageId))
+                       ?? Language.Unknown;
             }
 
             Debug.Fail("Expected string input object");
@@ -76,7 +73,11 @@ namespace SonarLint.VisualStudio.Core
             return base.CanConvertFrom(context, destinationType);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
         {
             Debug.Assert(value is Language, $"Expected {nameof(Language)} input object");
             Debug.Assert(destinationType == typeof(string), "Expected string destination type");

--- a/src/Core/RuleHelpLinkProvider.cs
+++ b/src/Core/RuleHelpLinkProvider.cs
@@ -47,7 +47,7 @@ namespace SonarLint.VisualStudio.Core
 
         private static string GetWebsiteFolderName(string repoKey)
         {
-            var language = Language.KnownLanguages.FirstOrDefault(lang => lang.HasRepoKey(repoKey));
+            var language = LanguageProvider.Instance.AllKnownLanguages.FirstOrDefault(lang => lang.HasRepoKey(repoKey));
 
             if (language?.SecurityRepoInfo?.Key == repoKey)
             {

--- a/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
+++ b/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
@@ -82,7 +82,7 @@ internal class RaisedFindingProcessor(
             var localPath = fileUri.LocalPath;
             var analysisStatusNotifier = analysisStatusNotifierFactory.Create(nameof(SLCoreAnalyzer), localPath, parameters.analysisId);
             var supportedRaisedIssues = GetSupportedLanguageFindings(fileAndIssues.Value ?? []);
-           findingsPublisher.Publish(localPath,
+            findingsPublisher.Publish(localPath,
                 parameters.analysisId!.Value,
                 raiseFindingToAnalysisIssueConverter.GetAnalysisIssues(fileUri, supportedRaisedIssues));
             analysisStatusNotifier.AnalysisProgressed(supportedRaisedIssues.Length, findingsPublisher.FindingsType, parameters.isIntermediatePublication);
@@ -95,7 +95,7 @@ internal class RaisedFindingProcessor(
     private static List<string> CalculateAnalyzableRulePrefixes(ISLCoreConstantsProvider slCoreConstantsProvider) =>
         slCoreConstantsProvider.AllAnalyzableLanguages?
             .Select(x => x.ConvertToCoreLanguage())
-            .Select(Language.GetSonarRepoKeyFromLanguage)
+            .Select(x => x.RepoInfo?.Key)
             .Where(r => r is not null)
             .ToList() ?? [];
 }


### PR DESCRIPTION
[SLVS-1826](https://sonarsource.atlassian.net/browse/SLVS-1826)

Introduce LanguageProvider service to increase testability 
This includes some feedback from [previous PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/5987) that has been split

[SLVS-1826]: https://sonarsource.atlassian.net/browse/SLVS-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ