### PR TITLE
SLVS-1752 Stop ignoring issues that are raised by SlCore when AnalysisId is null

### DIFF
--- a/src/Core.UnitTests/Analysis/HotspotsPublisherTests.cs
+++ b/src/Core.UnitTests/Analysis/HotspotsPublisherTests.cs
@@ -31,12 +31,10 @@ public class HotspotPublisherTests
     private HotspotPublisher testSubject;
 
     [TestMethod]
-    public void MefCtor_CheckIsExported() =>
-        MefTestHelpers.CheckTypeCanBeImported<HotspotPublisher, IHotspotPublisher>(MefTestHelpers.CreateExport<IIssueConsumerStorage>());
+    public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<HotspotPublisher, IHotspotPublisher>(MefTestHelpers.CreateExport<IIssueConsumerStorage>());
 
     [TestMethod]
-    public void MefCtor_CheckIsSingleton() =>
-        MefTestHelpers.CheckIsSingletonMefComponent<HotspotPublisher>();
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<HotspotPublisher>();
 
     [TestInitialize]
     public void TestInitialize()
@@ -47,8 +45,7 @@ public class HotspotPublisherTests
     }
 
     [TestMethod]
-    public void FindingsType_ReturnsCorrectValue() =>
-        testSubject.FindingsType.Should().Be(CoreStrings.FindingType_Hotspot);
+    public void FindingsType_ReturnsCorrectValue() => testSubject.FindingsType.Should().Be(CoreStrings.FindingType_Hotspot);
 
     [TestMethod]
     public void PublishHotspots_NoConsumerInStorage_DoesNothing()
@@ -93,6 +90,24 @@ public class HotspotPublisherTests
             });
 
         testSubject.Publish("file/path", analysisId, analysisIssues);
+
+        issueConsumer.Received().SetHotspots("file/path", analysisIssues);
+        issueConsumer.DidNotReceiveWithAnyArgs().SetIssues(default, default);
+    }
+
+    [TestMethod]
+    public void PublishHotspots_AnalysisIdNull_PublishesHotspots()
+    {
+        var analysisIssues = Substitute.For<IEnumerable<IAnalysisIssue>>();
+        issueConsumerStorage.TryGet("file/path", out Arg.Any<Guid>(), out Arg.Any<IIssueConsumer>())
+            .Returns(info =>
+            {
+                info[1] = Guid.NewGuid();
+                info[2] = issueConsumer;
+                return true;
+            });
+
+        testSubject.Publish("file/path", analysisId: null, analysisIssues);
 
         issueConsumer.Received().SetHotspots("file/path", analysisIssues);
         issueConsumer.DidNotReceiveWithAnyArgs().SetIssues(default, default);

--- a/src/Core.UnitTests/Analysis/IssuePublisherTests.cs
+++ b/src/Core.UnitTests/Analysis/IssuePublisherTests.cs
@@ -31,12 +31,10 @@ public class IssuePublisherTests
     private IssuePublisher testSubject;
 
     [TestMethod]
-    public void MefCtor_CheckIsExported() =>
-        MefTestHelpers.CheckTypeCanBeImported<IssuePublisher, IIssuePublisher>(MefTestHelpers.CreateExport<IIssueConsumerStorage>());
+    public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<IssuePublisher, IIssuePublisher>(MefTestHelpers.CreateExport<IIssueConsumerStorage>());
 
     [TestMethod]
-    public void MefCtor_CheckIsSingleton() =>
-        MefTestHelpers.CheckIsSingletonMefComponent<IssuePublisher>();
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<IssuePublisher>();
 
     [TestInitialize]
     public void TestInitialize()
@@ -47,8 +45,7 @@ public class IssuePublisherTests
     }
 
     [TestMethod]
-    public void FindingsType_ReturnsCorrectValue() =>
-        testSubject.FindingsType.Should().Be(CoreStrings.FindingType_Issue);
+    public void FindingsType_ReturnsCorrectValue() => testSubject.FindingsType.Should().Be(CoreStrings.FindingType_Issue);
 
     [TestMethod]
     public void PublishIssues_NoConsumerInStorage_DoesNothing()
@@ -93,6 +90,24 @@ public class IssuePublisherTests
             });
 
         testSubject.Publish("file/path", analysisId, analysisIssues);
+
+        issueConsumer.Received().SetIssues("file/path", analysisIssues);
+        issueConsumer.DidNotReceiveWithAnyArgs().SetHotspots(default, default);
+    }
+
+    [TestMethod]
+    public void PublishIssues_AnalysisIdIsNull_PublishesIssues()
+    {
+        var analysisIssues = Substitute.For<IEnumerable<IAnalysisIssue>>();
+        issueConsumerStorage.TryGet("file/path", out Arg.Any<Guid>(), out Arg.Any<IIssueConsumer>())
+            .Returns(info =>
+            {
+                info[1] = Guid.NewGuid();
+                info[2] = issueConsumer;
+                return true;
+            });
+
+        testSubject.Publish("file/path", analysisId: null, analysisIssues);
 
         issueConsumer.Received().SetIssues("file/path", analysisIssues);
         issueConsumer.DidNotReceiveWithAnyArgs().SetHotspots(default, default);

--- a/src/Core/Analysis/HotspotPublisher.cs
+++ b/src/Core/Analysis/HotspotPublisher.cs
@@ -24,12 +24,12 @@ namespace SonarLint.VisualStudio.Core.Analysis;
 
 [Export(typeof(IHotspotPublisher))]
 [PartCreationPolicy(CreationPolicy.Shared)]
-[method:ImportingConstructor]
+[method: ImportingConstructor]
 internal class HotspotPublisher(IIssueConsumerStorage issueConsumerStorage) : IHotspotPublisher
 {
     public string FindingsType => CoreStrings.FindingType_Hotspot;
 
-    public void Publish(string filePath, Guid analysisId, IEnumerable<IAnalysisIssue> findings)
+    public void Publish(string filePath, Guid? analysisId, IEnumerable<IAnalysisIssue> findings)
     {
         if (issueConsumerStorage.TryGet(filePath, out var currentAnalysisId, out var issueConsumer)
             && analysisId == currentAnalysisId)

--- a/src/Core/Analysis/HotspotPublisher.cs
+++ b/src/Core/Analysis/HotspotPublisher.cs
@@ -25,14 +25,13 @@ namespace SonarLint.VisualStudio.Core.Analysis;
 [Export(typeof(IHotspotPublisher))]
 [PartCreationPolicy(CreationPolicy.Shared)]
 [method: ImportingConstructor]
-internal class HotspotPublisher(IIssueConsumerStorage issueConsumerStorage) : IHotspotPublisher
+internal class HotspotPublisher(IIssueConsumerStorage issueConsumerStorage) : FindingsPublisherBase, IHotspotPublisher
 {
     public string FindingsType => CoreStrings.FindingType_Hotspot;
 
     public void Publish(string filePath, Guid? analysisId, IEnumerable<IAnalysisIssue> findings)
     {
-        if (issueConsumerStorage.TryGet(filePath, out var currentAnalysisId, out var issueConsumer)
-            && analysisId == currentAnalysisId)
+        if (issueConsumerStorage.TryGet(filePath, out var currentAnalysisId, out var issueConsumer) && IsValidAnalysisId(analysisId, currentAnalysisId))
         {
             issueConsumer.SetHotspots(filePath, findings);
         }

--- a/src/Core/Analysis/IFindingsPublisher.cs
+++ b/src/Core/Analysis/IFindingsPublisher.cs
@@ -32,3 +32,11 @@ public interface IFindingsPublisher
 
 public interface IIssuePublisher : IFindingsPublisher;
 public interface IHotspotPublisher : IFindingsPublisher;
+
+internal class FindingsPublisherBase
+{
+    /// <summary>
+    /// When <see cref="analysisId"/> is null, it means the issue comes directly from the server not from a local analysis (i.e. when a user muted an issue on the serer).
+    /// </summary>
+    protected bool IsValidAnalysisId(Guid? analysisId, Guid currentAnalysisId) => analysisId == null || analysisId == currentAnalysisId;
+}

--- a/src/Core/Analysis/IFindingsPublisher.cs
+++ b/src/Core/Analysis/IFindingsPublisher.cs
@@ -23,12 +23,12 @@ namespace SonarLint.VisualStudio.Core.Analysis;
 public interface IFindingsPublisher
 {
     string FindingsType { get; }
+
     /// <summary>
     /// Handles analysis results
     /// </summary>
-    void Publish(string filePath, Guid analysisId, IEnumerable<IAnalysisIssue> findings);
+    void Publish(string filePath, Guid? analysisId, IEnumerable<IAnalysisIssue> findings);
 }
 
 public interface IIssuePublisher : IFindingsPublisher;
-
 public interface IHotspotPublisher : IFindingsPublisher;

--- a/src/Core/Analysis/IssuePublisher.cs
+++ b/src/Core/Analysis/IssuePublisher.cs
@@ -25,14 +25,13 @@ namespace SonarLint.VisualStudio.Core.Analysis;
 [Export(typeof(IIssuePublisher))]
 [PartCreationPolicy(CreationPolicy.Shared)]
 [method: ImportingConstructor]
-internal class IssuePublisher(IIssueConsumerStorage issueConsumerStorage) : IIssuePublisher
+internal class IssuePublisher(IIssueConsumerStorage issueConsumerStorage) : FindingsPublisherBase, IIssuePublisher
 {
     public string FindingsType => CoreStrings.FindingType_Issue;
 
     public void Publish(string filePath, Guid? analysisId, IEnumerable<IAnalysisIssue> findings)
     {
-        if (issueConsumerStorage.TryGet(filePath, out var currentAnalysisId, out var issueConsumer)
-            && analysisId == currentAnalysisId)
+        if (issueConsumerStorage.TryGet(filePath, out var currentAnalysisId, out var issueConsumer) && IsValidAnalysisId(analysisId, currentAnalysisId))
         {
             issueConsumer.SetIssues(filePath, findings);
         }

--- a/src/Core/Analysis/IssuePublisher.cs
+++ b/src/Core/Analysis/IssuePublisher.cs
@@ -24,12 +24,12 @@ namespace SonarLint.VisualStudio.Core.Analysis;
 
 [Export(typeof(IIssuePublisher))]
 [PartCreationPolicy(CreationPolicy.Shared)]
-[method:ImportingConstructor]
+[method: ImportingConstructor]
 internal class IssuePublisher(IIssueConsumerStorage issueConsumerStorage) : IIssuePublisher
 {
     public string FindingsType => CoreStrings.FindingType_Issue;
 
-    public void Publish(string filePath, Guid analysisId, IEnumerable<IAnalysisIssue> findings)
+    public void Publish(string filePath, Guid? analysisId, IEnumerable<IAnalysisIssue> findings)
     {
         if (issueConsumerStorage.TryGet(filePath, out var currentAnalysisId, out var issueConsumer)
             && analysisId == currentAnalysisId)

--- a/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
+++ b/src/SLCore.Listeners/Implementation/Analysis/RaisedFindingProcessor.cs
@@ -59,12 +59,6 @@ internal class RaisedFindingProcessor(
     private bool IsValid<T>(RaiseFindingParams<T> parameters) where T : RaisedFindingDto
     {
         var logContext = $"[{nameof(RaiseFinding)}+{typeof(T).Name}]";
-        if (!parameters.analysisId.HasValue)
-        {
-            logger.LogVerbose($"{logContext} No {nameof(parameters.analysisId)}, ignoring...");
-            return false;
-        }
-
         if (parameters.issuesByFileUri.Count == 0)
         {
             logger.LogVerbose($"{logContext} Empty {nameof(parameters.issuesByFileUri)} dictionary, ignoring...");
@@ -83,7 +77,7 @@ internal class RaisedFindingProcessor(
             var analysisStatusNotifier = analysisStatusNotifierFactory.Create(nameof(SLCoreAnalyzer), localPath, parameters.analysisId);
             var supportedRaisedIssues = GetSupportedLanguageFindings(fileAndIssues.Value ?? []);
             findingsPublisher.Publish(localPath,
-                parameters.analysisId!.Value,
+                parameters.analysisId,
                 raiseFindingToAnalysisIssueConverter.GetAnalysisIssues(fileUri, supportedRaisedIssues));
             analysisStatusNotifier.AnalysisProgressed(supportedRaisedIssues.Length, findingsPublisher.FindingsType, parameters.isIntermediatePublication);
         }


### PR DESCRIPTION
[SLVS-1752](https://sonarsource.atlassian.net/browse/SLVS-1752)

When an issue is muted on the server, SlCore raises the RaiseFinding event for which the AnalysisId is NULL.
We have to stop ignoring such issues that are raised (they should be suppressed instead: not part of this PR)

[SLVS-1752]: https://sonarsource.atlassian.net/browse/SLVS-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ