### PR TITLE
SLVS-1863 Fix the button “Mark issue as” does not become enabled if you click directly on the RadioButton.

### DIFF
--- a/src/Integration/Transition/MuteWindowDialog.xaml
+++ b/src/Integration/Transition/MuteWindowDialog.xaml
@@ -86,7 +86,8 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            <RadioButton Grid.Row="0" GroupName="StatusGroup" Content="{Binding Path=Title}" Style="{StaticResource RadioButtonStyle}" IsChecked="{Binding IsChecked}"/>
+                            <RadioButton Grid.Row="0" GroupName="StatusGroup" Content="{Binding Path=Title}" Style="{StaticResource RadioButtonStyle}" 
+                                         IsChecked="{Binding IsChecked}" Checked="RadioButton_OnChecked"/>
                             <Label Grid.Row="1" Content="{Binding Path=Description}" Style="{StaticResource LabelStyle}" Margin="5,5" />
                         </Grid>
                     </Border>

--- a/src/Integration/Transition/MuteWindowDialog.xaml.cs
+++ b/src/Integration/Transition/MuteWindowDialog.xaml.cs
@@ -78,4 +78,14 @@ public partial class MuteWindowDialog : DialogWindow
             radioButton.IsChecked = true;
         }
     }
+
+    private void RadioButton_OnChecked(object sender, RoutedEventArgs e)
+    {
+        // The RadioButton consumes the click event, so the click event is not bubbled back to the parent
+        // ListBox.SelectedItem is not triggered, so we have to update the view model manually
+        if (sender is RadioButton { IsChecked: true, DataContext: StatusViewModel statusViewModel })
+        {
+            ViewModel.SelectedStatusViewModel = statusViewModel;
+        }
+    }
 }


### PR DESCRIPTION
[SLVS-1863](https://sonarsource.atlassian.net/browse/SLVS-1863)

This is caused by the fact that the radio button consumes the click event and it is not bubbled back to the parent event (ListBox.SelectedItem), which does not trigger the update of the ViewModel.SelectedStatusViewModel, to which the IsEnabled property is bound.


[SLVS-1863]: https://sonarsource.atlassian.net/browse/SLVS-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ