### PR TITLE
SLVS-1884 Add RPC method helpGenerateUserToken

### DIFF
--- a/src/SLCore.Listeners.UnitTests/Implementation/BrowserListenerTests.cs
+++ b/src/SLCore.Listeners.UnitTests/Implementation/BrowserListenerTests.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.SLCore.Listener.Visualization;
+using SonarLint.VisualStudio.SLCore.Listener.Visualization.Models;
+
+namespace SonarLint.VisualStudio.SLCore.Listeners.UnitTests.Implementation;
+
+[TestClass]
+public class BrowserListenerTests
+{
+    private IBrowserService browserService;
+    private BrowserListener testSubject;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        browserService = Substitute.For<IBrowserService>();
+        testSubject = new BrowserListener(browserService);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<BrowserListener, IBrowserListener>(
+            MefTestHelpers.CreateExport<IBrowserService>());
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<BrowserListener>();
+
+    [TestMethod]
+    public void OpenUrlInBrowser_NavigatesToUrl()
+    {
+        var url = "http://example.com";
+
+        testSubject.OpenUrlInBrowser(new OpenUrlInBrowserParams(url));
+
+        browserService.Received(1).Navigate(url);
+    }
+}

--- a/src/SLCore.Listeners/Implementation/BrowserListener.cs
+++ b/src/SLCore.Listeners/Implementation/BrowserListener.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.SLCore.Listener.Visualization;
+using SonarLint.VisualStudio.SLCore.Listener.Visualization.Models;
+
+namespace SonarLint.VisualStudio.SLCore.Listeners.Implementation;
+
+[Export(typeof(IBrowserListener))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+[method: ImportingConstructor]
+public class BrowserListener(IBrowserService browserService) : IBrowserListener
+{
+    public void OpenUrlInBrowser(OpenUrlInBrowserParams parameters) => browserService.Navigate(parameters.url);
+}

--- a/src/SLCore.UnitTests/Listener/Visualization/OpenUrlInBrowserParamsTests.cs
+++ b/src/SLCore.UnitTests/Listener/Visualization/OpenUrlInBrowserParamsTests.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using SonarLint.VisualStudio.SLCore.Listener.Visualization.Models;
+
+namespace SonarLint.VisualStudio.SLCore.UnitTests.Listener.Visualization;
+
+[TestClass]
+public class OpenUrlInBrowserParamsTests
+{
+    [TestMethod]
+    public void Serialize_AsExpected()
+    {
+        var openUrlInBrowserParams = new OpenUrlInBrowserParams("http://localhost:9000/home");
+        var expected = """
+                       {
+                         "url": "http://localhost:9000/home"
+                       }
+                       """;
+
+        var actual = JsonConvert.SerializeObject(openUrlInBrowserParams, Formatting.Indented);
+
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void Deserialize_AsExpected()
+    {
+        var expected = new OpenUrlInBrowserParams("http://localhost:9000/home");
+        var serialized = """
+                         {
+                           "url": "http://localhost:9000/home"
+                         }
+                         """;
+
+        var actual = JsonConvert.DeserializeObject<OpenUrlInBrowserParams>(serialized);
+
+        actual.Should().BeEquivalentTo(expected, options => options.ComparingByMembers<OpenUrlInBrowserParams>());
+    }
+}

--- a/src/SLCore.UnitTests/Service/Connection/Models/HelpGenerateUserTokenParamsTests.cs
+++ b/src/SLCore.UnitTests/Service/Connection/Models/HelpGenerateUserTokenParamsTests.cs
@@ -29,7 +29,7 @@ public class HelpGenerateUserTokenParamsTests
     [TestMethod]
     public void Serialize_AsExpected()
     {
-        var helpGenerateUserTokenParams = new HelpGenerateUserTokenParams(new Uri("http://localhost:9000"));
+        var helpGenerateUserTokenParams = new HelpGenerateUserTokenParams("http://localhost:9000");
         var expected = """
                        {
                          "serverUrl": "http://localhost:9000"

--- a/src/SLCore.UnitTests/Service/Connection/Models/HelpGenerateUserTokenParamsTests.cs
+++ b/src/SLCore.UnitTests/Service/Connection/Models/HelpGenerateUserTokenParamsTests.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Newtonsoft.Json;
+using SonarLint.VisualStudio.SLCore.Service.Connection.Models;
+
+namespace SonarLint.VisualStudio.SLCore.UnitTests.Service.Connection.Models;
+
+[TestClass]
+public class HelpGenerateUserTokenParamsTests
+{
+    [TestMethod]
+    public void Serialize_AsExpected()
+    {
+        var helpGenerateUserTokenParams = new HelpGenerateUserTokenParams(new Uri("http://localhost:9000"));
+        var expected = """
+                       {
+                         "serverUrl": "http://localhost:9000"
+                       }
+                       """;
+
+        var actual = JsonConvert.SerializeObject(helpGenerateUserTokenParams, Formatting.Indented);
+
+        actual.Should().Be(expected);
+    }
+}

--- a/src/SLCore.UnitTests/Service/Connection/Models/HelpGenerateUserTokenResponseTests.cs
+++ b/src/SLCore.UnitTests/Service/Connection/Models/HelpGenerateUserTokenResponseTests.cs
@@ -1,0 +1,68 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Newtonsoft.Json;
+using SonarLint.VisualStudio.SLCore.Service.Connection.Models;
+
+namespace SonarLint.VisualStudio.SLCore.UnitTests.Service.Connection.Models;
+
+[TestClass]
+public class HelpGenerateUserTokenResponseTests
+{
+    [TestMethod]
+    [DataRow("""
+             {
+               "token": "A186C072-9D8F-404C-9BA8-31EC450409B2"
+             }
+             """, "A186C072-9D8F-404C-9BA8-31EC450409B2")]
+    [DataRow("""
+             {
+               "token": null
+             }
+             """, null)]
+    public void Serialize_AsExpected(string expected, string token)
+    {
+        var helpGenerateUserTokenParams = new HelpGenerateUserTokenResponse(token);
+
+        var actual = JsonConvert.SerializeObject(helpGenerateUserTokenParams, Formatting.Indented);
+
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    [DataRow("""
+             {
+               "token": "A186C072-9D8F-404C-9BA8-31EC450409B2"
+             }
+             """, "A186C072-9D8F-404C-9BA8-31EC450409B2")]
+    [DataRow("""
+             {
+               "token": null
+             }
+             """, null)]
+    public void Deserialize_AsExpected(string serialized, string expectedToken)
+    {
+        var expected = new HelpGenerateUserTokenResponse(expectedToken);
+
+        var actual = JsonConvert.DeserializeObject<HelpGenerateUserTokenResponse>(serialized);
+
+        actual.Should().BeEquivalentTo(expected, options => options.ComparingByMembers<HelpGenerateUserTokenResponse>());
+    }
+}

--- a/src/SLCore/Listener/Visualization/IBrowserListener.cs
+++ b/src/SLCore/Listener/Visualization/IBrowserListener.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.SLCore.Core;
+using SonarLint.VisualStudio.SLCore.Listener.Visualization.Models;
+
+namespace SonarLint.VisualStudio.SLCore.Listener.Visualization;
+
+public interface IBrowserListener : ISLCoreListener
+{
+    void OpenUrlInBrowser(OpenUrlInBrowserParams parameters);
+}

--- a/src/SLCore/Listener/Visualization/Models/OpenUrlInBrowserParams.cs
+++ b/src/SLCore/Listener/Visualization/Models/OpenUrlInBrowserParams.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.SLCore.Listener.Visualization.Models;
+
+public record OpenUrlInBrowserParams(string url)
+{
+}

--- a/src/SLCore/Service/Connection/IConnectionConfigurationSLCoreService.cs
+++ b/src/SLCore/Service/Connection/IConnectionConfigurationSLCoreService.cs
@@ -18,8 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using SonarLint.VisualStudio.SLCore.Core;
 using SonarLint.VisualStudio.SLCore.Protocol;
+using SonarLint.VisualStudio.SLCore.Service.Connection.Models;
 
 namespace SonarLint.VisualStudio.SLCore.Service.Connection;
 
@@ -71,4 +73,12 @@ public interface IConnectionConfigurationSLCoreService : ISLCoreService
     /// <param name="parameters"></param>
     /// <returns></returns>
     Task<GetProjectNamesByKeyResponse> GetProjectNamesByKeyAsync(GetProjectNamesByKeyParams parameters);
+
+    /// <summary>
+    /// For servers that support automatic token generation, will return the token in the response. Else no token will be returned.
+    /// If the local server is not started or the server URL can not be reached, the future will fail
+    /// </summary>
+    /// <returns></returns>
+    [ExcludeFromCodeCoverage] // TODO by https://sonarsource.atlassian.net/browse/SLVS-1793 - remove this attribute
+    Task<HelpGenerateUserTokenResponse> HelpGenerateUserTokenAsync(HelpGenerateUserTokenParams parameters);
 }

--- a/src/SLCore/Service/Connection/Models/HelpGenerateUserTokenParams.cs
+++ b/src/SLCore/Service/Connection/Models/HelpGenerateUserTokenParams.cs
@@ -20,6 +20,6 @@
 
 namespace SonarLint.VisualStudio.SLCore.Service.Connection.Models;
 
-public record HelpGenerateUserTokenParams(Uri serverUrl)
+public record HelpGenerateUserTokenParams(string serverUrl)
 {
 }

--- a/src/SLCore/Service/Connection/Models/HelpGenerateUserTokenParams.cs
+++ b/src/SLCore/Service/Connection/Models/HelpGenerateUserTokenParams.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.SLCore.Service.Connection.Models;
+
+public record HelpGenerateUserTokenParams(Uri serverUrl)
+{
+}

--- a/src/SLCore/Service/Connection/Models/HelpGenerateUserTokenResponse.cs
+++ b/src/SLCore/Service/Connection/Models/HelpGenerateUserTokenResponse.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.SLCore.Service.Connection.Models;
+
+public record HelpGenerateUserTokenResponse(string token)
+{
+}


### PR DESCRIPTION
Add the RPCs method helpGenerateUserToken and OpenUrlInBrowser, needed for generating a token

[SLVS-1884](https://sonarsource.atlassian.net/browse/SLVS-1884)



[SLVS-1884]: https://sonarsource.atlassian.net/browse/SLVS-1884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ