### PR TITLE
SLVS-1875 JS analysis not working when S1451 is enabled

### DIFF
--- a/src/SLCore.UnitTests/Listener/Analysis/RaiseFindingToAnalysisIssueConverterTests.cs
+++ b/src/SLCore.UnitTests/Listener/Analysis/RaiseFindingToAnalysisIssueConverterTests.cs
@@ -296,7 +296,7 @@ public class RaiseFindingToAnalysisIssueConverterTests
                     2,
                     3,
                     4),
-               [],
+                [],
                 default,
                 default,
                 new MQRModeDetails(default,
@@ -312,6 +312,35 @@ public class RaiseFindingToAnalysisIssueConverterTests
         issue.HighestImpact.Should().NotBeNull();
         issue.HighestImpact.Quality.Should().Be(VisualStudio.Core.Analysis.SoftwareQuality.Security);
         issue.HighestImpact.Severity.Should().Be(expectedSoftwareQualitySeverity);
+    }
+
+    /// <summary>
+    /// File level issues do not have a TextRange
+    /// </summary>
+    [TestMethod]
+    public void GetAnalysisIssues_TextRangeDtoIsNull_ConvertsCorrectly()
+    {
+        var dateTimeOffset = DateTimeOffset.Now;
+        var issue1 = new RaisedHotspotDto(IssueWithFlowsAndQuickFixesUseCase.Issue1Id,
+            "serverKey1",
+            "ruleKey1",
+            "PrimaryMessage1",
+            dateTimeOffset,
+            true,
+            false,
+            textRange: null,
+            null,
+            null,
+            "context1",
+            VulnerabilityProbability.HIGH,
+            HotspotStatus.FIXED,
+            new StandardModeDetails(IssueSeverity.MAJOR, RuleType.CODE_SMELL));
+
+        var analysisIssues = testSubject.GetAnalysisIssues(new FileUri("C:\\IssueFile.cs"), new List<RaisedFindingDto> { issue1 }).ToList();
+
+        var issue = analysisIssues.SingleOrDefault() as AnalysisIssue;
+        issue.Should().NotBeNull();
+        issue.PrimaryLocation.TextRange.Should().BeNull();
     }
 
     private static class UnflattenedFlowsUseCase

--- a/src/SLCore.UnitTests/Listener/Analysis/RaiseFindingToAnalysisIssueConverterTests.cs
+++ b/src/SLCore.UnitTests/Listener/Analysis/RaiseFindingToAnalysisIssueConverterTests.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Listener.Analysis;
@@ -33,15 +34,25 @@ public class RaiseFindingToAnalysisIssueConverterTests
 {
     private readonly FileUri fileUri = new(@"C:\file");
     private RaiseFindingToAnalysisIssueConverter testSubject;
+    private ILogger logger;
 
     [TestInitialize]
-    public void TestInitialize() => testSubject = new RaiseFindingToAnalysisIssueConverter();
+    public void TestInitialize()
+    {
+        logger = Substitute.For<ILogger>();
+        logger.ForContext(Arg.Any<string[]>()).Returns(logger);
+        testSubject = new RaiseFindingToAnalysisIssueConverter(logger);
+    }
 
     [TestMethod]
-    public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<RaiseFindingToAnalysisIssueConverter, IRaiseFindingToAnalysisIssueConverter>();
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<RaiseFindingToAnalysisIssueConverter, IRaiseFindingToAnalysisIssueConverter>(MefTestHelpers.CreateExport<ILogger>(logger));
 
     [TestMethod]
     public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<RaiseFindingToAnalysisIssueConverter>();
+
+    [TestMethod]
+    public void Ctor_RegistersContextForLogs() => logger.Received(1).ForContext(nameof(RaiseFindingToAnalysisIssueConverter));
 
     [TestMethod]
     public void GetAnalysisIssues_HasNoIssues_ReturnsEmpty()
@@ -343,6 +354,85 @@ public class RaiseFindingToAnalysisIssueConverterTests
         issue.PrimaryLocation.TextRange.Should().BeNull();
     }
 
+    [TestMethod]
+    public void GetAnalysisIssues_TwoIssuesAndOneIsInvalidIssueDto_ReturnsOneIssueAndLogsTheInvalidOne()
+    {
+        var dateTimeOffset = DateTimeOffset.Now;
+        var issue1 = new RaisedIssueDto(
+            IssueWithFlowsAndQuickFixesUseCase.Issue1Id,
+            "serverKey1",
+            "ruleKey1",
+            "PrimaryMessage1",
+            dateTimeOffset,
+            true,
+            false,
+            new TextRangeDto(1, 2, 3, 4),
+            null,
+            null,
+            "context1",
+            new StandardModeDetails(IssueSeverity.MAJOR, RuleType.CODE_SMELL));
+        var invalidIssue = new RaisedIssueDto(
+            IssueWithFlowsAndQuickFixesUseCase.Issue2Id,
+            "serverKey2",
+            "ruleKey2",
+            "PrimaryMessage1",
+            dateTimeOffset,
+            true,
+            false,
+            new TextRangeDto(1, 2, 3, 4),
+            null,
+            null,
+            "context1",
+            severityMode: null);
+
+        var analysisIssues = testSubject.GetAnalysisIssues(new FileUri("C:\\IssueFile.cs"), new List<RaisedFindingDto> { issue1, invalidIssue }).ToList();
+
+        analysisIssues.Should().NotBeNull();
+        analysisIssues.Should().ContainSingle();
+        IssueWithFlowsAndQuickFixesUseCase.VerifyIssue1ConvertedCorrectly(analysisIssues[0]);
+        logger.Received(1).WriteLine(SLCoreStrings.RaiseFindingToAnalysisIssueConverter_CreateAnalysisIssueFailed, Arg.Is<object[]>(x => x[0].ToString() == "ruleKey2"));
+    }
+
+    [TestMethod]
+    public void GetAnalysisIssues_TwoIssuesAndOneIsInvalidHotspotDto_ReturnsOneIssueAndLogsTheInvalidOne()
+    {
+        var dateTimeOffset = DateTimeOffset.Now;
+        var issue1 = new RaisedIssueDto(
+            IssueWithFlowsAndQuickFixesUseCase.Issue1Id,
+            "serverKey1",
+            "ruleKey1",
+            "PrimaryMessage1",
+            dateTimeOffset,
+            true,
+            false,
+            new TextRangeDto(1, 2, 3, 4),
+            null,
+            null,
+            "context1",
+            new StandardModeDetails(IssueSeverity.MAJOR, RuleType.CODE_SMELL));
+        var invalidIssue = new RaisedHotspotDto(IssueWithFlowsAndQuickFixesUseCase.Issue2Id,
+            "serverKey2",
+            "ruleKey2",
+            "PrimaryMessage1",
+            dateTimeOffset,
+            true,
+            false,
+            textRange: null,
+            null,
+            null,
+            "context1",
+            VulnerabilityProbability.HIGH,
+            HotspotStatus.FIXED,
+            severityMode: null);
+
+        var analysisIssues = testSubject.GetAnalysisIssues(new FileUri("C:\\IssueFile.cs"), new List<RaisedFindingDto> { issue1, invalidIssue }).ToList();
+
+        analysisIssues.Should().NotBeNull();
+        analysisIssues.Should().ContainSingle();
+        IssueWithFlowsAndQuickFixesUseCase.VerifyIssue1ConvertedCorrectly(analysisIssues[0]);
+        logger.Received(1).WriteLine(SLCoreStrings.RaiseFindingToAnalysisIssueConverter_CreateAnalysisIssueFailed, Arg.Is<object[]>(x => x[0].ToString() == "ruleKey2"));
+    }
+
     private static class UnflattenedFlowsUseCase
     {
         internal static FileUri FileUri => new("C:\\IssueFile.cs");
@@ -392,23 +482,32 @@ public class RaiseFindingToAnalysisIssueConverterTests
             result.Should().NotBeNull();
             result.Should().HaveCount(2);
 
-            result[0].Id.Should().Be(Issue1Id);
-            result[0].RuleKey.Should().Be("ruleKey1");
-            result[0].Severity.Should().Be(AnalysisIssueSeverity.Major);
-            result[0].Type.Should().Be(AnalysisIssueType.CodeSmell);
-            result[0].HighestImpact.Should().BeNull();
+            VerifyIssue1ConvertedCorrectly(result[0]);
+            VerifyIssue2ConvertedCorrectly(result);
+        }
 
-            result[0].PrimaryLocation.FilePath.Should().Be("C:\\IssueFile.cs");
-            result[0].PrimaryLocation.Message.Should().Be("PrimaryMessage1");
-            result[0].PrimaryLocation.TextRange.StartLine.Should().Be(1);
-            result[0].PrimaryLocation.TextRange.StartLineOffset.Should().Be(2);
-            result[0].PrimaryLocation.TextRange.EndLine.Should().Be(3);
-            result[0].PrimaryLocation.TextRange.EndLineOffset.Should().Be(4);
-            result[0].PrimaryLocation.TextRange.LineHash.Should().BeNull();
+        internal static void VerifyIssue1ConvertedCorrectly(IAnalysisIssue issue)
+        {
+            issue.Id.Should().Be(Issue1Id);
+            issue.RuleKey.Should().Be("ruleKey1");
+            issue.Severity.Should().Be(AnalysisIssueSeverity.Major);
+            issue.Type.Should().Be(AnalysisIssueType.CodeSmell);
+            issue.HighestImpact.Should().BeNull();
 
-            result[0].Flows.Should().BeEmpty();
-            result[0].Fixes.Should().BeEmpty();
+            issue.PrimaryLocation.FilePath.Should().Be("C:\\IssueFile.cs");
+            issue.PrimaryLocation.Message.Should().Be("PrimaryMessage1");
+            issue.PrimaryLocation.TextRange.StartLine.Should().Be(1);
+            issue.PrimaryLocation.TextRange.StartLineOffset.Should().Be(2);
+            issue.PrimaryLocation.TextRange.EndLine.Should().Be(3);
+            issue.PrimaryLocation.TextRange.EndLineOffset.Should().Be(4);
+            issue.PrimaryLocation.TextRange.LineHash.Should().BeNull();
 
+            issue.Flows.Should().BeEmpty();
+            issue.Fixes.Should().BeEmpty();
+        }
+
+        private static void VerifyIssue2ConvertedCorrectly(List<IAnalysisIssue> result)
+        {
             result[1].Id.Should().Be(Issue2Id);
             result[1].RuleKey.Should().Be("ruleKey2");
             result[1].Severity.Should().BeNull();

--- a/src/SLCore/Listener/Analysis/RaiseFindingToAnalysisIssueConverter.cs
+++ b/src/SLCore/Listener/Analysis/RaiseFindingToAnalysisIssueConverter.cs
@@ -71,7 +71,7 @@ namespace SonarLint.VisualStudio.SLCore.Listener.Analysis
 
         private static Impact GetHighestImpact(List<ImpactDto> impacts)
         {
-            if(impacts is null || impacts.Count == 0)
+            if (impacts is null || impacts.Count == 0)
             {
                 return null;
             }
@@ -79,13 +79,20 @@ namespace SonarLint.VisualStudio.SLCore.Listener.Analysis
         }
 
         private static IAnalysisIssueLocation GetAnalysisIssueLocation(string filePath, string message, TextRangeDto textRangeDto) =>
-            new AnalysisIssueLocation(message,
-                filePath,
-                new TextRange(textRangeDto.startLine,
-                    textRangeDto.endLine,
-                    textRangeDto.startLineOffset,
-                    textRangeDto.endLineOffset,
-                    null));
+            new AnalysisIssueLocation(message, filePath, CopyTextRange(textRangeDto));
+
+        private static TextRange CopyTextRange(TextRangeDto textRangeDto)
+        {
+            if (textRangeDto is null)
+            {
+                return null;
+            }
+            return new TextRange(textRangeDto.startLine,
+                textRangeDto.endLine,
+                textRangeDto.startLineOffset,
+                textRangeDto.endLineOffset,
+                null);
+        }
 
         private static IAnalysisIssueFlow[] GetFlows(List<IssueFlowDto> issueFlows)
         {

--- a/src/SLCore/Listener/Analysis/RaiseFindingToAnalysisIssueConverter.cs
+++ b/src/SLCore/Listener/Analysis/RaiseFindingToAnalysisIssueConverter.cs
@@ -19,6 +19,7 @@
  */
 
 using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.SLCore.Common.Helpers;
 using SonarLint.VisualStudio.SLCore.Common.Models;
@@ -28,45 +29,57 @@ namespace SonarLint.VisualStudio.SLCore.Listener.Analysis
 {
     [Export(typeof(IRaiseFindingToAnalysisIssueConverter))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public class RaiseFindingToAnalysisIssueConverter : IRaiseFindingToAnalysisIssueConverter
+    [method: ImportingConstructor]
+    public class RaiseFindingToAnalysisIssueConverter(ILogger logger) : IRaiseFindingToAnalysisIssueConverter
     {
+        private readonly ILogger logger = logger.ForContext(nameof(RaiseFindingToAnalysisIssueConverter));
+
         public IEnumerable<IAnalysisIssue> GetAnalysisIssues<T>(FileUri fileUri, IEnumerable<T> raisedFindings) where T : RaisedFindingDto =>
             raisedFindings
-                .Select(item => CreateAnalysisIssue(fileUri, item))
+                .Select(item => TryCreateAnalysisIssue(fileUri, item))
+                .Where(x => x != null)
                 .ToList();
 
-        private static AnalysisIssue CreateAnalysisIssue<T>(FileUri fileUri, T item) where T : RaisedFindingDto
+        private AnalysisIssue TryCreateAnalysisIssue<T>(FileUri fileUri, T item) where T : RaisedFindingDto
         {
-            var id = item.id;
-            var itemRuleKey = item.ruleKey;
-            var analysisIssueSeverity = item.severityMode.Left?.severity.ToAnalysisIssueSeverity();
-            var analysisIssueType = item.severityMode.Left?.type.ToAnalysisIssueType();
-            var highestSoftwareQualitySeverity = GetHighestImpact(item.severityMode.Right?.impacts);
-            var analysisIssueLocation = GetAnalysisIssueLocation(fileUri.LocalPath, item.primaryMessage, item.textRange);
-            var analysisIssueFlows = GetFlows(item.flows);
-            var readOnlyList = item.quickFixes?.Select(qf => GetQuickFix(fileUri, qf)).Where(qf => qf is not null).ToList();
-
-            if (item is RaisedHotspotDto raisedHotspotDto)
+            try
             {
-                return new AnalysisHotspotIssue(id,
+                var id = item.id;
+                var itemRuleKey = item.ruleKey;
+                var analysisIssueSeverity = item.severityMode.Left?.severity.ToAnalysisIssueSeverity();
+                var analysisIssueType = item.severityMode.Left?.type.ToAnalysisIssueType();
+                var highestSoftwareQualitySeverity = GetHighestImpact(item.severityMode.Right?.impacts);
+                var analysisIssueLocation = GetAnalysisIssueLocation(fileUri.LocalPath, item.primaryMessage, item.textRange);
+                var analysisIssueFlows = GetFlows(item.flows);
+                var readOnlyList = item.quickFixes?.Select(qf => GetQuickFix(fileUri, qf)).Where(qf => qf is not null).ToList();
+
+                if (item is RaisedHotspotDto raisedHotspotDto)
+                {
+                    return new AnalysisHotspotIssue(id,
+                        itemRuleKey,
+                        analysisIssueSeverity,
+                        analysisIssueType,
+                        highestSoftwareQualitySeverity,
+                        analysisIssueLocation,
+                        analysisIssueFlows,
+                        readOnlyList,
+                        raisedHotspotDto.vulnerabilityProbability.GetHotspotPriority());
+                }
+
+                return new AnalysisIssue(id,
                     itemRuleKey,
                     analysisIssueSeverity,
                     analysisIssueType,
                     highestSoftwareQualitySeverity,
                     analysisIssueLocation,
                     analysisIssueFlows,
-                    readOnlyList,
-                    raisedHotspotDto.vulnerabilityProbability.GetHotspotPriority());
+                    readOnlyList);
             }
-
-            return new AnalysisIssue(id,
-                itemRuleKey,
-                analysisIssueSeverity,
-                analysisIssueType,
-                highestSoftwareQualitySeverity,
-                analysisIssueLocation,
-                analysisIssueFlows,
-                readOnlyList);
+            catch (Exception exception)
+            {
+                logger.WriteLine(SLCoreStrings.RaiseFindingToAnalysisIssueConverter_CreateAnalysisIssueFailed, item?.ruleKey, exception);
+                return null;
+            }
         }
 
         private static Impact GetHighestImpact(List<ImpactDto> impacts)

--- a/src/SLCore/SLCoreStrings.Designer.cs
+++ b/src/SLCore/SLCoreStrings.Designer.cs
@@ -151,6 +151,15 @@ namespace SonarLint.VisualStudio.SLCore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating analysis issue for {0} failed due to {1}..
+        /// </summary>
+        public static string RaiseFindingToAnalysisIssueConverter_CreateAnalysisIssueFailed {
+            get {
+                return ResourceManager.GetString("RaiseFindingToAnalysisIssueConverter_CreateAnalysisIssueFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The server certificate can not be verified. Please see the logs for more info..
         /// </summary>
         public static string ServerCertificateInfobar_CertificateInvalidMessage {

--- a/src/SLCore/SLCoreStrings.resx
+++ b/src/SLCore/SLCoreStrings.resx
@@ -195,4 +195,7 @@
   <data name="ServerCertificateInfobar_ShowLogs" xml:space="preserve">
     <value>Show logs</value>
   </data>
+  <data name="RaiseFindingToAnalysisIssueConverter_CreateAnalysisIssueFailed" xml:space="preserve">
+    <value>Creating analysis issue for {0} failed due to {1}.</value>
+  </data>
 </root>


### PR DESCRIPTION
[SLVS-1875](https://sonarsource.atlassian.net/browse/SLVS-1875)

The RaiseFindingToAnalysisIssueConverter.CreateAnalysisIssue crashes due to a null reference exception (the TextRangeDto is null [here](https://github.com/SonarSource/sonarlint-visualstudio/blob/c01c118a3ea0d2a53d500fb7aadcab96add98747/src/SLCore/Listener/Analysis/RaiseFindingToAnalysisIssueConverter.cs#L84)), so the RaisedFindingProcessor.PublishFindings  doesn’t publish any issue. The TextRangeDto is null because it's a file level issue.

Added null check and  try/catch inside RaiseFindingToAnalysisIssueConverter.CreateAnalysisIssue so that, if an issue can’t be converted, it doesn’t prevent all the other issues to be published

[SLVS-1875]: https://sonarsource.atlassian.net/browse/SLVS-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ