### PR TITLE
SLVS-1776 Fix rule description not shown when compliant and non-compliant code snippets are in different tabs

### DIFF
--- a/src/Education.UnitTests/XamlGenerator/RuleHelpXamlTranslatorTests.cs
+++ b/src/Education.UnitTests/XamlGenerator/RuleHelpXamlTranslatorTests.cs
@@ -351,6 +351,32 @@ same 1</Paragraph>
             result.Replace("\r\n", "\n").Should().Be(expectedText.Replace("\r\n", "\n"));
         }
 
+        [TestMethod]
+        public void TranslateHtmlToXaml_CompliantCodeExists_AndNonCompliantDoesNotExist_ShowsJustCompliantCodeWithoutAnyHighlighting()
+        {
+            var htmlText = "<pre data-diff-type=\"compliant\" data-diff-id=\"1\">Some text</pre>";
+            var expectedText = @"<Section xml:space=""preserve"" Style=""{DynamicResource Pre_Section}"">
+  <Paragraph>Some text</Paragraph>
+</Section>";
+
+            var result = testSubject.TranslateHtmlToXaml(htmlText);
+
+            result.Should().Be(expectedText);
+        }
+
+        [TestMethod]
+        public void TranslateHtmlToXaml_NonCompliantCodeExists_AndCompliantDoesNotExist_ShowsJustNonCompliantCodeWithoutAnyHighlighting()
+        {
+            var htmlText = "<pre data-diff-type=\"noncompliant\" data-diff-id=\"1\">Some text</pre>";
+            var expectedText = @"<Section xml:space=""preserve"" Style=""{DynamicResource Pre_Section}"">
+  <Paragraph>Some text</Paragraph>
+</Section>";
+
+            var result = testSubject.TranslateHtmlToXaml(htmlText);
+
+            result.Should().Be(expectedText);
+        }
+
         private static IRuleHelpXamlTranslator CreateTestSubject(IXamlWriterFactory xamlWriterFactory, IDiffTranslator diffTranslator) =>
             new RuleHelpXamlTranslatorFactory(xamlWriterFactory, diffTranslator).Create();
     }

--- a/src/Education/XamlGenerator/RuleHelpXamlTranslator.cs
+++ b/src/Education/XamlGenerator/RuleHelpXamlTranslator.cs
@@ -601,12 +601,17 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
                         continue;
                     }
 
-                    var diffXaml = diffTranslator.GetDiffXaml(diffCodes[noncompliantKey], diffCodes[compliantKey]);
+                    var compliantHtml = GetDiffCodeIfExists(compliantKey);
+                    var nonCompliantHtml = GetDiffCodeIfExists(noncompliantKey);
+                    // if one of the compliant/nonCompliant html is missing (for example is in another tab), we will use the one that exists to generate the diff (which will be no diff)
+                    var diffXaml = diffTranslator.GetDiffXaml(nonCompliantHtml ?? compliantHtml, compliantHtml ?? nonCompliantHtml);
 
                     sb.Replace(noncompliantKey, diffXaml.noncompliantXaml);
                     sb.Replace(compliantKey, diffXaml.compliantXaml);
                 }
             }
+
+            private string GetDiffCodeIfExists(string key) => diffCodes.ContainsKey(key) ? diffCodes[key] : null;
 
             private void ProcessInvalidDiffId(StringBuilder sb, string compliantKey, string noncompliantKey)
             {

--- a/src/Education/XamlGenerator/RuleHelpXamlTranslator.cs
+++ b/src/Education/XamlGenerator/RuleHelpXamlTranslator.cs
@@ -595,16 +595,17 @@ namespace SonarLint.VisualStudio.Education.XamlGenerator
                     var noncompliantKey = $"[noncompliant:{id}]";
                     var compliantKey = $"[compliant:{id}]";
 
-                    if (invalidIds.Contains(id))
+                    var compliantHtml = GetDiffCodeIfExists(compliantKey);
+                    var nonCompliantHtml = GetDiffCodeIfExists(noncompliantKey);
+
+                    // if one of the compliant/nonCompliant html is missing (for example is in another tab), we don't have to generate a diff
+                    if (invalidIds.Contains(id) || compliantHtml is null || nonCompliantHtml is null)
                     {
                         ProcessInvalidDiffId(sb, compliantKey, noncompliantKey);
                         continue;
                     }
 
-                    var compliantHtml = GetDiffCodeIfExists(compliantKey);
-                    var nonCompliantHtml = GetDiffCodeIfExists(noncompliantKey);
-                    // if one of the compliant/nonCompliant html is missing (for example is in another tab), we will use the one that exists to generate the diff (which will be no diff)
-                    var diffXaml = diffTranslator.GetDiffXaml(nonCompliantHtml ?? compliantHtml, compliantHtml ?? nonCompliantHtml);
+                    var diffXaml = diffTranslator.GetDiffXaml(nonCompliantHtml, compliantHtml);
 
                     sb.Replace(noncompliantKey, diffXaml.noncompliantXaml);
                     sb.Replace(compliantKey, diffXaml.compliantXaml);

--- a/src/SLCore.IntegrationTests/RuleDescriptionConversionSmokeTest.cs
+++ b/src/SLCore.IntegrationTests/RuleDescriptionConversionSmokeTest.cs
@@ -64,14 +64,11 @@ public class RuleDescriptionConversionSmokeTest
                 "cpp:S1232", // unsupported <caption> tag https://github.com/SonarSource/sonarlint-visualstudio/issues/5014
                 "csharpsquid:S6932", // unsupported <dl> and <dt> tag https://github.com/SonarSource/sonarlint-visualstudio/issues/5414
                 "csharpsquid:S6966", // unsupported <dl> and <dt> tag https://github.com/SonarSource/sonarlint-visualstudio/issues/5414
-                "typescript:S6811", // unsupported <caption> tag https://github.com/SonarSource/sonarlint-visualstudio/issues/5014
-                "javascript:S6811", // unsupported <caption> tag https://github.com/SonarSource/sonarlint-visualstudio/issues/5014
-                "Web:S6811" // unsupported compliant & non-compliant code snippets in different tabs https://sonarsource.atlassian.net/browse/SLVS-1776
             });
     }
 
-
-    private static async Task<List<IRuleInfo>> GetAllRuleDescriptions(ListAllStandaloneRulesDefinitionsResponse ruleDefinitions,
+    private static async Task<List<IRuleInfo>> GetAllRuleDescriptions(
+        ListAllStandaloneRulesDefinitionsResponse ruleDefinitions,
         IRuleMetaDataProvider slCoreRuleMetaDataProvider)
     {
         ruleDefinitions.rulesByKey.Count.Should().BeGreaterThan(1500);
@@ -88,8 +85,9 @@ public class RuleDescriptionConversionSmokeTest
         return ruleDescriptions;
     }
 
-
-    private static void CheckRuleDescriptionsOnSTAThread(List<IRuleInfo> ruleDescriptions, RuleHelpXamlBuilder ruleHelpXamlBuilder,
+    private static void CheckRuleDescriptionsOnSTAThread(
+        List<IRuleInfo> ruleDescriptions,
+        RuleHelpXamlBuilder ruleHelpXamlBuilder,
         List<string> failedRuleDescriptions)
     {
         var thread = new Thread(() =>
@@ -102,7 +100,9 @@ public class RuleDescriptionConversionSmokeTest
         thread.Join();
     }
 
-    private static void CheckRuleDescriptions(List<IRuleInfo> ruleDescriptions, RuleHelpXamlBuilder ruleHelpXamlBuilder,
+    private static void CheckRuleDescriptions(
+        List<IRuleInfo> ruleDescriptions,
+        RuleHelpXamlBuilder ruleHelpXamlBuilder,
         List<string> failedRuleDescriptions)
     {
         foreach (var ruleDescription in ruleDescriptions)
@@ -130,8 +130,10 @@ public class RuleDescriptionConversionSmokeTest
         docLength.Should().BeGreaterThan(30);
     }
 
-    private static SLCoreRuleMetaDataProvider CreateSlCoreRuleMetaDataProvider(SLCoreTestRunner slCoreTestRunner,
-        IActiveConfigScopeTracker activeConfigScopeTracker, ILogger testLogger) =>
+    private static SLCoreRuleMetaDataProvider CreateSlCoreRuleMetaDataProvider(
+        SLCoreTestRunner slCoreTestRunner,
+        IActiveConfigScopeTracker activeConfigScopeTracker,
+        ILogger testLogger) =>
         new(slCoreTestRunner.SLCoreServiceProvider,
             activeConfigScopeTracker,
             new RuleInfoConverter(),


### PR DESCRIPTION
[SLVS-1776](https://sonarsource.atlassian.net/browse/SLVS-1776)

Fix rule description not shown when compliant and non-compliant code snippets are in different tabs, like web:S6811
The fix consists in making sure that the code snippet (compliant/non-compliant) is shown in the tab even without a diff (the behavior seems to be the same on the server side)

[SLVS-1776]: https://sonarsource.atlassian.net/browse/SLVS-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ