### PR TITLE
SLVS-1908 Show warning when token becomes invalid

### DIFF
--- a/src/ConnectedMode.UnitTests/Binding/Suggestion/UpdateTokenNotificationTests.cs
+++ b/src/ConnectedMode.UnitTests/Binding/Suggestion/UpdateTokenNotificationTests.cs
@@ -83,7 +83,7 @@ public class UpdateTokenNotificationTests
         testSubject.Show(serverConnection.Id);
 
         InvokeNotificationCommand(BindingStrings.UpdateTokenNotificationEditCredentialsOptionText);
-        connectedModeUiManager.Received(1).ShowEditCredentialsDialog(Arg.Is<ConnectionInfo>(info => info.Id == serverConnection.ToConnection().Info.Id), withNextButton: false);
+        connectedModeUiManager.Received(1).ShowEditCredentialsDialog(Arg.Is<Connection>(connection => connection.Info.Id == serverConnection.ToConnection().Info.Id));
     }
 
     [TestMethod]

--- a/src/ConnectedMode.UnitTests/Binding/Suggestion/UpdateTokenNotificationTests.cs
+++ b/src/ConnectedMode.UnitTests/Binding/Suggestion/UpdateTokenNotificationTests.cs
@@ -88,7 +88,7 @@ public class UpdateTokenNotificationTests
         testSubject.Show(serverConnection.Id);
 
         InvokeNotificationCommand(BindingStrings.UpdateTokenNotificationEditCredentialsOptionText);
-        connectedModeUiManager.Received(1).ShowEditCredentialsDialog(Arg.Is<Connection>(connection => connection.Info.Id == serverConnection.ToConnection().Info.Id));
+        connectedModeUiManager.Received(1).ShowEditCredentialsDialogAsync(Arg.Is<Connection>(connection => connection.Info.Id == serverConnection.ToConnection().Info.Id));
     }
 
     [TestMethod]
@@ -158,5 +158,5 @@ public class UpdateTokenNotificationTests
         });
 
     private void MockShowEditCredentialsDialog(bool success) =>
-        connectedModeUiManager.ShowEditCredentialsDialog(Arg.Is<Connection>(connection => connection.Info.Id == serverConnection.ToConnection().Info.Id)).Returns(success);
+        connectedModeUiManager.ShowEditCredentialsDialogAsync(Arg.Is<Connection>(connection => connection.Info.Id == serverConnection.ToConnection().Info.Id)).Returns(success);
 }

--- a/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
@@ -71,13 +71,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI
         }
 
         [TestMethod]
-        [DataRow(ConnectionServerType.SonarCloud, true)]
-        [DataRow(ConnectionServerType.SonarCloud, false)]
-        [DataRow(ConnectionServerType.SonarQube, true)]
-        [DataRow(ConnectionServerType.SonarQube, false)]
-        public void ShowEditCredentialsDialog_RunsOnUIThread(ConnectionServerType serverType, bool withNextDialog)
+        [DataRow(ConnectionServerType.SonarCloud)]
+        [DataRow(ConnectionServerType.SonarQube)]
+        public void ShowEditCredentialsDialog_RunsOnUIThread(ConnectionServerType serverType)
         {
-            testSubject.ShowEditCredentialsDialog(new ConnectionInfo("id", serverType), withNextDialog);
+            testSubject.ShowEditCredentialsDialog(new Connection(new ConnectionInfo("id", serverType)));
 
             connectedModeServices.ThreadHandling.Received(1).RunOnUIThread(Arg.Any<Action>());
         }

--- a/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
@@ -73,9 +73,9 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI
         [TestMethod]
         [DataRow(ConnectionServerType.SonarCloud)]
         [DataRow(ConnectionServerType.SonarQube)]
-        public async Task ShowEditCredentialsDialog_RunsOnUIThread(ConnectionServerType serverType)
+        public async Task ShowEditCredentialsDialogAsync_RunsOnUIThread(ConnectionServerType serverType)
         {
-            await testSubject.ShowEditCredentialsDialog(new Connection(new ConnectionInfo("id", serverType)));
+            await testSubject.ShowEditCredentialsDialogAsync(new Connection(new ConnectionInfo("id", serverType)));
 
             await connectedModeServices.ThreadHandling.Received(1).RunOnUIThreadAsync(Arg.Any<Action>());
         }

--- a/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
@@ -73,11 +73,11 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI
         [TestMethod]
         [DataRow(ConnectionServerType.SonarCloud)]
         [DataRow(ConnectionServerType.SonarQube)]
-        public void ShowEditCredentialsDialog_RunsOnUIThread(ConnectionServerType serverType)
+        public async Task ShowEditCredentialsDialog_RunsOnUIThread(ConnectionServerType serverType)
         {
-            testSubject.ShowEditCredentialsDialog(new Connection(new ConnectionInfo("id", serverType)));
+            await testSubject.ShowEditCredentialsDialog(new Connection(new ConnectionInfo("id", serverType)));
 
-            connectedModeServices.ThreadHandling.Received(1).RunOnUIThread(Arg.Any<Action>());
+            await connectedModeServices.ThreadHandling.Received(1).RunOnUIThreadAsync(Arg.Any<Action>());
         }
     }
 }

--- a/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
+++ b/src/ConnectedMode.UnitTests/UI/ConnectedModeUIManagerTests.cs
@@ -44,14 +44,12 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI
         }
 
         [TestMethod]
-        public void MefCtor_CheckIsExported()
-        {
+        public void MefCtor_CheckIsExported() =>
             MefTestHelpers.CheckTypeCanBeImported<ConnectedModeUIManager, IConnectedModeUIManager>(
                 MefTestHelpers.CreateExport<IConnectedModeServices>(),
                 MefTestHelpers.CreateExport<IConnectedModeBindingServices>(),
                 MefTestHelpers.CreateExport<IConnectedModeUIServices>()
             );
-        }
 
         [TestMethod]
         public void MefCtor_CheckIsNonShared() => MefTestHelpers.CheckIsNonSharedMefComponent<ConnectedModeUIManager>();
@@ -70,6 +68,18 @@ namespace SonarLint.VisualStudio.ConnectedMode.UnitTests.UI
             await testSubject.ShowTrustConnectionDialogAsync(new ServerConnection.SonarCloud("myOrg"), null);
 
             await connectedModeServices.ThreadHandling.Received(1).RunOnUIThreadAsync(Arg.Any<Action>());
+        }
+
+        [TestMethod]
+        [DataRow(ConnectionServerType.SonarCloud, true)]
+        [DataRow(ConnectionServerType.SonarCloud, false)]
+        [DataRow(ConnectionServerType.SonarQube, true)]
+        [DataRow(ConnectionServerType.SonarQube, false)]
+        public void ShowEditCredentialsDialog_RunsOnUIThread(ConnectionServerType serverType, bool withNextDialog)
+        {
+            testSubject.ShowEditCredentialsDialog(new ConnectionInfo("id", serverType), withNextDialog);
+
+            connectedModeServices.ThreadHandling.Received(1).RunOnUIThread(Arg.Any<Action>());
         }
     }
 }

--- a/src/ConnectedMode/Binding/BindingStrings.Designer.cs
+++ b/src/ConnectedMode/Binding/BindingStrings.Designer.cs
@@ -150,5 +150,23 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding {
                 return ResourceManager.GetString("UpdateTokenNotificationText", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Credentials Updated Successfully.
+        /// </summary>
+        internal static string UpdateTokenSuccessfullyMessageBoxCaption {
+            get {
+                return ResourceManager.GetString("UpdateTokenSuccessfullyMessageBoxCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The credentials of the connection &quot;{0}&quot; have been updated successfully.
+        /// </summary>
+        internal static string UpdateTokenSuccessfullyMessageBoxText {
+            get {
+                return ResourceManager.GetString("UpdateTokenSuccessfullyMessageBoxText", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ConnectedMode/Binding/BindingStrings.Designer.cs
+++ b/src/ConnectedMode/Binding/BindingStrings.Designer.cs
@@ -123,5 +123,32 @@ namespace SonarLint.VisualStudio.ConnectedMode.Binding {
                 return ResourceManager.GetString("UnintrusiveController_InvalidConnection", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dismiss.
+        /// </summary>
+        internal static string UpdateTokenDismissOptionText {
+            get {
+                return ResourceManager.GetString("UpdateTokenDismissOptionText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit Credentials.
+        /// </summary>
+        internal static string UpdateTokenNotificationEditCredentialsOptionText {
+            get {
+                return ResourceManager.GetString("UpdateTokenNotificationEditCredentialsOptionText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The token used for the server connection &quot;{0}&quot; is invalid, please update the credentials..
+        /// </summary>
+        internal static string UpdateTokenNotificationText {
+            get {
+                return ResourceManager.GetString("UpdateTokenNotificationText", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ConnectedMode/Binding/BindingStrings.resx
+++ b/src/ConnectedMode/Binding/BindingStrings.resx
@@ -141,4 +141,13 @@
   <data name="UnintrusiveController_InvalidConnection" xml:space="preserve">
     <value>Could not convert connection information for the binding</value>
   </data>
+  <data name="UpdateTokenDismissOptionText" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
+  <data name="UpdateTokenNotificationEditCredentialsOptionText" xml:space="preserve">
+    <value>Edit Credentials</value>
+  </data>
+  <data name="UpdateTokenNotificationText" xml:space="preserve">
+    <value>The token used for the server connection "{0}" is invalid, please update the credentials.</value>
+  </data>
 </root>

--- a/src/ConnectedMode/Binding/BindingStrings.resx
+++ b/src/ConnectedMode/Binding/BindingStrings.resx
@@ -147,6 +147,12 @@
   <data name="UpdateTokenNotificationEditCredentialsOptionText" xml:space="preserve">
     <value>Edit Credentials</value>
   </data>
+  <data name="UpdateTokenSuccessfullyMessageBoxCaption" xml:space="preserve">
+    <value>Credentials Updated Successfully</value>
+  </data>
+  <data name="UpdateTokenSuccessfullyMessageBoxText" xml:space="preserve">
+    <value>The credentials of the connection "{0}" have been updated successfully</value>
+  </data>
   <data name="UpdateTokenNotificationText" xml:space="preserve">
     <value>The token used for the server connection "{0}" is invalid, please update the credentials.</value>
   </data>

--- a/src/ConnectedMode/Binding/Suggestion/IUpdateTokenNotification.cs
+++ b/src/ConnectedMode/Binding/Suggestion/IUpdateTokenNotification.cs
@@ -69,7 +69,7 @@ internal class UpdateTokenNotification(
 
     private async Task OnUpdateTokenHandlerAsync(Connection connection)
     {
-        var result = await connectedModeUiManager.ShowEditCredentialsDialog(connection);
+        var result = await connectedModeUiManager.ShowEditCredentialsDialogAsync(connection);
         if (result == true)
         {
             messageBox.Show(string.Format(BindingStrings.UpdateTokenSuccessfullyMessageBoxText, connection.Info.Id), BindingStrings.UpdateTokenSuccessfullyMessageBoxCaption, MessageBoxButton.OK,

--- a/src/ConnectedMode/Binding/Suggestion/IUpdateTokenNotification.cs
+++ b/src/ConnectedMode/Binding/Suggestion/IUpdateTokenNotification.cs
@@ -45,21 +45,22 @@ internal class UpdateTokenNotification(INotificationService notificationService,
             return;
         }
 
-        var connectionInfo = serverConnection.ToConnection().Info;
+        var connection = serverConnection.ToConnection();
+        var connectionInfo = connection.Info;
+
         var notification = new Notification(
             id: string.Format(IdTemplate, connectionInfo.Id),
             message: string.Format(BindingStrings.UpdateTokenNotificationText, connectionInfo.Id),
             actions:
             [
-                new NotificationAction(BindingStrings.UpdateTokenNotificationEditCredentialsOptionText, _ => OnUpdateTokenHandler(connectionInfo), true),
+                new NotificationAction(BindingStrings.UpdateTokenNotificationEditCredentialsOptionText, _ => OnUpdateTokenHandler(connection), true),
                 new NotificationAction(BindingStrings.UpdateTokenDismissOptionText, _ => OnDismissHandler(), true),
             ],
             showOncePerSession: true);
-
         notificationService.ShowNotification(notification);
     }
 
-    private void OnUpdateTokenHandler(ConnectionInfo connectionInfo) => connectedModeUiManager.ShowEditCredentialsDialog(connectionInfo, withNextButton: false);
+    private void OnUpdateTokenHandler(Connection connection) => connectedModeUiManager.ShowEditCredentialsDialog(connection);
 
     private void OnDismissHandler() => notificationService.CloseNotification();
 }

--- a/src/ConnectedMode/Binding/Suggestion/IUpdateTokenNotification.cs
+++ b/src/ConnectedMode/Binding/Suggestion/IUpdateTokenNotification.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.ConnectedMode.UI;
+using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Core.Notifications;
+
+namespace SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion;
+
+public interface IUpdateTokenNotification
+{
+    void Show(string connectionId);
+}
+
+[Export(typeof(IUpdateTokenNotification))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+[method: ImportingConstructor]
+internal class UpdateTokenNotification(INotificationService notificationService, IConnectedModeUIManager connectedModeUiManager, IServerConnectionsRepository serverConnectionsRepository)
+    : IUpdateTokenNotification
+{
+    internal const string IdTemplate = "update.token.for.{0}";
+
+    public void Show(string connectionId)
+    {
+        if (!serverConnectionsRepository.TryGet(connectionId, out var serverConnection))
+        {
+            return;
+        }
+
+        var connectionInfo = serverConnection.ToConnection().Info;
+        var notification = new Notification(
+            id: string.Format(IdTemplate, connectionInfo.Id),
+            message: string.Format(BindingStrings.UpdateTokenNotificationText, connectionInfo.Id),
+            actions:
+            [
+                new NotificationAction(BindingStrings.UpdateTokenNotificationEditCredentialsOptionText, _ => OnUpdateTokenHandler(connectionInfo), true),
+                new NotificationAction(BindingStrings.UpdateTokenDismissOptionText, _ => OnDismissHandler(), true),
+            ],
+            showOncePerSession: true);
+
+        notificationService.ShowNotification(notification);
+    }
+
+    private void OnUpdateTokenHandler(ConnectionInfo connectionInfo) => connectedModeUiManager.ShowEditCredentialsDialog(connectionInfo, withNextButton: false);
+
+    private void OnDismissHandler() => notificationService.CloseNotification();
+}

--- a/src/ConnectedMode/UI/ConnectedModeUIManager.cs
+++ b/src/ConnectedMode/UI/ConnectedModeUIManager.cs
@@ -35,7 +35,7 @@ public interface IConnectedModeUIManager
 
     Task<bool?> ShowTrustConnectionDialogAsync(ServerConnection serverConnection, string token);
 
-    Task<bool?> ShowEditCredentialsDialog(Connection connection);
+    Task<bool?> ShowEditCredentialsDialogAsync(Connection connection);
 }
 
 [Export(typeof(IConnectedModeUIManager))]
@@ -60,7 +60,7 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
         return dialogResult;
     }
 
-    public async Task<bool?> ShowEditCredentialsDialog(Connection connection)
+    public async Task<bool?> ShowEditCredentialsDialogAsync(Connection connection)
     {
         bool? dialogResult = null;
         await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(() => dialogResult = GetEditCredentialsDialogResult(connection));

--- a/src/ConnectedMode/UI/ConnectedModeUIManager.cs
+++ b/src/ConnectedMode/UI/ConnectedModeUIManager.cs
@@ -35,7 +35,7 @@ public interface IConnectedModeUIManager
 
     Task<bool?> ShowTrustConnectionDialogAsync(ServerConnection serverConnection, string token);
 
-    bool? ShowEditCredentialsDialog(Connection connection);
+    Task<bool?> ShowEditCredentialsDialog(Connection connection);
 }
 
 [Export(typeof(IConnectedModeUIManager))]
@@ -60,10 +60,10 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
         return dialogResult;
     }
 
-    public bool? ShowEditCredentialsDialog(Connection connection)
+    public async Task<bool?> ShowEditCredentialsDialog(Connection connection)
     {
         bool? dialogResult = null;
-        connectedModeServices.ThreadHandling.RunOnUIThread(() => dialogResult = GetEditCredentialsDialogResult(connection));
+        await connectedModeServices.ThreadHandling.RunOnUIThreadAsync(() => dialogResult = GetEditCredentialsDialogResult(connection));
 
         return dialogResult;
     }

--- a/src/ConnectedMode/UI/ConnectedModeUIManager.cs
+++ b/src/ConnectedMode/UI/ConnectedModeUIManager.cs
@@ -21,6 +21,7 @@
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
+using SonarLint.VisualStudio.ConnectedMode.UI.Credentials;
 using SonarLint.VisualStudio.ConnectedMode.UI.ManageBinding;
 using SonarLint.VisualStudio.ConnectedMode.UI.TrustConnection;
 using SonarLint.VisualStudio.Core.Binding;
@@ -33,6 +34,8 @@ public interface IConnectedModeUIManager
     Task<bool> ShowManageBindingDialogAsync(AutomaticBindingRequest automaticBinding = null);
 
     Task<bool?> ShowTrustConnectionDialogAsync(ServerConnection serverConnection, string token);
+
+    bool? ShowEditCredentialsDialog(ConnectionInfo connectionInfo, bool withNextButton);
 }
 
 [Export(typeof(IConnectedModeUIManager))]
@@ -57,6 +60,14 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
         return dialogResult;
     }
 
+    public bool? ShowEditCredentialsDialog(ConnectionInfo connectionInfo, bool withNextButton)
+    {
+        bool? dialogResult = null;
+        connectedModeServices.ThreadHandling.RunOnUIThread(() => dialogResult = GetEditCredentialsDialogResult(connectionInfo, withNextButton));
+
+        return dialogResult;
+    }
+
     [ExcludeFromCodeCoverage] // UI, not really unit-testable
     private bool? GetTrustConnectionDialogResult(ServerConnection serverConnection, string token)
     {
@@ -70,5 +81,12 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
         var manageBindingDialog = new ManageBindingDialog(connectedModeServices, connectedModeBindingServices, connectedModeUiServices, this, automaticBinding);
         manageBindingDialog.ShowDialog(Application.Current.MainWindow);
         return manageBindingDialog.ViewModel.BoundProject != null;
+    }
+
+    [ExcludeFromCodeCoverage] // UI, not really unit-testable
+    private bool? GetEditCredentialsDialogResult(ConnectionInfo connectionInfo, bool withNextButton)
+    {
+        var trustConnectionDialog = new CredentialsDialog(connectedModeServices, connectedModeUiServices, connectionInfo, withNextButton);
+        return trustConnectionDialog.ShowDialog(Application.Current.MainWindow);
     }
 }

--- a/src/ConnectedMode/UI/ConnectedModeUIManager.cs
+++ b/src/ConnectedMode/UI/ConnectedModeUIManager.cs
@@ -35,7 +35,7 @@ public interface IConnectedModeUIManager
 
     Task<bool?> ShowTrustConnectionDialogAsync(ServerConnection serverConnection, string token);
 
-    bool? ShowEditCredentialsDialog(ConnectionInfo connectionInfo, bool withNextButton);
+    bool? ShowEditCredentialsDialog(Connection connection);
 }
 
 [Export(typeof(IConnectedModeUIManager))]
@@ -60,10 +60,10 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
         return dialogResult;
     }
 
-    public bool? ShowEditCredentialsDialog(ConnectionInfo connectionInfo, bool withNextButton)
+    public bool? ShowEditCredentialsDialog(Connection connection)
     {
         bool? dialogResult = null;
-        connectedModeServices.ThreadHandling.RunOnUIThread(() => dialogResult = GetEditCredentialsDialogResult(connectionInfo, withNextButton));
+        connectedModeServices.ThreadHandling.RunOnUIThread(() => dialogResult = GetEditCredentialsDialogResult(connection));
 
         return dialogResult;
     }
@@ -84,9 +84,9 @@ internal sealed class ConnectedModeUIManager(IConnectedModeServices connectedMod
     }
 
     [ExcludeFromCodeCoverage] // UI, not really unit-testable
-    private bool? GetEditCredentialsDialogResult(ConnectionInfo connectionInfo, bool withNextButton)
+    private bool? GetEditCredentialsDialogResult(Connection connection)
     {
-        var trustConnectionDialog = new CredentialsDialog(connectedModeServices, connectedModeUiServices, connectionInfo, withNextButton);
-        return trustConnectionDialog.ShowDialog(Application.Current.MainWindow);
+        var editCredentialsDialog = new EditCredentialsDialog(connectedModeServices, connectedModeUiServices, connectedModeBindingServices, connection);
+        return editCredentialsDialog.ShowDialog(Application.Current.MainWindow);
     }
 }

--- a/src/SLCore.Listeners.UnitTests/ConnectionConfigurationListenerTests.cs
+++ b/src/SLCore.Listeners.UnitTests/ConnectionConfigurationListenerTests.cs
@@ -38,7 +38,9 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.UnitTests
         }
 
         [TestMethod]
-        public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<ConnectionConfigurationListener, ISLCoreListener>();
+        public void MefCtor_CheckIsExported() =>
+            MefTestHelpers.CheckTypeCanBeImported<ConnectionConfigurationListener, ISLCoreListener>(
+                MefTestHelpers.CreateExport<IUpdateTokenNotification>());
 
         [TestMethod]
         public void Mef_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<ConnectionConfigurationListener>();

--- a/src/SLCore.Listeners.UnitTests/ConnectionConfigurationListenerTests.cs
+++ b/src/SLCore.Listeners.UnitTests/ConnectionConfigurationListenerTests.cs
@@ -18,25 +18,30 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Threading.Tasks;
+using SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion;
 using SonarLint.VisualStudio.SLCore.Core;
+using SonarLint.VisualStudio.SLCore.Listener.Connection;
 
 namespace SonarLint.VisualStudio.SLCore.Listeners.UnitTests
 {
     [TestClass]
     public class ConnectionConfigurationListenerTests
     {
-        [TestMethod]
-        public void MefCtor_CheckIsExported()
+        private IUpdateTokenNotification updateTokenNotification;
+        private ConnectionConfigurationListener testSubject;
+
+        [TestInitialize]
+        public void TestInitialize()
         {
-            MefTestHelpers.CheckTypeCanBeImported<ConnectionConfigurationListener, ISLCoreListener>();
+            updateTokenNotification = Substitute.For<IUpdateTokenNotification>();
+            testSubject = new ConnectionConfigurationListener(updateTokenNotification);
         }
 
         [TestMethod]
-        public void Mef_CheckIsSingleton()
-        {
-            MefTestHelpers.CheckIsSingletonMefComponent<ConnectionConfigurationListener>();
-        }
+        public void MefCtor_CheckIsExported() => MefTestHelpers.CheckTypeCanBeImported<ConnectionConfigurationListener, ISLCoreListener>();
+
+        [TestMethod]
+        public void Mef_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<ConnectionConfigurationListener>();
 
         [TestMethod]
         [DataRow(null)]
@@ -44,11 +49,19 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.UnitTests
         [DataRow("something")]
         public void DidSynchronizeConfigurationScopesAsync_ReturnsTaskCompleted(object parameter)
         {
-            var testSubject = new ConnectionConfigurationListener();
-
             var result = testSubject.DidSynchronizeConfigurationScopesAsync(parameter);
 
             result.Should().Be(Task.CompletedTask);
+        }
+
+        [TestMethod]
+        public void InvalidToken_CallsUpdateTokenNotification()
+        {
+            var parameters = new InvalidTokenParams("myConnectionId");
+
+            testSubject.InvalidToken(parameters);
+
+            updateTokenNotification.Received(1).Show(parameters.connectionId);
         }
     }
 }

--- a/src/SLCore.Listeners/Implementation/ConnectionConfigurationListener.cs
+++ b/src/SLCore.Listeners/Implementation/ConnectionConfigurationListener.cs
@@ -19,6 +19,7 @@
  */
 
 using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.ConnectedMode.Binding.Suggestion;
 using SonarLint.VisualStudio.SLCore.Core;
 using SonarLint.VisualStudio.SLCore.Listener.Connection;
 
@@ -26,16 +27,11 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.Implementation
 {
     [Export(typeof(ISLCoreListener))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    public class ConnectionConfigurationListener : IConnectionConfigurationListener
+    [method: ImportingConstructor]
+    public class ConnectionConfigurationListener(IUpdateTokenNotification updateTokenNotification) : IConnectionConfigurationListener
     {
-        public Task DidSynchronizeConfigurationScopesAsync(object parameters)
-        {
-            return Task.CompletedTask;
-        }
+        public Task DidSynchronizeConfigurationScopesAsync(object parameters) => Task.CompletedTask;
 
-        public void InvalidToken(InvalidTokenParams parameters)
-        {
-            // TODO by https://sonarsource.atlassian.net/browse/SLVS-1908 Add implementation
-        }
+        public void InvalidToken(InvalidTokenParams parameters) => updateTokenNotification.Show(parameters.connectionId);
     }
 }

--- a/src/SLCore/Listener/Connection/IConnectionConfigurationListener.cs
+++ b/src/SLCore/Listener/Connection/IConnectionConfigurationListener.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Threading.Tasks;
 using SonarLint.VisualStudio.SLCore.Core;
 
 namespace SonarLint.VisualStudio.SLCore.Listener.Connection;
@@ -26,4 +25,6 @@ namespace SonarLint.VisualStudio.SLCore.Listener.Connection;
 public interface IConnectionConfigurationListener : ISLCoreListener
 {
     Task DidSynchronizeConfigurationScopesAsync(object parameters);
+
+    void InvalidToken(InvalidTokenParams parameters);
 }

--- a/src/SLCore/Listener/Connection/InvalidTokenParams.cs
+++ b/src/SLCore/Listener/Connection/InvalidTokenParams.cs
@@ -18,24 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.ComponentModel.Composition;
-using SonarLint.VisualStudio.SLCore.Core;
-using SonarLint.VisualStudio.SLCore.Listener.Connection;
-
-namespace SonarLint.VisualStudio.SLCore.Listeners.Implementation
+namespace SonarLint.VisualStudio.SLCore.Listener.Connection
 {
-    [Export(typeof(ISLCoreListener))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
-    public class ConnectionConfigurationListener : IConnectionConfigurationListener
+    public record InvalidTokenParams(string connectionId)
     {
-        public Task DidSynchronizeConfigurationScopesAsync(object parameters)
-        {
-            return Task.CompletedTask;
-        }
-
-        public void InvalidToken(InvalidTokenParams parameters)
-        {
-            // TODO by https://sonarsource.atlassian.net/browse/SLVS-1908 Add implementation
-        }
     }
 }


### PR DESCRIPTION
[SLVS-1908](https://sonarsource.atlassian.net/browse/SLVS-1908)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6111) in which the EditCredentialsDialog was introduced, because it depends on it.

[SLVS-1908]: https://sonarsource.atlassian.net/browse/SLVS-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ