### PR TITLE
SLVS-1894 Enhance ConnectionInfoComponent to always show URL for SQC

### DIFF
--- a/src/ConnectedMode.UnitTests/UI/ConnectionDisplay/ConnectionNameViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ConnectionDisplay/ConnectionNameViewModelTests.cs
@@ -92,11 +92,24 @@ public class ConnectionNameViewModelTests
     }
 
     [TestMethod]
-    public void DisplayName_SonarCloud_HasId_ReturnsId()
+    public void DisplayName_SonarCloud_HasId_AlwaysShowUrlFalse_ReturnsId()
     {
+        testSubject.AlwaysShowUrl = false;
+
         testSubject.ConnectionInfo = new ConnectionInfo("any id", ConnectionServerType.SonarCloud, CloudServerRegion.Eu);
 
         testSubject.DisplayName.Should().Be("any id");
+    }
+
+    [DynamicData(nameof(Regions))]
+    [DataTestMethod]
+    public void DisplayName_SonarCloud_HasId_AlwaysShowUrlTrue_ReturnsUrl(CloudServerRegion region)
+    {
+        testSubject.AlwaysShowUrl = true;
+
+        testSubject.ConnectionInfo = new ConnectionInfo("any id", ConnectionServerType.SonarCloud, region);
+
+        testSubject.DisplayName.Should().Be(region.Url.ToString());
     }
 
     [TestMethod]
@@ -145,6 +158,18 @@ public class ConnectionNameViewModelTests
         testSubject.ConnectionInfo = new ConnectionInfo(id, ConnectionServerType.SonarCloud, CloudServerRegion.Us);
 
         VerifyDoesNotDisplayRegion();
+    }
+
+    [TestMethod]
+    public void AlwaysShowUrl_Set_RaisesPropertyChanged()
+    {
+        var eventHandler = Substitute.For<PropertyChangedEventHandler>();
+        testSubject.PropertyChanged += eventHandler;
+
+        testSubject.AlwaysShowUrl = true;
+
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.AlwaysShowUrl)));
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.DisplayName)));
     }
 
     private void VerifyDoesNotDisplayRegion()

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionIconComponent.xaml.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionIconComponent.xaml.cs
@@ -27,7 +27,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ConnectionDisplay;
 [ExcludeFromCodeCoverage] // UI, not really unit-testable
 public partial class ConnectionIconComponent : UserControl
 {
-    public static readonly DependencyProperty ServerTypeProp = DependencyProperty.Register(nameof(ServerType), typeof(ConnectionServerType), typeof(ConnectionIconComponent), new PropertyMetadata(ConnectionServerType.SonarCloud));
+    public static readonly DependencyProperty ServerTypeProp
+        = DependencyProperty.Register(nameof(ServerType), typeof(ConnectionServerType), typeof(ConnectionIconComponent), new PropertyMetadata(ConnectionServerType.SonarCloud));
 
     public ConnectionIconComponent()
     {
@@ -40,4 +41,3 @@ public partial class ConnectionIconComponent : UserControl
         set => SetValue(ServerTypeProp, value);
     }
 }
-

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml
@@ -18,7 +18,8 @@
             Margin="5, 0, 0, 0"
             ConnectionInfo="{Binding Path=.}"
             VerticalAlignment="{Binding ElementName=ConnectionInfoUc, Path=TextAndIconVerticalAlignment}"
-            ConnectionNameFontWeight="{Binding ElementName=ConnectionInfoUc, Path=ConnectionNameFontWeight}"/>
+            ConnectionNameFontWeight="{Binding ElementName=ConnectionInfoUc, Path=ConnectionNameFontWeight}"
+            AlwaysShowUrl="{Binding ElementName=ConnectionInfoUc, Path=ShowUrlForName}"/>
     </Grid>
 
 </UserControl>

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml.cs
@@ -32,6 +32,8 @@ public sealed partial class ConnectionInfoComponent : UserControl
     public static readonly DependencyProperty ConnectionInfoProp = DependencyProperty.Register(nameof(ConnectionInfo), typeof(ConnectionInfo), typeof(ConnectionInfoComponent), new PropertyMetadata());
     public static readonly DependencyProperty TextAndIconVerticalAlignmentProp = DependencyProperty.Register(nameof(TextAndIconVerticalAlignment), typeof(VerticalAlignment),
         typeof(ConnectionInfoComponent), new PropertyMetadata(VerticalAlignment.Center));
+    public static readonly DependencyProperty ShowUrlForNameProp
+        = DependencyProperty.Register(nameof(ShowUrlForName), typeof(bool), typeof(ConnectionInfoComponent), new PropertyMetadata(false));
 
     public ConnectionInfoComponent()
     {
@@ -54,5 +56,11 @@ public sealed partial class ConnectionInfoComponent : UserControl
     {
         get => (VerticalAlignment)GetValue(TextAndIconVerticalAlignmentProp);
         set => SetValue(TextAndIconVerticalAlignmentProp, value);
+    }
+
+    public bool ShowUrlForName
+    {
+        get => (bool)GetValue(ShowUrlForNameProp);
+        set => SetValue(ShowUrlForNameProp, value);
     }
 }

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameComponent.xaml.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameComponent.xaml.cs
@@ -27,9 +27,12 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ConnectionDisplay;
 [ExcludeFromCodeCoverage] // UI, not really unit-testable
 public sealed partial class ConnectionNameComponent : UserControl
 {
-    public static readonly DependencyProperty ConnectionNameFontWeightProp = DependencyProperty.Register(nameof(ConnectionNameFontWeight), typeof(FontWeight), typeof(ConnectionNameComponent), new PropertyMetadata(FontWeights.DemiBold));
+    public static readonly DependencyProperty ConnectionNameFontWeightProp
+        = DependencyProperty.Register(nameof(ConnectionNameFontWeight), typeof(FontWeight), typeof(ConnectionNameComponent), new PropertyMetadata(FontWeights.DemiBold));
     public static readonly DependencyProperty ConnectionInfoProp
         = DependencyProperty.Register(nameof(ConnectionInfo), typeof(ConnectionInfo), typeof(ConnectionNameComponent), new PropertyMetadata(OnConnectionInfoSet));
+    public static readonly DependencyProperty AlwaysShowUrlProp
+        = DependencyProperty.Register(nameof(AlwaysShowUrl), typeof(bool), typeof(ConnectionNameComponent), new PropertyMetadata(OnAlwaysShowUrlSet));
 
     public ConnectionNameViewModel ViewModel { get; } = new();
 
@@ -50,11 +53,25 @@ public sealed partial class ConnectionNameComponent : UserControl
         set => SetValue(ConnectionNameFontWeightProp, value);
     }
 
+    public bool AlwaysShowUrl
+    {
+        get => (bool)GetValue(AlwaysShowUrlProp);
+        set => SetValue(AlwaysShowUrlProp, value);
+    }
+
     private static void OnConnectionInfoSet(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is ConnectionNameComponent component && e.NewValue is ConnectionInfo connectionInfo)
         {
             component.ViewModel.ConnectionInfo = connectionInfo;
+        }
+    }
+
+    private static void OnAlwaysShowUrlSet(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is ConnectionNameComponent component && e.NewValue is bool newAlwaysShowUrl)
+        {
+            component.ViewModel.AlwaysShowUrl = newAlwaysShowUrl;
         }
     }
 }

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameViewModel.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameViewModel.cs
@@ -34,6 +34,7 @@ public class ConnectionNameViewModel : ViewModelBase
 
     private ConnectionInfo connectionInfo;
     private readonly IDogfoodingService dogfoodingService;
+    private bool alwaysShowUrl;
 
     public ConnectionInfo ConnectionInfo
     {
@@ -48,9 +49,20 @@ public class ConnectionNameViewModel : ViewModelBase
         }
     }
 
+    public bool AlwaysShowUrl
+    {
+        get => alwaysShowUrl;
+        set
+        {
+            alwaysShowUrl = value;
+            RaisePropertyChanged();
+            RaisePropertyChanged(nameof(DisplayName));
+        }
+    }
+
     public string DisplayName =>
-        connectionInfo is { Id: null, ServerType: ConnectionServerType.SonarCloud }
-            ? connectionInfo.CloudServerRegion.Url.ToString()
+        connectionInfo is { Id: null, ServerType: ConnectionServerType.SonarCloud } || AlwaysShowUrl
+            ? connectionInfo?.CloudServerRegion.Url.ToString()
             : connectionInfo?.Id ?? string.Empty;
 
     public bool ShouldDisplayRegion => dogfoodingService.IsDogfoodingEnvironment && connectionInfo?.ServerType is ConnectionServerType.SonarCloud;

--- a/src/ConnectedMode/UI/TrustConnection/TrustConnectionDialog.xaml
+++ b/src/ConnectedMode/UI/TrustConnection/TrustConnectionDialog.xaml
@@ -46,7 +46,7 @@
                 <Grid>
                     <TextBlock VerticalAlignment="Center" Padding="5,0">
                         <InlineUIContainer Style="{StaticResource ConnectionInfoInlineWrapper}">
-                            <connectionDisplay:ConnectionInfoComponent ConnectionInfo="{Binding ElementName=This, Path=ConnectionInfo}" />
+                            <connectionDisplay:ConnectionInfoComponent ConnectionInfo="{Binding ElementName=This, Path=ConnectionInfo}" ShowUrlForName="True"/>
                         </InlineUIContainer>
                     </TextBlock>
                 </Grid>


### PR DESCRIPTION
[SLVS-1894](https://sonarsource.atlassian.net/browse/SLVS-1894)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6054) in which the `TrustConnectionDialog` was created, because the property is set for this dialog

[SLVS-1894]: https://sonarsource.atlassian.net/browse/SLVS-1894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ