### PR TITLE
SLVS-1835 Adapt ServerConnectionsProvider to ensure region is set

### DIFF
--- a/src/SLCore.UnitTests/Service/Connection/Models/SonarCloudRegionExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Service/Connection/Models/SonarCloudRegionExtensionsTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.SLCore.Service.Connection.Models;
+
+namespace SonarLint.VisualStudio.SLCore.UnitTests.Service.Connection.Models;
+
+[TestClass]
+public class SonarCloudRegionExtensionsTests
+{
+    [TestMethod]
+    [DynamicData(nameof(GetCoreToExpectedSlCoreRegion))]
+    public void ToSlCoreRegion_MapsAsExpects(CloudServerRegion coreRegion, SonarCloudRegion expectedSlCoreRegion)
+    {
+        var result = coreRegion.ToSlCoreRegion();
+
+        result.Should().Be(expectedSlCoreRegion);
+    }
+
+    [TestMethod]
+    public void ToSlCoreRegion_UnknownRegion_Throws()
+    {
+        var act = () => (null as CloudServerRegion).ToSlCoreRegion();
+
+        act.Should().Throw<Exception>();
+    }
+
+    public static IEnumerable<object[]> GetCoreToExpectedSlCoreRegion =>
+    [
+        [CloudServerRegion.Eu, SonarCloudRegion.EU],
+        [CloudServerRegion.Us, SonarCloudRegion.US]
+    ];
+}

--- a/src/SLCore/Service/Connection/Models/SonarCloudRegionExtensions.cs
+++ b/src/SLCore/Service/Connection/Models/SonarCloudRegionExtensions.cs
@@ -18,13 +18,23 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using SonarLint.VisualStudio.Core.Binding;
 
 namespace SonarLint.VisualStudio.SLCore.Service.Connection.Models;
 
-[JsonConverter(typeof(StringEnumConverter))]
-public enum SonarCloudRegion
+public static class SonarCloudRegionExtensions
 {
-    EU, US
+    private static readonly IReadOnlyDictionary<CloudServerRegion, SonarCloudRegion> CoreToSlCoreLanguageMap = new Dictionary<CloudServerRegion, SonarCloudRegion>()
+    {
+        { CloudServerRegion.Eu, SonarCloudRegion.EU }, { CloudServerRegion.Us, SonarCloudRegion.US },
+    };
+
+    public static SonarCloudRegion ToSlCoreRegion(this CloudServerRegion region)
+    {
+        if (CoreToSlCoreLanguageMap.TryGetValue(region, out var slCoreLanguage))
+        {
+            return slCoreLanguage;
+        }
+        throw new ArgumentOutOfRangeException(region.Name);
+    }
 }

--- a/src/SLCore/State/ServerConnectionsProvider.cs
+++ b/src/SLCore/State/ServerConnectionsProvider.cs
@@ -31,16 +31,9 @@ internal interface IServerConnectionsProvider
 
 [Export(typeof(IServerConnectionsProvider))]
 [PartCreationPolicy(CreationPolicy.Shared)]
-internal class ServerConnectionsProvider : IServerConnectionsProvider
+[method: ImportingConstructor]
+internal class ServerConnectionsProvider(IServerConnectionsRepository serverConnectionsRepository) : IServerConnectionsProvider
 {
-    private readonly IServerConnectionsRepository serverConnectionsRepository;
-
-    [ImportingConstructor]
-    public ServerConnectionsProvider(IServerConnectionsRepository serverConnectionsRepository)
-    {
-        this.serverConnectionsRepository = serverConnectionsRepository;
-    }
-
     public Dictionary<string, ServerConnectionConfigurationDtoBase> GetServerConnections()
     {
         var succeeded = serverConnectionsRepository.TryGetAll(out var serverConnections);
@@ -55,10 +48,12 @@ internal class ServerConnectionsProvider : IServerConnectionsProvider
             switch (serverConnection)
             {
                 case ServerConnection.SonarQube sonarQubeConnection:
-                    serverConnectionConfigurations.Add(new SonarQubeConnectionConfigurationDto(sonarQubeConnection.Id, !sonarQubeConnection.Settings.IsSmartNotificationsEnabled, sonarQubeConnection.ServerUri.ToString()));
+                    serverConnectionConfigurations.Add(new SonarQubeConnectionConfigurationDto(sonarQubeConnection.Id, !sonarQubeConnection.Settings.IsSmartNotificationsEnabled,
+                        sonarQubeConnection.ServerUri.ToString()));
                     break;
                 case ServerConnection.SonarCloud sonarCloudConnection:
-                    serverConnectionConfigurations.Add(new SonarCloudConnectionConfigurationDto(sonarCloudConnection.Id, !sonarCloudConnection.Settings.IsSmartNotificationsEnabled, sonarCloudConnection.OrganizationKey));
+                    serverConnectionConfigurations.Add(new SonarCloudConnectionConfigurationDto(sonarCloudConnection.Id, !sonarCloudConnection.Settings.IsSmartNotificationsEnabled,
+                        sonarCloudConnection.OrganizationKey, sonarCloudConnection.Region.ToSlCoreRegion()));
                     break;
                 default:
                     throw new InvalidOperationException(SLCoreStrings.UnexpectedServerConnectionType);


### PR DESCRIPTION
[SLVS-1835](https://sonarsource.atlassian.net/browse/SLVS-1835)

Adapt ServerConnectionsProvider to ensure that the ServerConnectionConfigurationDtoBase models have the region set.


[SLVS-1835]: https://sonarsource.atlassian.net/browse/SLVS-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ