### PR TITLE
SLVS-1922 Fix mute Roslyn language issues with comment on SQC

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -10,6 +10,6 @@
     <EmbeddedSonarHtmlAnalyzerVersion>3.19.0.5695</EmbeddedSonarHtmlAnalyzerVersion>
     <EmbeddedSonarSecretsJarVersion>2.21.0.5225</EmbeddedSonarSecretsJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->
-    <EmbeddedSloopVersion>10.16.0.80440</EmbeddedSloopVersion>
+    <EmbeddedSloopVersion>10.17.0.80464</EmbeddedSloopVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
[SLVS-1922](https://sonarsource.atlassian.net/browse/SLVS-1922)

Fix mute Roslyn language issues with comment on SonarQube Cloud fails by updating the SlCore version to the one that includes a fix for this problem.

[SLVS-1922]: https://sonarsource.atlassian.net/browse/SLVS-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ