### PR TITLE
SLVS-2016 Improve the CommaSeparatedStringArrayConverter to trim the list items.

### DIFF
--- a/src/Core.UnitTests/UserRuleSettings/AnalysisSettingsTests.cs
+++ b/src/Core.UnitTests/UserRuleSettings/AnalysisSettingsTests.cs
@@ -11,10 +11,7 @@ public class AnalysisSettingsTests
     {
         var settings = new AnalysisSettings
         {
-            Rules =
-            {
-                { "typescript:S2685", new RuleConfig { Level = RuleLevel.On, Parameters = new Dictionary<string, string> { { "key1", "value1" } } } }
-            },
+            Rules = { { "typescript:S2685", new RuleConfig { Level = RuleLevel.On, Parameters = new Dictionary<string, string> { { "key1", "value1" } } } } },
             FileExclusions = ["file1.cpp", "**/obj/*", "file2.cpp"]
         };
         const string expectedJson =
@@ -57,10 +54,7 @@ public class AnalysisSettingsTests
         var settings = JsonConvert.DeserializeObject<AnalysisSettings>(json);
 
         settings.Rules.Should().BeEquivalentTo(
-            new Dictionary<string, RuleConfig>
-            {
-                { "typescript:S2685", new RuleConfig { Level = RuleLevel.On, Parameters = new Dictionary<string, string> { { "key1", "value1" } } } }
-            });
+            new Dictionary<string, RuleConfig> { { "typescript:S2685", new RuleConfig { Level = RuleLevel.On, Parameters = new Dictionary<string, string> { { "key1", "value1" } } } } });
         settings.FileExclusions.Should().BeEquivalentTo("file1.cpp", "**/obj/*", "file2.cpp");
     }
 
@@ -73,6 +67,23 @@ public class AnalysisSettingsTests
             {
               "sonarlint.rules": {},
               "sonarlint.analysisExcludesStandalone": "file1.cpp,**/obj/*,file2.cpp"
+            }
+            """;
+
+        var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
+
+        json.Should().Be(expectedJson);
+    }
+
+    [TestMethod]
+    public void AnalysisSettings_FileExclusionsWithSpaces_SerializesCorrectlyAndTrims()
+    {
+        var settings = new AnalysisSettings { FileExclusions = ["file1.cpp ", " **/My Folder/*", "file2.cpp "] };
+        const string expectedJson =
+            """
+            {
+              "sonarlint.rules": {},
+              "sonarlint.analysisExcludesStandalone": "file1.cpp,**/My Folder/*,file2.cpp"
             }
             """;
 
@@ -110,6 +121,21 @@ public class AnalysisSettingsTests
         var settings = JsonConvert.DeserializeObject<AnalysisSettings>(json);
 
         settings.FileExclusions.Should().BeEquivalentTo("file1.cpp", "**/obj/*", "file2.cpp");
+    }
+
+    [TestMethod]
+    public void AnalysisSettings_FileExclusionsWithSpaces_DeserializesCorrectly()
+    {
+        const string json = """
+                            {
+                              "sonarlint.rules": {},
+                              "sonarlint.analysisExcludesStandalone": " file1.cpp, **/My Folder/*, file2.cpp "
+                            }
+                            """;
+
+        var settings = JsonConvert.DeserializeObject<AnalysisSettings>(json);
+
+        settings.FileExclusions.Should().BeEquivalentTo("file1.cpp", "**/My Folder/*", "file2.cpp");
     }
 
     [TestMethod]

--- a/src/Core/Helpers/CommaSeparatedStringArrayConverter.cs
+++ b/src/Core/Helpers/CommaSeparatedStringArrayConverter.cs
@@ -11,7 +11,8 @@ public class CommaSeparatedStringArrayConverter : JsonConverter
             return;
         }
 
-        writer.WriteValue(string.Join(",", strings));
+        var commaSeparatedList = string.Join(",", TrimValues(strings));
+        writer.WriteValue(commaSeparatedList);
     }
 
     public override object ReadJson(
@@ -20,9 +21,12 @@ public class CommaSeparatedStringArrayConverter : JsonConverter
         object existingValue,
         JsonSerializer serializer)
     {
-        var value = reader.Value as string;
-        return value?.Split([','], StringSplitOptions.RemoveEmptyEntries);
+        var commaSeparatedList = reader.Value as string;
+        var values = commaSeparatedList?.Split([','], StringSplitOptions.RemoveEmptyEntries);
+        return TrimValues(values);
     }
 
     public override bool CanConvert(Type objectType) => objectType == typeof(string[]);
+
+    private static string[] TrimValues(string[] values) => values?.Select(value => value.Trim()).ToArray();
 }


### PR DESCRIPTION
[SLVS-2016](https://sonarsource.atlassian.net/browse/SLVS-2016)

The file exclusions do not work when provided to SlCore, if the pattern contains spaces at the end or beginning. So we should improve our converter to trim the list items, for a better user experience.

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6140) in which integration with SlCore was done for better testability for the reviewer.

[SLVS-2016]: https://sonarsource.atlassian.net/browse/SLVS-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ