### PR TITLE
SLVS-1985 Fix RPC parameter name mismatch

### DIFF
--- a/src/SLCore.Listeners/Implementation/ConnectedModeSuggestionListener.cs
+++ b/src/SLCore.Listeners/Implementation/ConnectedModeSuggestionListener.cs
@@ -75,7 +75,8 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.Implementation
                 return null;
             }
 
-            var boundConfigScope = await connectedModeUiManager.ShowManageBindingDialogAsync(new AutomaticBindingRequest.Assisted(parameters.connectionId, parameters.projectKey, parameters.isFromSharedConfiguration)).ConfigureAwait(false)
+            var boundConfigScope = await connectedModeUiManager
+                .ShowManageBindingDialogAsync(new AutomaticBindingRequest.Assisted(parameters.connectionId, parameters.projectKey, parameters.isFromSharedConfiguration)).ConfigureAwait(false)
                 ? parameters.configScopeId
                 : null;
 
@@ -96,7 +97,7 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.Implementation
         {
             if (parameters.connectionParams?.Right is { } sonarCloudConnectionParams)
             {
-                return new ServerConnection.SonarCloud(sonarCloudConnectionParams.organizationKey, region: sonarCloudConnectionParams.sonarCloudRegion.ToCloudServerRegion());
+                return new ServerConnection.SonarCloud(sonarCloudConnectionParams.organizationKey, region: sonarCloudConnectionParams.region.ToCloudServerRegion());
             }
             if (parameters.connectionParams?.Left is { } sonarQubeConnectionParams)
             {

--- a/src/SLCore.UnitTests/Listener/Binding/AssistCreatingConnectionParamsTests.cs
+++ b/src/SLCore.UnitTests/Listener/Binding/AssistCreatingConnectionParamsTests.cs
@@ -62,7 +62,7 @@ public class AssistCreatingConnectionParamsTests
                       "organizationKey": "myOrganization",
                       "tokenName": "myToken2",
                       "tokenValue": "89D385F9-88CC-4AF5-B34B-7DAAE7FFB25B",
-                      "sonarCloudRegion": "{{region}}"
+                      "region": "{{region}}"
                   }
               }
               """;
@@ -107,7 +107,7 @@ public class AssistCreatingConnectionParamsTests
                   "organizationKey": "myOrganization",
                   "tokenName": "myToken2",
                   "tokenValue": "89D385F9-88CC-4AF5-B34B-7DAAE7FFB25B",
-                  "sonarCloudRegion": "{{region}}"
+                  "region": "{{region}}"
                 }
               }
               """;

--- a/src/SLCore.UnitTests/Listener/Binding/SonarCloudConnectionParamsTests.cs
+++ b/src/SLCore.UnitTests/Listener/Binding/SonarCloudConnectionParamsTests.cs
@@ -39,7 +39,7 @@ public class SonarCloudConnectionParamsTests
                   "organizationKey": "myOrg",
                   "tokenName": "myToken",
                   "tokenValue": "89D385F9-88CC-4AF5-B34B-7DAAE7FFB24A",
-                  "sonarCloudRegion": "{{region}}"
+                  "region": "{{region}}"
               }
               """;
 
@@ -59,7 +59,7 @@ public class SonarCloudConnectionParamsTests
                            "organizationKey": "myOrg",
                            "tokenName": "myToken",
                            "tokenValue": "89D385F9-88CC-4AF5-B34B-7DAAE7FFB24A",
-                           "sonarCloudRegion": "{{region}}"
+                           "region": "{{region}}"
                          }
                          """;
 

--- a/src/SLCore/Listener/Binding/SonarCloudConnectionParams.cs
+++ b/src/SLCore/Listener/Binding/SonarCloudConnectionParams.cs
@@ -26,4 +26,4 @@ public record SonarCloudConnectionParams(
     string organizationKey,
     string tokenName,
     string tokenValue,
-    SonarCloudRegion sonarCloudRegion);
+    SonarCloudRegion region);


### PR DESCRIPTION
[SLVS-1985](https://sonarsource.atlassian.net/browse/SLVS-1985)

Fix RPC parameter name mismatch makes assist connection fail for SQC, US region.

[SLVS-1985]: https://sonarsource.atlassian.net/browse/SLVS-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ