### PR TITLE
SLVS-2068 Show exclusions stored in settings.json into the UI and save them on disk on OK

### DIFF
--- a/src/Core/Helpers/CommaSeparatedStringArrayConverter.cs
+++ b/src/Core/Helpers/CommaSeparatedStringArrayConverter.cs
@@ -26,7 +26,7 @@ public class CommaSeparatedStringArrayConverter : JsonConverter
 {
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
-        if (value is not string[] strings)
+        if (value is not IEnumerable<string> strings)
         {
             return;
         }
@@ -62,5 +62,5 @@ public class CommaSeparatedStringArrayConverter : JsonConverter
 
     public override bool CanConvert(Type objectType) => objectType == typeof(string[]);
 
-    private static string[] TrimValues(string[] values) => values?.Select(value => value.Trim()).ToArray();
+    private static IEnumerable<string> TrimValues(IEnumerable<string> values) => values?.Select(value => value.Trim()).ToList();
 }

--- a/src/Core/UserRuleSettings/AnalysisSettings.cs
+++ b/src/Core/UserRuleSettings/AnalysisSettings.cs
@@ -58,13 +58,13 @@ public class AnalysisSettings
     private const string AnyDirectoryWildcard = "**";
     private static readonly string AnyRootPrefix = AnyDirectoryWildcard + Path.AltDirectorySeparatorChar;
 
-    private readonly string[] userDefinedFileExclusions = [];
+    private readonly List<string> userDefinedFileExclusions = [];
     [JsonProperty("sonarlint.rules", ObjectCreationHandling = ObjectCreationHandling.Reuse)]
     public Dictionary<string, RuleConfig> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     [JsonProperty("sonarlint.analysisExcludesStandalone")]
     [JsonConverter(typeof(CommaSeparatedStringArrayConverter))]
-    public string[] UserDefinedFileExclusions
+    public List<string> UserDefinedFileExclusions
     {
         get => userDefinedFileExclusions;
         init

--- a/src/Core/UserRuleSettings/IUserSettingsProvider.cs
+++ b/src/Core/UserRuleSettings/IUserSettingsProvider.cs
@@ -33,9 +33,14 @@ public interface IUserSettingsProvider
     string SettingsFilePath { get; }
 
     /// <summary>
-    /// Updates the user settings to disabled the specified rule
+    /// Updates the user settings to disable the specified rule
     /// </summary>
     void DisableRule(string ruleId);
+
+    /// <summary>
+    /// Updates the user settings to include the provided file exclusions. The value will override existing exclusions.
+    /// </summary>
+    void UpdateFileExclusions(IEnumerable<string> exclusions);
 
     /// <summary>
     /// Ensure the settings file exists, creating a new file if necessary

--- a/src/Core/UserRuleSettings/UserSettingsProvider.cs
+++ b/src/Core/UserRuleSettings/UserSettingsProvider.cs
@@ -44,12 +44,16 @@ internal sealed class UserSettingsProvider : IUserSettingsProvider, IDisposable
     [ImportingConstructor]
     public UserSettingsProvider(ILogger logger, ISingleFileMonitorFactory singleFileMonitorFactory) : this(logger, singleFileMonitorFactory, new FileSystem(), UserSettingsFilePath) { }
 
-    internal /* for testing */ UserSettingsProvider(ILogger logger, ISingleFileMonitorFactory singleFileMonitorFactory, IFileSystem fileSystem, string settingsFilePath)
+    internal /* for testing */ UserSettingsProvider(
+        ILogger logger,
+        ISingleFileMonitorFactory singleFileMonitorFactory,
+        IFileSystem fileSystem,
+        string settingsFilePath)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         var fileMonitorFactory = singleFileMonitorFactory ?? throw new ArgumentNullException(nameof(singleFileMonitorFactory));
-        this.serializer = new AnalysisSettingsSerializer(fileSystem, logger);
+        serializer = new AnalysisSettingsSerializer(fileSystem, logger);
 
         SettingsFilePath = settingsFilePath;
         settingsFileMonitor = fileMonitorFactory.Create(SettingsFilePath);
@@ -87,6 +91,13 @@ internal sealed class UserSettingsProvider : IUserSettingsProvider, IDisposable
             UserSettings.AnalysisSettings.Rules[ruleId] = new RuleConfig { Level = RuleLevel.Off };
         }
 
+        serializer.SafeSave(SettingsFilePath, UserSettings.AnalysisSettings);
+    }
+
+    public void UpdateFileExclusions(IEnumerable<string> exclusions)
+    {
+        UserSettings.AnalysisSettings.UserDefinedFileExclusions.Clear();
+        UserSettings.AnalysisSettings.UserDefinedFileExclusions.AddRange(exclusions);
         serializer.SafeSave(SettingsFilePath, UserSettings.AnalysisSettings);
     }
 

--- a/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
+++ b/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
@@ -167,5 +167,30 @@ public class FileExclusionsViewModelTests
         testSubject.Exclusions.Should().BeSameAs(initialInstance);
     }
 
-    private void MockUserSettingsProvider(params string[] exclusions) => userSettingsProvider.UserSettings.Returns(new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = exclusions }));
+    [TestMethod]
+    public void SaveExclusions_SavesExclusions()
+    {
+        testSubject.Exclusions.Add(new ExclusionViewModel(Pattern1));
+        testSubject.Exclusions.Add(new ExclusionViewModel(Pattern2));
+
+        testSubject.SaveExclusions();
+
+        userSettingsProvider.Received(1).UpdateFileExclusions(Arg.Is<IEnumerable<string>>(x => x.SequenceEqual(new List<string> { Pattern1, Pattern2 })));
+    }
+
+    [TestMethod]
+    public void SaveExclusions_InvalidPatterns_RemovesInvalidPatternsBeforeSave()
+    {
+        testSubject.Exclusions.Add(new ExclusionViewModel(Pattern1));
+        testSubject.Exclusions.Add(new ExclusionViewModel(string.Empty));
+        testSubject.Exclusions.Add(new ExclusionViewModel(Pattern2));
+        testSubject.Exclusions.Add(new ExclusionViewModel(null));
+
+        testSubject.SaveExclusions();
+
+        userSettingsProvider.Received(1).UpdateFileExclusions(Arg.Is<IEnumerable<string>>(x => x.SequenceEqual(new List<string> { Pattern1, Pattern2 })));
+    }
+
+    private void MockUserSettingsProvider(params string[] exclusions) =>
+        userSettingsProvider.UserSettings.Returns(new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = exclusions.ToList() }));
 }

--- a/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
+++ b/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
@@ -139,5 +139,33 @@ public class FileExclusionsViewModelTests
         browserService.Received().Navigate(uri);
     }
 
+    [TestMethod]
+    public void InitializeExclusions_InitializesExclusionsAndSelectedExclusionProperty()
+    {
+        MockUserSettingsProvider(Pattern1, Pattern2);
+
+        testSubject.InitializeExclusions();
+
+        testSubject.Exclusions.Should().HaveCount(2);
+        testSubject.Exclusions[0].Pattern.Should().Contain(Pattern1);
+        testSubject.Exclusions[1].Pattern.Should().Contain(Pattern2);
+        testSubject.SelectedExclusion.Should().Be(testSubject.Exclusions[0]);
+    }
+
+    [TestMethod]
+    public void InitializeExclusions_InvokedMultipleTimes_DoesNotOverrideExclusionsCollection()
+    {
+        var initialInstance = testSubject.Exclusions;
+        userSettingsProvider.UserSettings.Returns(
+            new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = [Pattern1] }),
+            new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = [Pattern2] })
+        );
+
+        testSubject.InitializeExclusions();
+        testSubject.InitializeExclusions();
+
+        testSubject.Exclusions.Should().BeSameAs(initialInstance);
+    }
+
     private void MockUserSettingsProvider(params string[] exclusions) => userSettingsProvider.UserSettings.Returns(new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = exclusions }));
 }

--- a/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
+++ b/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
@@ -46,16 +46,6 @@ public class FileExclusionsViewModelTests
     }
 
     [TestMethod]
-    public void Ctor_ExclusionsExistInUserSettingsFile_InitializesSelectedExclusion()
-    {
-        MockUserSettingsProvider(Pattern1, Pattern2);
-
-        testSubject = new FileExclusionsViewModel(browserService, userSettingsProvider);
-
-        testSubject.SelectedExclusion.Should().Be(testSubject.Exclusions[0]);
-    }
-
-    [TestMethod]
     public void SelectedExclusion_Setter_RaisesEvents()
     {
         var eventHandler = Substitute.For<PropertyChangedEventHandler>();

--- a/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
+++ b/src/Integration.Vsix.UnitTests/Settings/FileExclusions/FileExclusionsViewModelTests.cs
@@ -46,18 +46,6 @@ public class FileExclusionsViewModelTests
     }
 
     [TestMethod]
-    public void Ctor_ExclusionsExistInUserSettingsFile_InitializesExclusions()
-    {
-        MockUserSettingsProvider(Pattern1, Pattern2);
-
-        testSubject = new FileExclusionsViewModel(browserService, userSettingsProvider);
-
-        testSubject.Exclusions.Should().HaveCount(2);
-        testSubject.Exclusions[0].Pattern.Should().Contain(Pattern1);
-        testSubject.Exclusions[1].Pattern.Should().Contain(Pattern2);
-    }
-
-    [TestMethod]
     public void Ctor_ExclusionsExistInUserSettingsFile_InitializesSelectedExclusion()
     {
         MockUserSettingsProvider(Pattern1, Pattern2);

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsDialogPage.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsDialogPage.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using Microsoft.VisualStudio.Shell;
@@ -47,5 +48,11 @@ internal class FileExclusionsDialogPage : UIElementDialogPage
             }
             return viewModel;
         }
+    }
+
+    protected override void OnActivate(CancelEventArgs e)
+    {
+        ViewModel.InitializeExclusions();
+        base.OnActivate(e);
     }
 }

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsDialogPage.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsDialogPage.cs
@@ -55,4 +55,13 @@ internal class FileExclusionsDialogPage : UIElementDialogPage
         ViewModel.InitializeExclusions();
         base.OnActivate(e);
     }
+
+    protected override void OnApply(PageApplyEventArgs e)
+    {
+        if (e.ApplyBehavior == ApplyKind.Apply)
+        {
+            ViewModel.SaveExclusions();
+        }
+        base.OnApply(e);
+    }
 }

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsDialogPage.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsDialogPage.cs
@@ -22,6 +22,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using Microsoft.VisualStudio.Shell;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.UserRuleSettings;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Settings.FileExclusions;
 
@@ -41,7 +42,8 @@ internal class FileExclusionsDialogPage : UIElementDialogPage
             if (viewModel == null)
             {
                 var browserService = Site.GetMefService<IBrowserService>();
-                viewModel = new FileExclusionsViewModel(browserService);
+                var userSettingsProvider = Site.GetMefService<IUserSettingsProvider>();
+                viewModel = new FileExclusionsViewModel(browserService, userSettingsProvider);
             }
             return viewModel;
         }

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
@@ -20,13 +20,23 @@
 
 using System.Collections.ObjectModel;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.UserRuleSettings;
 using SonarLint.VisualStudio.Core.WPF;
 
 namespace SonarLint.VisualStudio.Integration.Vsix.Settings.FileExclusions;
 
-internal class FileExclusionsViewModel(IBrowserService browserService) : ViewModelBase
+internal class FileExclusionsViewModel : ViewModelBase
 {
     private ExclusionViewModel selectedExclusion;
+    private readonly IBrowserService browserService;
+    private readonly IUserSettingsProvider userSettingsProvider;
+
+    public FileExclusionsViewModel(IBrowserService browserService, IUserSettingsProvider userSettingsProvider)
+    {
+        this.browserService = browserService;
+        this.userSettingsProvider = userSettingsProvider;
+        InitializeExclusions();
+    }
 
     public bool CanExecuteDelete => SelectedExclusion != null;
     public ObservableCollection<ExclusionViewModel> Exclusions { get; } = [];
@@ -59,5 +69,13 @@ internal class FileExclusionsViewModel(IBrowserService browserService) : ViewMod
         }
         Exclusions.Remove(SelectedExclusion);
         SelectedExclusion = null;
+    }
+
+    private void InitializeExclusions()
+    {
+        Exclusions.Clear();
+        var exclusionViewModels = userSettingsProvider.UserSettings.AnalysisSettings.NormalizedFileExclusions.Select(ex => new ExclusionViewModel(ex));
+        exclusionViewModels.ToList().ForEach(vm => Exclusions.Add(vm));
+        SelectedExclusion = Exclusions.FirstOrDefault();
     }
 }

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
@@ -78,4 +78,10 @@ internal class FileExclusionsViewModel : ViewModelBase
         exclusionViewModels.ToList().ForEach(vm => Exclusions.Add(vm));
         SelectedExclusion = Exclusions.FirstOrDefault();
     }
+
+    internal void SaveExclusions()
+    {
+        var exclusionsToSave = Exclusions.Where(vm => vm.Error == null).Select(vm => vm.Pattern);
+        userSettingsProvider.UpdateFileExclusions(exclusionsToSave);
+    }
 }

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
@@ -74,7 +74,7 @@ internal class FileExclusionsViewModel : ViewModelBase
     internal void InitializeExclusions()
     {
         Exclusions.Clear();
-        var exclusionViewModels = userSettingsProvider.UserSettings.AnalysisSettings.NormalizedFileExclusions.Select(ex => new ExclusionViewModel(ex));
+        var exclusionViewModels = userSettingsProvider.UserSettings.AnalysisSettings.UserDefinedFileExclusions.Select(ex => new ExclusionViewModel(ex));
         exclusionViewModels.ToList().ForEach(vm => Exclusions.Add(vm));
         SelectedExclusion = Exclusions.FirstOrDefault();
     }

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
@@ -35,7 +35,6 @@ internal class FileExclusionsViewModel : ViewModelBase
     {
         this.browserService = browserService;
         this.userSettingsProvider = userSettingsProvider;
-        InitializeExclusions();
     }
 
     public bool CanExecuteDelete => SelectedExclusion != null;

--- a/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
+++ b/src/Integration.Vsix/Settings/FileExclusions/FileExclusionsViewModel.cs
@@ -71,7 +71,7 @@ internal class FileExclusionsViewModel : ViewModelBase
         SelectedExclusion = null;
     }
 
-    private void InitializeExclusions()
+    internal void InitializeExclusions()
     {
         Exclusions.Clear();
         var exclusionViewModels = userSettingsProvider.UserSettings.AnalysisSettings.NormalizedFileExclusions.Select(ex => new ExclusionViewModel(ex));

--- a/src/SLCore.Listeners.UnitTests/Implementation/GetFileExclusionsListenerTests.cs
+++ b/src/SLCore.Listeners.UnitTests/Implementation/GetFileExclusionsListenerTests.cs
@@ -119,7 +119,7 @@ public class GetFileExclusionsListenerTests
     }
 
     private void MockUserSettingsFileExclusions(params string[] fileExclusions) =>
-        userSettingsProvider.UserSettings.Returns(new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = fileExclusions }));
+        userSettingsProvider.UserSettings.Returns(new UserSettings(new AnalysisSettings { UserDefinedFileExclusions = fileExclusions.ToList() }));
 
     private void MockCurrentConfigScope(string id) => activeConfigScopeTracker.Current.Returns(id != null ? new ConfigurationScope(id) : null);
 }


### PR DESCRIPTION
[SLVS-2068](https://sonarsource.atlassian.net/browse/SLVS-2068)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6157) in which the UI for file exclusions was added.

[SLVS-2068]: https://sonarsource.atlassian.net/browse/SLVS-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ