### PR TITLE
SLVS-1464 Show trust connection dialog on use shared binding configuration without pre-existing connection 

### DIFF
--- a/src/ConnectedMode.UnitTests/Binding/Suggestion/SuggestSharedBindingGoldBarTests.cs
+++ b/src/ConnectedMode.UnitTests/Binding/Suggestion/SuggestSharedBindingGoldBarTests.cs
@@ -72,8 +72,8 @@ public class SuggestSharedBindingGoldBarTests
         notificationActions[1].ShouldDismissAfterAction.Should().BeFalse();
         notificationActions[2].Should().BeSameAs(doNotShowAgainMock.Object);
         notification.CloseOnSolutionClose.Should().Be(true);
+        notification.ShowOncePerSession.Should().Be(false);
     }
-
 
     [DataTestMethod]
     [DataRow(ServerType.SonarQube)]
@@ -134,7 +134,7 @@ public class SuggestSharedBindingGoldBarTests
 
         var testSubject = CreateTestSubject(notificationServiceMock.Object);
 
-        testSubject.Show(default, () => { connectExecuted = true;});
+        testSubject.Show(default, () => { connectExecuted = true; });
 
         var notification = (INotification)notificationServiceMock.Invocations.Single().Arguments.First();
         var connectAction = notification.Actions.ToArray()[0];
@@ -156,7 +156,8 @@ public class SuggestSharedBindingGoldBarTests
         notificationServiceMock.Verify(x => x.CloseNotification(), Times.Once);
     }
 
-    private SuggestSharedBindingGoldBar CreateTestSubject(INotificationService notificationServiceMock,
+    private SuggestSharedBindingGoldBar CreateTestSubject(
+        INotificationService notificationServiceMock,
         IDoNotShowAgainNotificationAction doNotShowAgainNotificationAction = null,
         ISolutionInfoProvider solutionInfoProvider = null,
         IBrowserService browserService = null)

--- a/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
@@ -64,6 +64,7 @@ public class ManageBindingViewModelTests
     private ISharedBindingConfigProvider sharedBindingConfigProvider;
     private IMessageBox messageBox;
     private IConnectedModeUIServices connectedModeUIServices;
+    private IConnectedModeUIManager connectedModeUIManager;
 
     [TestInitialize]
     public void TestInitialize()
@@ -72,8 +73,9 @@ public class ManageBindingViewModelTests
         progressReporterViewModel = Substitute.For<IProgressReporterViewModel>();
         connectedModeBindingServices = Substitute.For<IConnectedModeBindingServices>();
         connectedModeUIServices = Substitute.For<IConnectedModeUIServices>();
+        connectedModeUIManager = Substitute.For<IConnectedModeUIManager>();
 
-        testSubject = new ManageBindingViewModel(connectedModeServices, connectedModeBindingServices, connectedModeUIServices, progressReporterViewModel);
+        testSubject = new ManageBindingViewModel(connectedModeServices, connectedModeBindingServices, connectedModeUIServices, connectedModeUIManager, progressReporterViewModel);
 
         testSubject.SolutionInfo = DefaultSolution;
         MockServices();

--- a/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ManageBinding/ManageBindingViewModelTests.cs
@@ -1065,8 +1065,6 @@ public class ManageBindingViewModelTests
 
         response.Success.Should().BeFalse();
         response.ResponseData.Should().Be(BindingResult.ConnectionNotFound);
-        messageBox.Received(1).Show(UiResources.NotFoundConnectionForAutomaticBindingMessageBoxText, UiResources.NotFoundConnectionForAutomaticBindingMessageBoxCaption, MessageBoxButton.OK,
-            MessageBoxImage.Warning);
         logger.Received().WriteLine(Arg.Is<MessageLevelContext>(ctx => ctx.Context.Contains(automaticBindingRequest.TypeName)), Resources.AutomaticBinding_ConnectionNotFound,
             testSubject.SharedBindingConfigModel.Uri);
         await bindingController.DidNotReceive()
@@ -1088,8 +1086,6 @@ public class ManageBindingViewModelTests
         response.ResponseData.Should().Be(BindingResult.ConnectionNotFound);
         logger.Received().WriteLine(Arg.Is<MessageLevelContext>(ctx => ctx.Context.Contains(automaticBindingRequest.TypeName)), Resources.AutomaticBinding_ConnectionNotFound,
             Arg.Is<string>(x => x.Contains(sonarCloudSharedBindingConfigModel.Organization)));
-        messageBox.Received(1).Show(UiResources.NotFoundConnectionForAutomaticBindingMessageBoxText, UiResources.NotFoundConnectionForAutomaticBindingMessageBoxCaption, MessageBoxButton.OK,
-            MessageBoxImage.Warning);
         await bindingController.DidNotReceive()
             .BindAsync(Arg.Is<BoundServerProject>(proj =>
                 proj.ServerProjectKey == testSubject.SharedBindingConfigModel.ProjectKey), Arg.Any<CancellationToken>());
@@ -1201,8 +1197,6 @@ public class ManageBindingViewModelTests
 
         response.Success.Should().BeFalse();
         response.ResponseData.Should().Be(BindingResult.ConnectionNotFound);
-        messageBox.Received(1).Show(UiResources.NotFoundConnectionForAutomaticBindingMessageBoxText, UiResources.NotFoundConnectionForAutomaticBindingMessageBoxCaption, MessageBoxButton.OK,
-            MessageBoxImage.Warning);
         logger.Received().WriteLine(Arg.Is<MessageLevelContext>(ctx => ctx.Context.Contains(automaticBindingRequest.TypeName)), Resources.AutomaticBinding_ConnectionNotFound,
             automaticBindingRequest.ServerConnectionId);
         await bindingController.DidNotReceiveWithAnyArgs().BindAsync(default, default);

--- a/src/ConnectedMode/Binding/Suggestion/SuggestSharedBindingGoldBar.cs
+++ b/src/ConnectedMode/Binding/Suggestion/SuggestSharedBindingGoldBar.cs
@@ -44,7 +44,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion
         internal /* for testing */ const string IdTemplate = "shared.binding.suggestion.for.{0}";
 
         [ImportingConstructor]
-        public SuggestSharedBindingGoldBar(INotificationService notificationService,
+        public SuggestSharedBindingGoldBar(
+            INotificationService notificationService,
             IDoNotShowAgainNotificationAction doNotShowAgainNotificationAction,
             ISolutionInfoProvider solutionInfoProvider,
             IBrowserService browserService)
@@ -65,7 +66,8 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion
                     new NotificationAction(BindingStrings.SharedBindingSuggestionConnectOptionText, _ => onConnectHandler(), true),
                     new NotificationAction(BindingStrings.SharedBindingSuggestionInfoOptionText, _ => OnLearnMore(), false),
                     doNotShowAgainNotificationAction
-                ]);
+                ],
+                showOncePerSession: false);
 
             notificationService.ShowNotification(notification);
         }

--- a/src/ConnectedMode/Resources.Designer.cs
+++ b/src/ConnectedMode/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace SonarLint.VisualStudio.ConnectedMode {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connection to server {0} could not be found.
+        ///   Looks up a localized string similar to Connection to server could not be found.
         /// </summary>
         internal static string AutomaticBinding_ConnectionNotFound {
             get {
@@ -93,6 +93,15 @@ namespace SonarLint.VisualStudio.ConnectedMode {
         internal static string AutomaticBinding_CredentiasNotFound {
             get {
                 return ResourceManager.GetString("AutomaticBinding_CredentiasNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project key could not be found.
+        /// </summary>
+        internal static string AutomaticBinding_ProjectKeyNotFound {
+            get {
+                return ResourceManager.GetString("AutomaticBinding_ProjectKeyNotFound", resourceCulture);
             }
         }
         

--- a/src/ConnectedMode/Resources.resx
+++ b/src/ConnectedMode/Resources.resx
@@ -332,7 +332,7 @@
     <value>Binding failed due to: {0}</value>
   </data>
   <data name="AutomaticBinding_ConnectionNotFound" xml:space="preserve">
-    <value>Connection to server {0} could not be found</value>
+    <value>Connection to server could not be found</value>
   </data>
   <data name="AutomaticBinding_ConfigurationNotAvailable" xml:space="preserve">
     <value>Configuration not available</value>
@@ -342,6 +342,10 @@
   </data>
   <data name="AutomaticBinding_CredentiasNotFound" xml:space="preserve">
     <value>The credentials for the connection {0} could not be found</value>
+  </data>
+
+  <data name="AutomaticBinding_ProjectKeyNotFound" xml:space="preserve">
+    <value>The project key could not be found</value>
   </data>
   <data name="FuzzySearchProjects_Fails" xml:space="preserve">
     <value>The search for projects for the connectionId {0} with the search term "{1}" failed: {2}</value>

--- a/src/ConnectedMode/Shared/SharedBindingConfigModel.cs
+++ b/src/ConnectedMode/Shared/SharedBindingConfigModel.cs
@@ -19,6 +19,7 @@
  */
 
 using Newtonsoft.Json;
+using SonarLint.VisualStudio.Core.Binding;
 using SonarQube.Client;
 
 namespace SonarLint.VisualStudio.ConnectedMode.Shared
@@ -51,5 +52,10 @@ namespace SonarLint.VisualStudio.ConnectedMode.Shared
 
             return sharedBindingConfig.IsSonarCloud() ? ServerType.SonarCloud : ServerType.SonarQube;
         }
-}
+
+        public static ConnectionInfo CreateConnectionInfo(this SharedBindingConfigModel sharedBindingConfig) =>
+            sharedBindingConfig.IsSonarCloud()
+                ? new ConnectionInfo(sharedBindingConfig.Organization, ConnectionServerType.SonarCloud, CloudServerRegion.GetRegionByName(sharedBindingConfig.Region))
+                : new ConnectionInfo(sharedBindingConfig.Uri.ToString(), ConnectionServerType.SonarQube);
+    }
 }

--- a/src/ConnectedMode/UI/BindingResult.cs
+++ b/src/ConnectedMode/UI/BindingResult.cs
@@ -26,5 +26,6 @@ internal enum BindingResult
     Failed,
     ConnectionNotFound,
     SharedConfigurationNotAvailable,
-    CredentialsNotFound
+    CredentialsNotFound,
+    ProjectKeyNotFound
 }

--- a/src/ConnectedMode/UI/BindingResult.cs
+++ b/src/ConnectedMode/UI/BindingResult.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarLint.VisualStudio.ConnectedMode.UI;
+
+internal enum BindingResult
+{
+    Success,
+    Failed,
+    ConnectionNotFound,
+    SharedConfigurationNotAvailable,
+    CredentialsNotFound
+}

--- a/src/ConnectedMode/UI/ConnectedModeUIManager.cs
+++ b/src/ConnectedMode/UI/ConnectedModeUIManager.cs
@@ -67,7 +67,7 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
     [ExcludeFromCodeCoverage] // UI, not really unit-testable
     private bool ShowDialogManageBinding(AutomaticBindingRequest automaticBinding)
     {
-        var manageBindingDialog = new ManageBindingDialog(connectedModeServices, connectedModeBindingServices, connectedModeUiServices, automaticBinding);
+        var manageBindingDialog = new ManageBindingDialog(connectedModeServices, connectedModeBindingServices, connectedModeUiServices, this, automaticBinding);
         manageBindingDialog.ShowDialog(Application.Current.MainWindow);
         return manageBindingDialog.ViewModel.BoundProject != null;
     }

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml
@@ -144,7 +144,7 @@
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="{x:Static res:UiResources.ConnectionToBindLabel}" Margin="0,15,0,5"/>
                 <ComboBox x:Name="ConnectionsComboBox" Grid.Row="1" Grid.Column="0" ItemsSource="{Binding Path=Connections}" 
-                          SelectedItem="{Binding Path=SelectedConnectionInfo}" IsEnabled="{Binding Path=IsConnectionSelectionEnabled}">
+                          SelectedItem="{Binding Path=SelectedConnectionInfo, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding Path=IsConnectionSelectionEnabled}">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <connectionDisplay:ConnectionInfoComponent ConnectedModeServices="{Binding ElementName=This, Path=ConnectedModeUiServices}"

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -21,6 +21,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Navigation;
+using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections;
 using SonarLint.VisualStudio.ConnectedMode.UI.ProjectSelection;
 using SonarLint.VisualStudio.ConnectedMode.UI.TrustConnection;
@@ -94,8 +95,8 @@ internal partial class ManageBindingDialog : Window
     {
         if (bindingResult == BindingResult.ConnectionNotFound && automaticBindingRequest is AutomaticBindingRequest.Shared && ViewModel.SharedBindingConfigModel != null)
         {
-            var connection = ViewModel.CreateConnectionInfoFromSharedBinding();
-            var trustConnectionDialog = new TrustConnectionDialog(connectedModeServices, ConnectedModeUiServices, connection.GetServerConnectionFromConnectionInfo(), null);
+            var connectionInfo = ViewModel.SharedBindingConfigModel.CreateConnectionInfo();
+            var trustConnectionDialog = new TrustConnectionDialog(connectedModeServices, ConnectedModeUiServices, connectionInfo.GetServerConnectionFromConnectionInfo(), null);
             trustConnectionDialog.ShowDialog(Application.Current.MainWindow);
             await ViewModel.PerformAutomaticBindingWithProgressAsync(automaticBindingRequest);
         }

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -89,11 +89,11 @@ internal partial class ManageBindingDialog : Window
     {
         var validationResult = ViewModel.ValidateAutomaticBindingArguments(automaticBindingRequest, ViewModel.GetServerConnection(automaticBindingRequest),
             ViewModel.GetServerProjectKey(automaticBindingRequest));
-        CreateConnectionIfMissing(validationResult, automaticBindingRequest);
+        await CreateConnectionIfMissingAsync(validationResult, automaticBindingRequest);
         await ViewModel.PerformAutomaticBindingWithProgressAsync(automaticBindingRequest);
     }
 
-    private void CreateConnectionIfMissing(BindingResult result, AutomaticBindingRequest automaticBindingRequest)
+    private async Task CreateConnectionIfMissingAsync(BindingResult result, AutomaticBindingRequest automaticBindingRequest)
     {
         if (result != BindingResult.ConnectionNotFound || automaticBindingRequest is not AutomaticBindingRequest.Shared || ViewModel.SharedBindingConfigModel == null)
         {
@@ -102,6 +102,7 @@ internal partial class ManageBindingDialog : Window
         var connectionInfo = ViewModel.SharedBindingConfigModel.CreateConnectionInfo();
         var trustConnectionDialog = new TrustConnectionDialog(connectedModeServices, ConnectedModeUiServices, connectionInfo.GetServerConnectionFromConnectionInfo(), token: null);
         trustConnectionDialog.ShowDialog(Application.Current.MainWindow);
+        await ViewModel.InitializeDataAsync();
     }
 
     private async void ExportBindingConfigurationButton_OnClick(object sender, RoutedEventArgs e)

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -39,6 +39,7 @@ internal partial class ManageBindingDialog : Window
         IConnectedModeServices connectedModeServices,
         IConnectedModeBindingServices connectedModeBindingServices,
         IConnectedModeUIServices connectedModeUiServices,
+        IConnectedModeUIManager connectedModeUiManager,
         AutomaticBindingRequest automaticBinding = null)
     {
         this.connectedModeServices = connectedModeServices;
@@ -48,6 +49,7 @@ internal partial class ManageBindingDialog : Window
         ViewModel = new ManageBindingViewModel(connectedModeServices,
             connectedModeBindingServices,
             connectedModeUiServices,
+            connectedModeUiManager,
             new ProgressReporterViewModel(connectedModeServices.Logger));
         InitializeComponent();
     }

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingDialog.xaml.cs
@@ -21,10 +21,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Navigation;
-using SonarLint.VisualStudio.ConnectedMode.Shared;
 using SonarLint.VisualStudio.ConnectedMode.UI.ManageConnections;
 using SonarLint.VisualStudio.ConnectedMode.UI.ProjectSelection;
-using SonarLint.VisualStudio.ConnectedMode.UI.TrustConnection;
 
 namespace SonarLint.VisualStudio.ConnectedMode.UI.ManageBinding;
 
@@ -79,33 +77,13 @@ internal partial class ManageBindingDialog : Window
         await ViewModel.InitializeDataAsync();
         if (automaticBinding is not null)
         {
-            await PerformAutomaticBindingAsync(automaticBinding);
+            await ViewModel.PerformAutomaticBindingWithProgressAsync(automaticBinding);
         }
     }
 
     private async void Unbind_OnClick(object sender, RoutedEventArgs e) => await ViewModel.UnbindWithProgressAsync();
 
-    private async void UseSharedBinding_OnClick(object sender, RoutedEventArgs e) => await PerformAutomaticBindingAsync(new AutomaticBindingRequest.Shared());
-
-    private async Task PerformAutomaticBindingAsync(AutomaticBindingRequest automaticBindingRequest)
-    {
-        var validationResult = ViewModel.ValidateAutomaticBindingArguments(automaticBindingRequest, ViewModel.GetServerConnection(automaticBindingRequest),
-            ViewModel.GetServerProjectKey(automaticBindingRequest));
-        await CreateConnectionIfMissingAsync(validationResult, automaticBindingRequest);
-        await ViewModel.PerformAutomaticBindingWithProgressAsync(automaticBindingRequest);
-    }
-
-    private async Task CreateConnectionIfMissingAsync(BindingResult result, AutomaticBindingRequest automaticBindingRequest)
-    {
-        if (result != BindingResult.ConnectionNotFound || automaticBindingRequest is not AutomaticBindingRequest.Shared || ViewModel.SharedBindingConfigModel == null)
-        {
-            return;
-        }
-        var connectionInfo = ViewModel.SharedBindingConfigModel.CreateConnectionInfo();
-        var trustConnectionDialog = new TrustConnectionDialog(connectedModeServices, ConnectedModeUiServices, connectionInfo.GetServerConnectionFromConnectionInfo(), token: null);
-        trustConnectionDialog.ShowDialog(Application.Current.MainWindow);
-        await ViewModel.InitializeDataAsync();
-    }
+    private async void UseSharedBinding_OnClick(object sender, RoutedEventArgs e) => await ViewModel.PerformAutomaticBindingWithProgressAsync(new AutomaticBindingRequest.Shared());
 
     private async void ExportBindingConfigurationButton_OnClick(object sender, RoutedEventArgs e)
     {

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
@@ -345,7 +345,7 @@ internal sealed class ManageBindingViewModel : ViewModelBase, IDisposable
         }
     }
 
-    private ConnectionInfo CreateConnectionInfoFromSharedBinding() =>
+    internal ConnectionInfo CreateConnectionInfoFromSharedBinding() =>
         SharedBindingConfigModel.IsSonarCloud()
             ? new ConnectionInfo(SharedBindingConfigModel.Organization, ConnectionServerType.SonarCloud)
             : new ConnectionInfo(SharedBindingConfigModel.Uri.ToString(), ConnectionServerType.SonarQube);
@@ -450,11 +450,6 @@ internal sealed class ManageBindingViewModel : ViewModelBase, IDisposable
             logContext,
             ConnectedMode.Resources.AutomaticBinding_ConnectionNotFound,
             connectionId);
-        connectedModeUiServices.MessageBox.Show(
-            UiResources.NotFoundConnectionForAutomaticBindingMessageBoxText,
-            UiResources.NotFoundConnectionForAutomaticBindingMessageBoxCaption,
-            MessageBoxButton.OK,
-            MessageBoxImage.Warning);
         return BindingResult.ConnectionNotFound;
     }
 

--- a/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
+++ b/src/ConnectedMode/UI/ManageBinding/ManageBindingViewModel.cs
@@ -345,11 +345,6 @@ internal sealed class ManageBindingViewModel : ViewModelBase, IDisposable
         }
     }
 
-    internal ConnectionInfo CreateConnectionInfoFromSharedBinding() =>
-        SharedBindingConfigModel.IsSonarCloud()
-            ? new ConnectionInfo(SharedBindingConfigModel.Organization, ConnectionServerType.SonarCloud)
-            : new ConnectionInfo(SharedBindingConfigModel.Uri.ToString(), ConnectionServerType.SonarQube);
-
     private void UpdateBoundProjectProperties(ServerConnection serverConnection, ServerProject serverProject)
     {
         SelectedConnectionInfo = serverConnection == null ? null : ConnectionInfo.From(serverConnection);
@@ -428,7 +423,7 @@ internal sealed class ManageBindingViewModel : ViewModelBase, IDisposable
                 serverProjectKey = assistedBinding.ServerProjectKey;
                 return BindingResult.Success;
             case AutomaticBindingRequest.Shared when SharedBindingConfigModel != null:
-                serverConnectionId = CreateConnectionInfoFromSharedBinding().GetServerIdFromConnectionInfo();
+                serverConnectionId = sharedBindingConfigModel.CreateConnectionInfo().GetServerIdFromConnectionInfo();
                 serverProjectKey = SharedBindingConfigModel.ProjectKey;
                 return BindingResult.Success;
             default:

--- a/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
+++ b/src/ConnectedMode/UI/Resources/UiResources.Designer.cs
@@ -718,25 +718,6 @@ namespace SonarLint.VisualStudio.ConnectedMode.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connection not found.
-        /// </summary>
-        public static string NotFoundConnectionForAutomaticBindingMessageBoxCaption {
-            get {
-                return ResourceManager.GetString("NotFoundConnectionForAutomaticBindingMessageBoxCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The automatic binding could not be executed, because the connection to the server could not be found. 
-        ///Please manually add the connection through &quot;Manage Connections&quot; and then try again..
-        /// </summary>
-        public static string NotFoundConnectionForAutomaticBindingMessageBoxText {
-            get {
-                return ResourceManager.GetString("NotFoundConnectionForAutomaticBindingMessageBoxText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Credentials not found.
         /// </summary>
         public static string NotFoundCredentialsForAutomaticBindingMessageBoxCaption {

--- a/src/ConnectedMode/UI/Resources/UiResources.resx
+++ b/src/ConnectedMode/UI/Resources/UiResources.resx
@@ -357,13 +357,6 @@
   <data name="LoadingProjectsFailedTextForNotFoundServerConnection" xml:space="preserve">
     <value>Server connection was not found. Projects could not be loaded.</value>
   </data>
-  <data name="NotFoundConnectionForAutomaticBindingMessageBoxText" xml:space="preserve">
-    <value>The automatic binding could not be executed, because the connection to the server could not be found. 
-Please manually add the connection through "Manage Connections" and then try again.</value>
-  </data>
-  <data name="NotFoundConnectionForAutomaticBindingMessageBoxCaption" xml:space="preserve">
-    <value>Connection not found</value>
-  </data>
   <data name="DeleteBindingHelpText" xml:space="preserve">
     <value>To manually delete a binding, please follow the "Unbinding a project" documentation </value>
   </data>

--- a/src/IssueViz.UnitTests/Editor/Common/CommonTaggerProviderTestsBase.cs
+++ b/src/IssueViz.UnitTests/Editor/Common/CommonTaggerProviderTestsBase.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Text.Tagging;
 using SonarLint.VisualStudio.IssueVisualization.Editor;
 using static SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.Common.TaggerTestHelper;


### PR DESCRIPTION
When using the shared binding and the server connection could not be found in the `connections.json`, a message box is shown that informs the user that he has to add it manually (this was a temporary workaround) 

Instead of the message box, the trust connection dialog should be shown

[SLVS-1464](https://sonarsource.atlassian.net/browse/SLVS-1464)



[SLVS-1464]: https://sonarsource.atlassian.net/browse/SLVS-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ