### PR TITLE
SLVS-1839 Fix ConnectionsComboBox name used in xaml binding in ManageBindingDialog.xaml

### DIFF
--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
@@ -172,7 +172,7 @@
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="{x:Static res:UiResources.ProjectToBindLabel}" Margin="0,15,0,5"/>
                 <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource {x:Static vsShell:VsBrushes.ActiveBorderKey}}" BorderThickness="1" Height="30"
-                        Background="{Binding ElementName=ConnectionsCombobox, Path=Background}">
+                        Background="{Binding ElementName=ConnectionsComboBox, Path=Background}">
                     <TextBlock VerticalAlignment="Center" Padding="5,0">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">


### PR DESCRIPTION
[SLVS-1839](https://sonarsource.atlassian.net/browse/SLVS-1839)

Part of SLVS-1823


[SLVS-1839]: https://sonarsource.atlassian.net/browse/SLVS-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ