### PR TITLE
SLVS-2028 Re-generate standalone roslyn configs on startup

### DIFF
--- a/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
+++ b/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
@@ -64,7 +64,7 @@ internal sealed class AnalysisConfigMonitor : IAnalysisConfigMonitor, IDisposabl
         this.slCoreRuleSettingsUpdater = slCoreRuleSettingsUpdater;
         this.roslynSettingsUpdater = roslynSettingsUpdater;
 
-        // todo https://sonarsource.atlassian.net/browse/SLVS-2025
+        // todo https://sonarsource.atlassian.net/browse/SLVS-2025 fix this MEF importing constructor is not free-threaded
         roslynSettingsUpdater.Update(userSettingsUpdater.UserSettings);
         userSettingsUpdater.SettingsChanged += OnUserSettingsChanged;
         activeSolutionBoundTracker.SolutionBindingChanged += OnSolutionBindingChanged;

--- a/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
+++ b/src/Integration.Vsix/Analysis/AnalysisConfigMonitor.cs
@@ -64,6 +64,8 @@ internal sealed class AnalysisConfigMonitor : IAnalysisConfigMonitor, IDisposabl
         this.slCoreRuleSettingsUpdater = slCoreRuleSettingsUpdater;
         this.roslynSettingsUpdater = roslynSettingsUpdater;
 
+        // todo https://sonarsource.atlassian.net/browse/SLVS-2025
+        roslynSettingsUpdater.Update(userSettingsUpdater.UserSettings);
         userSettingsUpdater.SettingsChanged += OnUserSettingsChanged;
         activeSolutionBoundTracker.SolutionBindingChanged += OnSolutionBindingChanged;
     }


### PR DESCRIPTION
[SLVS-2028](https://sonarsource.atlassian.net/browse/SLVS-2028)

Part of 1960


[SLVS-2028]: https://sonarsource.atlassian.net/browse/SLVS-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ