### PR TITLE
SLVS-2003 Fail integration tests when MSVC is improperly configured instead of silently failing later

### DIFF
--- a/src/SLCore.IntegrationTests/SimpleAnalysisTests.cs
+++ b/src/SLCore.IntegrationTests/SimpleAnalysisTests.cs
@@ -111,6 +111,7 @@ public class SimpleAnalysisTests
            For the compiler we use the MSVC which is set as an environment variable. Make sure the environment variable is set to point to the compiler path
            (the absolute path to cl.exe). */
         var compilerPath = NormalizePath(Environment.GetEnvironmentVariable("MSVC"));
+        File.Exists(compilerPath).Should().BeTrue(compilerPath);
         var cFamilyIssuesFileAbsolutePath = NormalizePath(FileAnalysisTestsRunner.CFamilyIssues.GetFullPath());
         var analysisDirectory = NormalizePath(Path.GetDirectoryName(cFamilyIssuesFileAbsolutePath));
         var jsonContent = $$"""


### PR DESCRIPTION
[SLVS-2003](https://sonarsource.atlassian.net/browse/SLVS-2003)

Part of SLVS-1990

[SLVS-2003]: https://sonarsource.atlassian.net/browse/SLVS-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ