### PR TITLE
SLVS-1914 Remove multiple source of truth for language

### DIFF
--- a/src/Core.UnitTests/LanguageTests.cs
+++ b/src/Core.UnitTests/LanguageTests.cs
@@ -148,6 +148,21 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             LanguageHasExpectedPlugin(Language.TSql, "tsql", null);
         }
 
+        [TestMethod]
+        public void Language_HasExpectedServerLanguageKey()
+        {
+            LanguageHasExpectedServerLanguageKey(Language.CSharp, "cs");
+            LanguageHasExpectedServerLanguageKey(Language.VBNET, "vbnet");
+            LanguageHasExpectedServerLanguageKey(Language.Cpp, "cpp");
+            LanguageHasExpectedServerLanguageKey(Language.C, "c");
+            LanguageHasExpectedServerLanguageKey(Language.Js, "js");
+            LanguageHasExpectedServerLanguageKey(Language.Ts, "ts");
+            LanguageHasExpectedServerLanguageKey(Language.Css, "css");
+            LanguageHasExpectedServerLanguageKey(Language.Html, "web");
+            LanguageHasExpectedServerLanguageKey(Language.Secrets, "secrets");
+            LanguageHasExpectedServerLanguageKey(Language.TSql, "tsql");
+        }
+
         private static void LanguageHasExpectedPlugin(Language language, string pluginKey, string filePattern)
         {
             language.PluginInfo.Key.Should().Be(pluginKey);
@@ -166,5 +181,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             repoInfo.Key.Should().Be(repoKey);
             repoInfo.FolderName.Should().Be(folderName);
         }
+
+        private static void LanguageHasExpectedServerLanguageKey(Language language, string key) => language.ServerLanguageKey.Should().Be(key);
     }
 }

--- a/src/SonarQube.Client.Tests/SonarQubeService_GetQualityProfileAsync.cs
+++ b/src/SonarQube.Client.Tests/SonarQubeService_GetQualityProfileAsync.cs
@@ -134,7 +134,7 @@ namespace SonarQube.Client.Tests
   ]
 }");
 
-            var result = await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+            var result = await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None);
 
             httpClientHandler.VerifyAll();
@@ -200,7 +200,7 @@ namespace SonarQube.Client.Tests
   ]
 }");
 
-            var result = await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+            var result = await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None);
 
             httpClientHandler.VerifyAll();
@@ -222,7 +222,7 @@ namespace SonarQube.Client.Tests
                 HttpStatusCode.InternalServerError);
 
             Func<Task<SonarQubeQualityProfile>> func = async () =>
-                await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp, CancellationToken.None);
+                await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(), CancellationToken.None);
 
             func.Should().ThrowExactly<HttpRequestException>().And
                 .Message.Should().Be("Response status code does not indicate success: 500 (Internal Server Error).");
@@ -337,7 +337,7 @@ namespace SonarQube.Client.Tests
   ]
 }");
 
-            var result = await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+            var result = await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None);
 
             httpClientHandler.VerifyAll();
@@ -407,7 +407,7 @@ namespace SonarQube.Client.Tests
   ]
 }");
 
-            var result = await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+            var result = await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None);
 
             httpClientHandler.VerifyAll();
@@ -456,11 +456,11 @@ namespace SonarQube.Client.Tests
   }
 }");
 
-            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None));
 
             action.Should().ThrowExactly<InvalidOperationException>().And
-                .Message.Should().Be("The SonarC# plugin is not installed on the connected SonarQube.");
+                .Message.Should().Be("The plugin for C# is not installed on the connected SonarQube.");
 
             httpClientHandler.VerifyAll();
         }
@@ -501,11 +501,11 @@ namespace SonarQube.Client.Tests
   }
 }");
 
-            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.CSharp,
+            var action = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None));
 
             action.Should().ThrowExactly<InvalidOperationException>().And
-                .Message.Should().Be("The SonarC# plugin is not installed on the connected SonarQube.");
+                .Message.Should().Be("The plugin for C# is not installed on the connected SonarQube.");
 
             httpClientHandler.VerifyAll();
         }
@@ -524,11 +524,11 @@ namespace SonarQube.Client.Tests
   }
 }");
 
-            var func = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.VbNet,
+            var func = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeVbNetLanguage(),
                 CancellationToken.None));
 
             func.Should().ThrowExactly<InvalidOperationException>().And
-                .Message.Should().Be("The SonarVB plugin is not installed on the connected SonarQube.");
+                .Message.Should().Be("The plugin for VB.NET is not installed on the connected SonarQube.");
 
             httpClientHandler.VerifyAll();
         }
@@ -539,7 +539,7 @@ namespace SonarQube.Client.Tests
             // No calls to Connect
             // No need to setup request, the operation should fail
 
-            var func = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", SonarQubeLanguage.VbNet,
+            var func = new Func<Task>(async () => await service.GetQualityProfileAsync("my_project", "my_organization", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None));
 
             func.Should().ThrowExactly<InvalidOperationException>().And
@@ -547,5 +547,9 @@ namespace SonarQube.Client.Tests
 
             logger.ErrorMessages.Should().Contain("The service is expected to be connected.");
         }
+
+        private static SonarQubeLanguage CreateSonarQubeCsharpLanguage() => new("cs", "C#");
+
+        private static SonarQubeLanguage CreateSonarQubeVbNetLanguage() => new("vbnet", "VB.NET");
     }
 }

--- a/src/SonarQube.Client.Tests/SonarQubeService_GetRoslynExportProfileAsync.cs
+++ b/src/SonarQube.Client.Tests/SonarQubeService_GetRoslynExportProfileAsync.cs
@@ -56,7 +56,7 @@ namespace SonarQube.Client.Tests
   </Deployment>
 </RoslynExportProfile>");
 
-            var result = await service.GetRoslynExportProfileAsync("quality_profile", "my-org", SonarQubeLanguage.CSharp,
+            var result = await service.GetRoslynExportProfileAsync("quality_profile", "my-org", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None);
 
             httpClientHandler.VerifyAll();
@@ -85,7 +85,7 @@ namespace SonarQube.Client.Tests
                 "", HttpStatusCode.NotFound);
 
             Func<Task<RoslynExportProfileResponse>> func = async () =>
-                await service.GetRoslynExportProfileAsync("quality_profile", "my-org", SonarQubeLanguage.CSharp,
+                await service.GetRoslynExportProfileAsync("quality_profile", "my-org", CreateSonarQubeCsharpLanguage(),
                     CancellationToken.None);
 
             func.Should().ThrowExactly<HttpRequestException>().And
@@ -122,7 +122,7 @@ namespace SonarQube.Client.Tests
   </Deployment>
 </RoslynExportProfile>");
 
-            var result = await service.GetRoslynExportProfileAsync("quality_profile", "my-org", SonarQubeLanguage.CSharp,
+            var result = await service.GetRoslynExportProfileAsync("quality_profile", "my-org", CreateSonarQubeCsharpLanguage(),
                 CancellationToken.None);
 
             httpClientHandler.VerifyAll();
@@ -149,7 +149,7 @@ namespace SonarQube.Client.Tests
             // No need to setup request, the operation should fail
 
             Func<Task<RoslynExportProfileResponse>> func = async () =>
-                await service.GetRoslynExportProfileAsync("quality_profile", "my-org", SonarQubeLanguage.CSharp,
+                await service.GetRoslynExportProfileAsync("quality_profile", "my-org", CreateSonarQubeCsharpLanguage(),
                     CancellationToken.None);
 
             func.Should().ThrowExactly<InvalidOperationException>().And
@@ -157,5 +157,7 @@ namespace SonarQube.Client.Tests
 
             logger.ErrorMessages.Should().Contain("The service is expected to be connected.");
         }
+
+        private static SonarQubeLanguage CreateSonarQubeCsharpLanguage() => new("cs", "C#");
     }
 }

--- a/src/SonarQube.Client/Api/V9_4/GetSonarLintEventStream.cs
+++ b/src/SonarQube.Client/Api/V9_4/GetSonarLintEventStream.cs
@@ -22,22 +22,18 @@ using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Newtonsoft.Json;
-using SonarQube.Client.Models;
+using SonarLint.VisualStudio.Core;
 using SonarQube.Client.Requests;
 
 namespace SonarQube.Client.Api.V9_4;
 
 internal class GetSonarLintEventStream : RequestBase<Stream>, IGetSonarLintEventStream
 {
-    private static readonly string RoslynLanguages = string.Join(",", SonarQubeLanguage.CSharp.Key, SonarQubeLanguage.VbNet.Key);
+    private static readonly string RoslynServerLanguageKeys = string.Join(",", LanguageProvider.Instance.RoslynLanguages.Select(x => x.ServerLanguageKey));
 
     protected override string Path => "api/push/sonarlint_events";
 
-    protected override MediaTypeWithQualityHeaderValue[] AllowedMediaTypeHeaders =>
-        new[]
-        {
-            MediaTypeWithQualityHeaderValue.Parse("text/event-stream")
-        };
+    protected override MediaTypeWithQualityHeaderValue[] AllowedMediaTypeHeaders => new[] { MediaTypeWithQualityHeaderValue.Parse("text/event-stream") };
 
     protected override async Task<Result<Stream>> ReadResponseAsync(HttpResponseMessage httpResponse)
     {
@@ -56,7 +52,7 @@ internal class GetSonarLintEventStream : RequestBase<Stream>, IGetSonarLintEvent
     /// Supports only Roslyn languages as the SSE for non-Roslyn languages are handled by SLCore.
     /// </summary>
     [JsonProperty("languages")]
-    public string Languages { get; set; } = RoslynLanguages;
+    public string Languages { get; set; } = RoslynServerLanguageKeys;
 
     [JsonProperty("projectKeys")]
     public string ProjectKey { get; set; }

--- a/src/SonarQube.Client/Models/SonarQubeLanguage.cs
+++ b/src/SonarQube.Client/Models/SonarQubeLanguage.cs
@@ -18,25 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// TODO by https://sonarsource.atlassian.net/browse/SLVS-1816 Drop this model and use the Language from Core assembly. There should only be one source of truth for the language.
-
 namespace SonarQube.Client.Models
 {
     public class SonarQubeLanguage
     {
-        public static readonly SonarQubeLanguage CSharp = new SonarQubeLanguage("cs", "C#", "SonarC#");
-        public static readonly SonarQubeLanguage VbNet = new SonarQubeLanguage("vbnet", "VB.NET", "SonarVB");
-        public static readonly SonarQubeLanguage Cpp = new SonarQubeLanguage("cpp", "C++", "SonarCFamily");
-        public static readonly SonarQubeLanguage C = new SonarQubeLanguage("c", "C", "SonarCFamily");
-        public static readonly SonarQubeLanguage Js = new SonarQubeLanguage("js", "JavaScript", "javascript");
-        public static readonly SonarQubeLanguage Ts = new SonarQubeLanguage("ts", "TypeScript", "typescript");
-        public static readonly SonarQubeLanguage Css = new SonarQubeLanguage("css", "CSS", "css");
-        public static readonly SonarQubeLanguage Html = new SonarQubeLanguage("web", "HTML", "html");
-        public static readonly SonarQubeLanguage Secrets = new SonarQubeLanguage("secrets", "Secrets", "SonarSecrets");
-        public static readonly SonarQubeLanguage TSql = new SonarQubeLanguage("tsql", "Secrets", "T-SQL");
-
-        public static readonly SonarQubeLanguage[] AllLanguages = { CSharp, VbNet, Cpp, C, Js, Ts, Secrets, Css, Html, TSql };
-
         public string Key { get; }
 
         public string Name { get; }

--- a/src/SonarQube.Client/SonarQubeService.cs
+++ b/src/SonarQube.Client/SonarQubeService.cs
@@ -266,7 +266,7 @@ namespace SonarQube.Client
 
             if (profilesWithGivenLanguage.Count == 0)
             {
-                throw new InvalidOperationException($"The {language.PluginName} plugin is not installed on the connected SonarQube.");
+                throw new InvalidOperationException($"The plugin for {language.Name} is not installed on the connected SonarQube.");
             }
 
             var qualityProfile = profilesWithGivenLanguage.Count > 1


### PR DESCRIPTION
[SLVS-1914](https://sonarsource.atlassian.net/browse/SLVS-1914)

`SonarQubeLanguage` should not have a list of all known languages and instead should use the `LanguageProvider`
This targets the branch in which the dependcies between `SonarQube.Client` and `Core` has been swapped

[SLVS-1914]: https://sonarsource.atlassian.net/browse/SLVS-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ