### PR TITLE
SLVS-1930 Show multi-region info depending on setting

### DIFF
--- a/src/ConnectedMode.UnitTests/UI/ConnectionDisplay/ConnectionNameViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ConnectionDisplay/ConnectionNameViewModelTests.cs
@@ -19,6 +19,7 @@
  */
 
 using System.ComponentModel;
+using SonarLint.VisualStudio.ConnectedMode.UI;
 using SonarLint.VisualStudio.ConnectedMode.UI.ConnectionDisplay;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
@@ -32,14 +33,18 @@ public class ConnectionNameViewModelTests
 
     private ConnectionNameViewModel testSubject;
     private IDogfoodingService dogfoodingService;
+    private IConnectedModeUIServices connectedModeUIServices;
 
     [TestInitialize]
     public void TestInitialize()
     {
         dogfoodingService = Substitute.For<IDogfoodingService>();
-        testSubject = new ConnectionNameViewModel(dogfoodingService);
+        connectedModeUIServices = Substitute.For<IConnectedModeUIServices>();
+        testSubject = new ConnectionNameViewModel();
 
+        connectedModeUIServices.DogfoodingService.Returns(dogfoodingService);
         dogfoodingService.IsDogfoodingEnvironment.Returns(true);
+        testSubject.ConnectedModeUiServices = connectedModeUIServices;
     }
 
     [TestMethod]
@@ -145,6 +150,22 @@ public class ConnectionNameViewModelTests
         testSubject.ConnectionInfo = new ConnectionInfo(id, ConnectionServerType.SonarCloud, CloudServerRegion.Us);
 
         VerifyDoesNotDisplayRegion();
+    }
+
+    [TestMethod]
+    public void ConnectedModeUiServices_Set_RaisesPropertyChanged()
+    {
+        var connectedModeUiServices = Substitute.For<IConnectedModeUIServices>();
+        var eventHandler = Substitute.For<PropertyChangedEventHandler>();
+        testSubject.PropertyChanged += eventHandler;
+
+        testSubject.ConnectedModeUiServices = connectedModeUiServices;
+
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.ConnectedModeUiServices)));
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.DisplayName)));
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.ShouldDisplayRegion)));
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.DisplayRegion)));
+        testSubject.ConnectedModeUiServices.Should().BeSameAs(connectedModeUiServices);
     }
 
     private void VerifyDoesNotDisplayRegion()

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml
@@ -16,6 +16,7 @@
         <connectionDisplay:ConnectionNameComponent
             Grid.Column="1"
             Margin="5, 0, 0, 0"
+            ConnectedModeUiServices="{Binding ElementName=ConnectionInfoUc, Path=ConnectedModeServices}"
             ConnectionInfo="{Binding Path=.}"
             VerticalAlignment="{Binding ElementName=ConnectionInfoUc, Path=TextAndIconVerticalAlignment}"
             ConnectionNameFontWeight="{Binding ElementName=ConnectionInfoUc, Path=ConnectionNameFontWeight}"/>

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionInfoComponent.xaml.cs
@@ -32,6 +32,8 @@ public sealed partial class ConnectionInfoComponent : UserControl
     public static readonly DependencyProperty ConnectionInfoProp = DependencyProperty.Register(nameof(ConnectionInfo), typeof(ConnectionInfo), typeof(ConnectionInfoComponent), new PropertyMetadata());
     public static readonly DependencyProperty TextAndIconVerticalAlignmentProp = DependencyProperty.Register(nameof(TextAndIconVerticalAlignment), typeof(VerticalAlignment),
         typeof(ConnectionInfoComponent), new PropertyMetadata(VerticalAlignment.Center));
+    public static readonly DependencyProperty ConnectedModeServicesProp
+        = DependencyProperty.Register(nameof(ConnectedModeServices), typeof(IConnectedModeUIServices), typeof(ConnectionInfoComponent));
 
     public ConnectionInfoComponent()
     {
@@ -54,5 +56,11 @@ public sealed partial class ConnectionInfoComponent : UserControl
     {
         get => (VerticalAlignment)GetValue(TextAndIconVerticalAlignmentProp);
         set => SetValue(TextAndIconVerticalAlignmentProp, value);
+    }
+
+    public IConnectedModeUIServices ConnectedModeServices
+    {
+        get => (IConnectedModeUIServices)GetValue(ConnectedModeServicesProp);
+        set => SetValue(ConnectedModeServicesProp, value);
     }
 }

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameComponent.xaml.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameComponent.xaml.cs
@@ -27,9 +27,12 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ConnectionDisplay;
 [ExcludeFromCodeCoverage] // UI, not really unit-testable
 public sealed partial class ConnectionNameComponent : UserControl
 {
-    public static readonly DependencyProperty ConnectionNameFontWeightProp = DependencyProperty.Register(nameof(ConnectionNameFontWeight), typeof(FontWeight), typeof(ConnectionNameComponent), new PropertyMetadata(FontWeights.DemiBold));
+    public static readonly DependencyProperty ConnectionNameFontWeightProp
+        = DependencyProperty.Register(nameof(ConnectionNameFontWeight), typeof(FontWeight), typeof(ConnectionNameComponent), new PropertyMetadata(FontWeights.DemiBold));
     public static readonly DependencyProperty ConnectionInfoProp
         = DependencyProperty.Register(nameof(ConnectionInfo), typeof(ConnectionInfo), typeof(ConnectionNameComponent), new PropertyMetadata(OnConnectionInfoSet));
+    public static readonly DependencyProperty ConnectedModeUiServicesProp
+        = DependencyProperty.Register(nameof(ConnectedModeUiServices), typeof(IConnectedModeUIServices), typeof(ConnectionNameComponent), new PropertyMetadata(OnConnectedModeUiServicesSet));
 
     public ConnectionNameViewModel ViewModel { get; } = new();
 
@@ -50,11 +53,25 @@ public sealed partial class ConnectionNameComponent : UserControl
         set => SetValue(ConnectionNameFontWeightProp, value);
     }
 
+    public IConnectedModeUIServices ConnectedModeUiServices
+    {
+        get => (IConnectedModeUIServices)GetValue(ConnectedModeUiServicesProp);
+        set => SetValue(ConnectedModeUiServicesProp, value);
+    }
+
     private static void OnConnectionInfoSet(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is ConnectionNameComponent component && e.NewValue is ConnectionInfo connectionInfo)
         {
             component.ViewModel.ConnectionInfo = connectionInfo;
+        }
+    }
+
+    private static void OnConnectedModeUiServicesSet(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is ConnectionNameComponent component && e.NewValue is IConnectedModeUIServices connectedModeUiServices)
+        {
+            component.ViewModel.ConnectedModeUiServices = connectedModeUiServices;
         }
     }
 }

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameViewModel.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameViewModel.cs
@@ -18,22 +18,27 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.WPF;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ConnectionDisplay;
 
 public class ConnectionNameViewModel : ViewModelBase
 {
-    public ConnectionNameViewModel() : this(DogfoodingService.Instance) { }
-
-    internal ConnectionNameViewModel(IDogfoodingService dogfoodingService)
-    {
-        this.dogfoodingService = dogfoodingService ?? throw new ArgumentNullException(nameof(dogfoodingService));
-    }
-
     private ConnectionInfo connectionInfo;
-    private readonly IDogfoodingService dogfoodingService;
+    private IConnectedModeUIServices connectedModeUiServices;
+
+    public IConnectedModeUIServices ConnectedModeUiServices
+    {
+        get => connectedModeUiServices;
+        set
+        {
+            connectedModeUiServices = value;
+            RaisePropertyChanged();
+            RaisePropertyChanged(nameof(DisplayName));
+            RaisePropertyChanged(nameof(ShouldDisplayRegion));
+            RaisePropertyChanged(nameof(DisplayRegion));
+        }
+    }
 
     public ConnectionInfo ConnectionInfo
     {
@@ -53,6 +58,6 @@ public class ConnectionNameViewModel : ViewModelBase
             ? connectionInfo.CloudServerRegion.Url.ToString()
             : connectionInfo?.Id ?? string.Empty;
 
-    public bool ShouldDisplayRegion => dogfoodingService.IsDogfoodingEnvironment && connectionInfo?.ServerType is ConnectionServerType.SonarCloud;
+    public bool ShouldDisplayRegion => ConnectedModeUiServices?.DogfoodingService.IsDogfoodingEnvironment == true && connectionInfo?.ServerType is ConnectionServerType.SonarCloud;
     public string DisplayRegion => ShouldDisplayRegion ? connectionInfo.CloudServerRegion.Name : string.Empty;
 }

--- a/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameViewModel.cs
+++ b/src/ConnectedMode/UI/ConnectionDisplay/ConnectionNameViewModel.cs
@@ -58,6 +58,8 @@ public class ConnectionNameViewModel : ViewModelBase
             ? connectionInfo.CloudServerRegion.Url.ToString()
             : connectionInfo?.Id ?? string.Empty;
 
-    public bool ShouldDisplayRegion => ConnectedModeUiServices?.DogfoodingService.IsDogfoodingEnvironment == true && connectionInfo?.ServerType is ConnectionServerType.SonarCloud;
+    public bool ShouldDisplayRegion =>
+        ConnectedModeUiServices?.DogfoodingService.IsDogfoodingEnvironment == true && ConnectedModeUiServices?.SonarLintSettings.ShowCloudRegion == true &&
+        connectionInfo?.ServerType is ConnectionServerType.SonarCloud;
     public string DisplayRegion => ShouldDisplayRegion ? connectionInfo.CloudServerRegion.Name : string.Empty;
 }

--- a/src/ConnectedMode/UI/Credentials/CredentialsDialog.xaml
+++ b/src/ConnectedMode/UI/Credentials/CredentialsDialog.xaml
@@ -34,7 +34,7 @@
         <TextBlock Grid.Row="0" VerticalAlignment="Center" Margin="0, 10, 0, 0">
             <Run Text="{x:Static res:UiResources.AuthenticationDescription}" />
             <InlineUIContainer Style="{StaticResource ConnectionInfoInlineWrapper}">
-                <connectionDisplay:ConnectionInfoComponent ConnectionInfo="{Binding Path=ConnectionInfo}"/>
+                <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}" ConnectionInfo="{Binding Path=ConnectionInfo}"/>
             </InlineUIContainer>
         </TextBlock>
 

--- a/src/ConnectedMode/UI/Credentials/CredentialsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/Credentials/CredentialsDialog.xaml.cs
@@ -30,9 +30,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Credentials;
 public partial class CredentialsDialog : Window
 {
     private readonly IConnectedModeServices connectedModeServices;
-    private readonly IConnectedModeUIServices connectedModeUiServices;
 
     public CredentialsViewModel ViewModel { get; }
+    public IConnectedModeUIServices ConnectedModeUiServices { get; }
 
     public CredentialsDialog(
         IConnectedModeServices connectedModeServices,
@@ -41,7 +41,7 @@ public partial class CredentialsDialog : Window
         bool withNextButton)
     {
         this.connectedModeServices = connectedModeServices;
-        this.connectedModeUiServices = connectedModeUiServices;
+        ConnectedModeUiServices = connectedModeUiServices;
         ViewModel = new CredentialsViewModel(connectionInfo,
             connectedModeServices.SlCoreConnectionAdapter,
             new ProgressReporterViewModel(connectedModeServices.Logger));
@@ -91,12 +91,12 @@ public partial class CredentialsDialog : Window
         if (responseWithData.Success)
         {
             TokenBox.Password = responseWithData.ResponseData;
-            connectedModeUiServices.IdeWindowService.BringToFront();
+            ConnectedModeUiServices.IdeWindowService.BringToFront();
             CloseWindowWithSuccess();
         }
         else
         {
-            connectedModeUiServices.BrowserService.Navigate(ViewModel.AccountSecurityUrl);
+            ConnectedModeUiServices.BrowserService.Navigate(ViewModel.AccountSecurityUrl);
         }
     }
 

--- a/src/ConnectedMode/UI/DeleteConnection/DeleteConnectionDialog.xaml
+++ b/src/ConnectedMode/UI/DeleteConnection/DeleteConnectionDialog.xaml
@@ -39,7 +39,7 @@
         <TextBlock Grid.Row="0" Margin="0, 0, 0, 20">
             <Run Text="{x:Static res:UiResources.DeleteConnectionDescription}" />
             <InlineUIContainer Style="{StaticResource ConnectionInfoInlineWrapper}">
-                <connectionDisplay:ConnectionInfoComponent ConnectionInfo="{Binding ConnectionInfo}"/>
+                <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}" ConnectionInfo="{Binding ConnectionInfo}"/>
             </InlineUIContainer>
             <Run Text="?" />
         </TextBlock>

--- a/src/ConnectedMode/UI/DeleteConnection/DeleteConnectionDialog.xaml.cs
+++ b/src/ConnectedMode/UI/DeleteConnection/DeleteConnectionDialog.xaml.cs
@@ -27,9 +27,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.DeleteConnection;
 public partial class DeleteConnectionDialog : Window
 {
     public DeleteConnectionDialogViewModel ViewModel { get; }
+    public IConnectedModeUIServices ConnectedModeUiServices { get; }
 
-    public DeleteConnectionDialog(IReadOnlyList<string> projectsToUnbind, ConnectionInfo connectionInfo)
+    public DeleteConnectionDialog(IConnectedModeUIServices connectedModeUiServices, IReadOnlyList<string> projectsToUnbind, ConnectionInfo connectionInfo)
     {
+        ConnectedModeUiServices = connectedModeUiServices;
         ViewModel = new DeleteConnectionDialogViewModel(projectsToUnbind, connectionInfo);
         InitializeComponent();
     }
@@ -39,4 +41,3 @@ public partial class DeleteConnectionDialog : Window
         DialogResult = true;
     }
 }
-

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
@@ -149,7 +149,8 @@
                           SelectedItem="{Binding Path=SelectedConnectionInfo}" IsEnabled="{Binding Path=IsConnectionSelectionEnabled}">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
-                            <connectionDisplay:ConnectionInfoComponent ConnectionInfo="{Binding Path=.}" ConnectionNameFontWeight="Normal" TextAndIconVerticalAlignment="Center"
+                            <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}"
+                                                        ConnectionInfo="{Binding Path=.}" ConnectionNameFontWeight="Normal" TextAndIconVerticalAlignment="Center"
                                                         MaxWidth="{Binding ElementName=ConnectionsComboBox, Path=ActualWidth, UpdateSourceTrigger=PropertyChanged}"/>
                         </DataTemplate>
                     </ComboBox.ItemTemplate>

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -32,7 +32,6 @@ internal partial class ManageBindingDialog : Window
 {
     private readonly IConnectedModeServices connectedModeServices;
     private readonly IConnectedModeBindingServices connectedModeBindingServices;
-    private readonly IConnectedModeUIServices connectedModeUiServices;
     private readonly AutomaticBindingRequest automaticBinding;
 
     public ManageBindingDialog(
@@ -43,7 +42,7 @@ internal partial class ManageBindingDialog : Window
     {
         this.connectedModeServices = connectedModeServices;
         this.connectedModeBindingServices = connectedModeBindingServices;
-        this.connectedModeUiServices = connectedModeUiServices;
+        ConnectedModeUiServices = connectedModeUiServices;
         this.automaticBinding = automaticBinding;
         ViewModel = new ManageBindingViewModel(connectedModeServices,
             connectedModeBindingServices,
@@ -53,10 +52,11 @@ internal partial class ManageBindingDialog : Window
     }
 
     public ManageBindingViewModel ViewModel { get; }
+    public IConnectedModeUIServices ConnectedModeUiServices { get; }
 
     private async void ManageConnections_OnClick(object sender, RoutedEventArgs e)
     {
-        new ManageConnectionsDialog(connectedModeServices, connectedModeBindingServices, connectedModeUiServices).ShowDialog(this);
+        new ManageConnectionsDialog(connectedModeServices, connectedModeBindingServices, ConnectedModeUiServices).ShowDialog(this);
         await ViewModel.InitializeDataAsync();
     }
 
@@ -67,7 +67,7 @@ internal partial class ManageBindingDialog : Window
 
     private void SelectProject_OnClick(object sender, RoutedEventArgs e)
     {
-        var projectSelection = new ProjectSelectionDialog(ViewModel.SelectedConnectionInfo, connectedModeServices);
+        var projectSelection = new ProjectSelectionDialog(ViewModel.SelectedConnectionInfo, connectedModeServices, ConnectedModeUiServices);
         if (projectSelection.ShowDialog(this) == true)
         {
             ViewModel.SelectedProject = projectSelection.ViewModel.SelectedProject;
@@ -99,5 +99,5 @@ internal partial class ManageBindingDialog : Window
         ViewModel.ExportBindingConfigurationAsync().Forget();
     }
 
-    private void ViewWebsite(object sender, RequestNavigateEventArgs e) => connectedModeUiServices.BrowserService.Navigate(e.Uri.AbsoluteUri);
+    private void ViewWebsite(object sender, RequestNavigateEventArgs e) => ConnectedModeUiServices.BrowserService.Navigate(e.Uri.AbsoluteUri);
 }

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml
@@ -82,7 +82,8 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
 
-                                <connectionDisplay:ConnectionNameComponent Grid.Row="0" Grid.RowSpan="2" ConnectionInfo="{Binding Path=Connection.Info}" VerticalAlignment="Center" ConnectionNameFontWeight="Normal"/>
+                                <connectionDisplay:ConnectionNameComponent Grid.Row="0" Grid.RowSpan="2" ConnectedModeUiServices="{Binding ElementName=This, Path=ConnectedModeUiServices}"
+                                                                           ConnectionInfo="{Binding Path=Connection.Info}" VerticalAlignment="Center" ConnectionNameFontWeight="Normal"/>
                                 <CheckBox Visibility="Collapsed" Grid.Row="1"
                                           Content="{x:Static res:UiResources.SmartNotificationsCheckboxLabel}"
                                           IsChecked="{Binding Path=EnableSmartNotifications}"

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
@@ -80,7 +80,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 
         private ConnectionInfo GetTransientConnection()
         {
-            var serverSelectionDialog = new ServerSelectionDialog(ConnectedModeUiServices.BrowserService, connectedModeServices.TelemetryManager, ConnectedModeUiServices.DogfoodingService);
+            var serverSelectionDialog = new ServerSelectionDialog(ConnectedModeUiServices, connectedModeServices.TelemetryManager);
             return serverSelectionDialog.ShowDialog(this) != true ? null : serverSelectionDialog.ViewModel.CreateTransientConnectionInfo();
         }
 

--- a/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageConnections/ManageConnectionsDialog.xaml.cs
@@ -32,14 +32,14 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
     public partial class ManageConnectionsDialog : Window
     {
         private readonly IConnectedModeServices connectedModeServices;
-        private readonly IConnectedModeUIServices connectedModeUiServices;
 
+        public IConnectedModeUIServices ConnectedModeUiServices { get; }
         public ManageConnectionsViewModel ViewModel { get; }
 
         public ManageConnectionsDialog(IConnectedModeServices connectedModeServices, IConnectedModeBindingServices connectedModeBindingServices, IConnectedModeUIServices connectedModeUiServices)
         {
             this.connectedModeServices = connectedModeServices;
-            this.connectedModeUiServices = connectedModeUiServices;
+            ConnectedModeUiServices = connectedModeUiServices;
             ViewModel = new ManageConnectionsViewModel(connectedModeServices,
                 connectedModeBindingServices,
                 new ProgressReporterViewModel(connectedModeServices.Logger));
@@ -53,7 +53,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
                 return;
             }
 
-            var credentialsDialog = new CredentialsDialog(connectedModeServices, connectedModeUiServices, connectionViewModel.Connection.Info, false);
+            var credentialsDialog = new CredentialsDialog(connectedModeServices, ConnectedModeUiServices, connectionViewModel.Connection.Info, false);
             if (!CredentialsDialogSucceeded(credentialsDialog))
             {
                 return;
@@ -80,14 +80,14 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
 
         private ConnectionInfo GetTransientConnection()
         {
-            var serverSelectionDialog = new ServerSelectionDialog(connectedModeUiServices.BrowserService, connectedModeServices.TelemetryManager, connectedModeUiServices.DogfoodingService);
+            var serverSelectionDialog = new ServerSelectionDialog(ConnectedModeUiServices.BrowserService, connectedModeServices.TelemetryManager, ConnectedModeUiServices.DogfoodingService);
             return serverSelectionDialog.ShowDialog(this) != true ? null : serverSelectionDialog.ViewModel.CreateTransientConnectionInfo();
         }
 
         private CredentialsDialog GetCredentialsDialog(ConnectionInfo newConnectionInfo)
         {
             var isAnyDialogFollowing = newConnectionInfo.ServerType == ConnectionServerType.SonarCloud;
-            return new CredentialsDialog(connectedModeServices, connectedModeUiServices, newConnectionInfo, withNextButton: isAnyDialogFollowing);
+            return new CredentialsDialog(connectedModeServices, ConnectedModeUiServices, newConnectionInfo, withNextButton: isAnyDialogFollowing);
         }
 
         private bool CredentialsDialogSucceeded(CredentialsDialog credentialsDialog)
@@ -120,7 +120,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections
             }
 
             var connectionReferences = await ViewModel.GetConnectionReferencesWithProgressAsync(connectionViewModel);
-            var deleteConnectionDialog = new DeleteConnectionDialog(connectionReferences, connectionViewModel.Connection.Info);
+            var deleteConnectionDialog = new DeleteConnectionDialog(ConnectedModeUiServices, connectionReferences, connectionViewModel.Connection.Info);
             if (deleteConnectionDialog.ShowDialog(this) == true)
             {
                 await ViewModel.RemoveConnectionWithProgressAsync(connectionReferences, connectionViewModel);

--- a/src/ConnectedMode/UI/ProjectSelection/ProjectSelectionDialog.xaml
+++ b/src/ConnectedMode/UI/ProjectSelection/ProjectSelectionDialog.xaml
@@ -41,7 +41,7 @@
         <TextBlock Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="0">
             <Run Text="{x:Static res:UiResources.ProjectSelectionConnectionLabel}" />
             <InlineUIContainer Style="{StaticResource ConnectionInfoInlineWrapper}">
-                <connectionDisplay:ConnectionInfoComponent ConnectionInfo="{Binding ConnectionInfo}" />
+                <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}" ConnectionInfo="{Binding ConnectionInfo}" />
             </InlineUIContainer>
         </TextBlock>
 

--- a/src/ConnectedMode/UI/ProjectSelection/ProjectSelectionDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ProjectSelection/ProjectSelectionDialog.xaml.cs
@@ -20,7 +20,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
-using SonarLint.VisualStudio.ConnectedMode.UI.Credentials;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ProjectSelection;
 
@@ -28,9 +27,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ProjectSelection;
 public partial class ProjectSelectionDialog
 {
     public ProjectSelectionViewModel ViewModel { get; }
+    public IConnectedModeUIServices ConnectedModeUiServices { get; }
 
-    public ProjectSelectionDialog(ConnectionInfo connectionInfo, IConnectedModeServices connectedModeServices)
+    public ProjectSelectionDialog(ConnectionInfo connectionInfo, IConnectedModeServices connectedModeServices, IConnectedModeUIServices connectedModeUiServices)
     {
+        ConnectedModeUiServices = connectedModeUiServices;
         ViewModel = new ProjectSelectionViewModel(connectionInfo,
             connectedModeServices,
             new ProgressReporterViewModel(connectedModeServices.Logger));
@@ -48,4 +49,3 @@ public partial class ProjectSelectionDialog
         await ViewModel.InitializeProjectWithProgressAsync();
     }
 }
-

--- a/src/ConnectedMode/UI/ServerSelection/ServerSelectionDialog.xaml
+++ b/src/ConnectedMode/UI/ServerSelection/ServerSelectionDialog.xaml
@@ -48,7 +48,7 @@
                         </RadioButton>
                     </StackPanel>
                     <TextBlock Grid.Row="1" Text="{x:Static res:UiResources.SonarCloudDescription}" Margin="10, 0"/>
-                    <Grid Grid.Row="2" Margin="10" Visibility="{Binding DogfoodingService.IsDogfoodingEnvironment, Converter={StaticResource TrueToVisibleConverter}}">
+                    <Grid Grid.Row="2" Margin="10" Visibility="{Binding Path=ShowCloudRegion, Converter={StaticResource TrueToVisibleConverter}}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>

--- a/src/ConnectedMode/UI/ServerSelection/ServerSelectionDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ServerSelection/ServerSelectionDialog.xaml.cs
@@ -21,7 +21,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Navigation;
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Telemetry;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ServerSelection;
@@ -29,23 +28,23 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ServerSelection;
 [ExcludeFromCodeCoverage] // UI, not really unit-testable
 public partial class ServerSelectionDialog : Window
 {
-    private readonly IBrowserService browserService;
+    private readonly IConnectedModeUIServices connectedModeUiServices;
     private readonly ITelemetryManager telemetryManager;
 
     public ServerSelectionViewModel ViewModel { get; }
 
-    public ServerSelectionDialog(IBrowserService browserService, ITelemetryManager telemetryManager, IDogfoodingService dogfoodingService)
+    public ServerSelectionDialog(IConnectedModeUIServices connectedModeUiServices, ITelemetryManager telemetryManager)
     {
-        this.browserService = browserService;
+        this.connectedModeUiServices = connectedModeUiServices;
         this.telemetryManager = telemetryManager;
-        ViewModel = new ServerSelectionViewModel(dogfoodingService);
+        ViewModel = new ServerSelectionViewModel(connectedModeUiServices);
         InitializeComponent();
     }
 
     private void FreeSonaQubeCloudFreeTier_OnRequestNavigate(object sender, RequestNavigateEventArgs e)
     {
         var telemetryLinkId = TelemetryLinks.SonarQubeCloudFreeSignUpId;
-        browserService.Navigate(TelemetryLinks.LinkIdToUrls[telemetryLinkId]);
+        connectedModeUiServices.BrowserService.Navigate(TelemetryLinks.LinkIdToUrls[telemetryLinkId]);
         telemetryManager.LinkClicked(telemetryLinkId);
     }
 

--- a/src/ConnectedMode/UI/ServerSelection/ServerSelectionViewModel.cs
+++ b/src/ConnectedMode/UI/ServerSelection/ServerSelectionViewModel.cs
@@ -18,21 +18,18 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.WPF;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ServerSelection
 {
-    public class ServerSelectionViewModel(IDogfoodingService dogfoodingService) : ViewModelBase
+    public class ServerSelectionViewModel(IConnectedModeUIServices connectedModeUiServices) : ViewModelBase
     {
         private bool isSonarCloudSelected = true;
         private bool isSonarQubeSelected;
         private bool isEuRegionSelected = true;
         private bool isUsRegionSelected;
         private string sonarQubeUrl;
-
-        public IDogfoodingService DogfoodingService { get; } = dogfoodingService;
 
         public bool IsSonarCloudSelected
         {
@@ -93,6 +90,7 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.ServerSelection
             }
         }
 
+        public bool ShowCloudRegion => connectedModeUiServices.DogfoodingService.IsDogfoodingEnvironment && connectedModeUiServices.SonarLintSettings.ShowCloudRegion;
         public bool IsNextButtonEnabled => (IsSonarCloudSelected && IsSonarCloudRegionSelected) || (IsSonarQubeSelected && IsSonarQubeUrlProvided);
         public bool ShouldSonarQubeUrlBeFilled => IsSonarQubeSelected && !IsSonarQubeUrlProvided;
         public static string SonarCloudForEuRegion => CloudServerRegion.Eu.Url.Host;

--- a/src/ConnectedMode/UI/TrustConnection/TrustConnectionDialog.xaml
+++ b/src/ConnectedMode/UI/TrustConnection/TrustConnectionDialog.xaml
@@ -68,7 +68,7 @@
                     <Grid>
                         <TextBlock VerticalAlignment="Center" Padding="5,0">
                             <InlineUIContainer Style="{StaticResource ConnectionInfoInlineWrapper}">
-                                <connectionDisplay:ConnectionInfoComponent
+                                <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}"
                                     ConnectionInfo="{Binding Path=Connection.Info}" />
                             </InlineUIContainer>
                         </TextBlock>
@@ -134,7 +134,7 @@
                     <Grid>
                         <TextBlock VerticalAlignment="Center" Padding="5,0">
                             <InlineUIContainer Style="{StaticResource ConnectionInfoInlineWrapper}">
-                                <connectionDisplay:ConnectionInfoComponent
+                                <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}"
                                     ConnectionInfo="{Binding Path=Connection.Info}" />
                             </InlineUIContainer>
                         </TextBlock>

--- a/src/ConnectedMode/UI/TrustConnection/TrustConnectionDialog.xaml.cs
+++ b/src/ConnectedMode/UI/TrustConnection/TrustConnectionDialog.xaml.cs
@@ -32,8 +32,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.TrustConnection;
 public partial class TrustConnectionDialog : Window
 {
     private readonly IConnectedModeServices connectedModeServices;
-    private readonly IConnectedModeUIServices connectedModeUiServices;
 
+    public IConnectedModeUIServices ConnectedModeUiServices { get; }
     public TrustConnectionViewModel ViewModel { get; }
 
     public TrustConnectionDialog(
@@ -43,13 +43,13 @@ public partial class TrustConnectionDialog : Window
         SecureString token)
     {
         this.connectedModeServices = connectedModeServices;
-        this.connectedModeUiServices = connectedModeUiServices;
+        ConnectedModeUiServices = connectedModeUiServices;
         ViewModel = new TrustConnectionViewModel(connectedModeServices, new ProgressReporterViewModel(connectedModeServices.Logger), serverConnection, token);
         InitializeComponent();
         Title = ViewModel.IsCloud ? UiResources.TrustOrganizationDialogTitle : UiResources.TrustServerDialogTitle;
     }
 
-    private void ViewWebsite(object sender, RequestNavigateEventArgs e) => connectedModeUiServices.BrowserService.Navigate(e.Uri.AbsoluteUri);
+    private void ViewWebsite(object sender, RequestNavigateEventArgs e) => ConnectedModeUiServices.BrowserService.Navigate(e.Uri.AbsoluteUri);
 
     private async void TrustServerButton_OnClick(object sender, RoutedEventArgs e)
     {
@@ -65,7 +65,7 @@ public partial class TrustConnectionDialog : Window
 
     private bool AddToken()
     {
-        var credentialsDialog = new CredentialsDialog(connectedModeServices, connectedModeUiServices, ViewModel.Connection.Info, withNextButton: false);
+        var credentialsDialog = new CredentialsDialog(connectedModeServices, ConnectedModeUiServices, ViewModel.Connection.Info, withNextButton: false);
         var wasTokenAdded = credentialsDialog.ShowDialog(this) == true;
         if (wasTokenAdded)
         {


### PR DESCRIPTION
This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6088) in which the `SonarLintSettings` service has been added to the `ConnectedModeUiServices`, which is needed to access the show region setting