### PR TITLE
SLVS-2021 Update to SLCore 10.20 release and fix breaking change caused by FeatureFlagsDto being dropped.

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -10,7 +10,7 @@
     <EmbeddedSonarHtmlAnalyzerVersion>3.19.0.5695</EmbeddedSonarHtmlAnalyzerVersion>
     <EmbeddedSonarSecretsJarVersion>2.22.0.5855</EmbeddedSonarSecretsJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->
-    <EmbeddedSloopVersion>10.19.1.80951</EmbeddedSloopVersion>
+    <EmbeddedSloopVersion>10.20.0.80985</EmbeddedSloopVersion>
     <EmbeddedEsLintBridgeVersion>1.0.0</EmbeddedEsLintBridgeVersion>
   </PropertyGroup>
 </Project>

--- a/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
+++ b/src/Integration.UnitTests/SLCore/SLCoreConstantsProviderTests.cs
@@ -68,21 +68,21 @@ public class SLCoreConstantsProviderTests
     }
 
     [TestMethod]
-    public void FeatureFlags_ShouldBeExpected()
+    public void BackendCapabilities_ShouldBeExpected()
     {
-        var expectedFeatureFlags = new FeatureFlagsDto(taintVulnerabilitiesEnabled: true,
-            shouldSynchronizeProjects: true,
-            shouldManageLocalServer: true,
-            enableSecurityHotspots: true,
-            shouldManageServerSentEvents: true,
-            enableDataflowBugDetection: false,
-            shouldManageFullSynchronization: true,
-            enableTelemetry: true,
-            canOpenFixSuggestion: true,
-            enableMonitoring: true);
-        var actual = testSubject.FeatureFlags;
+        HashSet<BackendCapability> expectedBackendCapabilities =
+        [
+            BackendCapability.PROJECT_SYNCHRONIZATION,
+            BackendCapability.EMBEDDED_SERVER,
+            BackendCapability.SECURITY_HOTSPOTS,
+            BackendCapability.SERVER_SENT_EVENTS,
+            BackendCapability.FULL_SYNCHRONIZATION,
+            BackendCapability.TELEMETRY,
+            BackendCapability.MONITORING,
+        ];
+        var actual = testSubject.BackendCapabilities;
 
-        actual.Should().BeEquivalentTo(expectedFeatureFlags);
+        actual.Should().BeEquivalentTo(expectedBackendCapabilities);
     }
 
     [TestMethod]

--- a/src/Integration/SLCore/SLCoreConstantsProvider.cs
+++ b/src/Integration/SLCore/SLCoreConstantsProvider.cs
@@ -33,18 +33,16 @@ namespace SonarLint.VisualStudio.Integration.SLCore;
 public class SLCoreConstantsProvider(IUserAgentProvider userAgentProvider, IVsInfoProvider vsInfoProvider) : ISLCoreConstantsProvider
 {
     public ClientConstantInfoDto ClientConstants => new(vsInfoProvider.Name, userAgentProvider.UserAgent);
-
-    public FeatureFlagsDto FeatureFlags =>
-        new(taintVulnerabilitiesEnabled: true,
-            shouldSynchronizeProjects: true,
-            shouldManageLocalServer: true,
-            enableSecurityHotspots: true,
-            shouldManageServerSentEvents: true,
-            enableDataflowBugDetection: false,
-            shouldManageFullSynchronization: true,
-            enableTelemetry: true,
-            canOpenFixSuggestion: true,
-            enableMonitoring: true);
+    public HashSet<BackendCapability> BackendCapabilities =>
+    [
+        BackendCapability.PROJECT_SYNCHRONIZATION,
+        BackendCapability.EMBEDDED_SERVER,
+        BackendCapability.SECURITY_HOTSPOTS,
+        BackendCapability.SERVER_SENT_EVENTS,
+        BackendCapability.FULL_SYNCHRONIZATION,
+        BackendCapability.TELEMETRY,
+        BackendCapability.MONITORING
+    ];
 
     public TelemetryClientConstantAttributesDto TelemetryConstants =>
         new("visualstudio", "SonarLint Visual Studio", VersionHelper.SonarLintVersion, VisualStudioHelpers.VisualStudioVersion,

--- a/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
+++ b/src/SLCore.IntegrationTests/SLCoreTestRunner.cs
@@ -95,7 +95,11 @@ public sealed class SLCoreTestRunner : IDisposable
             var sLCoreLanguageProvider = Substitute.For<ISLCoreLanguageProvider>();
             var constantsProvider = Substitute.For<ISLCoreConstantsProvider>();
             constantsProvider.ClientConstants.Returns(new ClientConstantInfoDto("SLVS_Integration_Tests", $"SLVS_Integration_Tests/{VersionHelper.SonarLintVersion}"));
-            constantsProvider.FeatureFlags.Returns(new FeatureFlagsDto(true, true, false, true, false, false, true, false, false, false));
+            constantsProvider.BackendCapabilities.Returns([
+                BackendCapability.PROJECT_SYNCHRONIZATION,
+                BackendCapability.SECURITY_HOTSPOTS,
+                BackendCapability.FULL_SYNCHRONIZATION
+            ]);
             constantsProvider.TelemetryConstants.Returns(new TelemetryClientConstantAttributesDto("slvs_integration_tests", "SLVS Integration Tests",
                 VersionHelper.SonarLintVersion, "17.0", new()));
             SetLanguagesConfigurationToDefaults(sLCoreLanguageProvider);

--- a/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
+++ b/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
@@ -46,7 +46,7 @@ public class SLCoreInstanceHandleTests
     private const string UserHome = "userHomeSl";
 
     private static readonly ClientConstantInfoDto ClientConstantInfo = new(default, default);
-    private static readonly FeatureFlagsDto FeatureFlags = new(default, default, default, default, default, default, default, default, default, default);
+    private static readonly HashSet<BackendCapability> BackendCapabilities = [BackendCapability.PROJECT_SYNCHRONIZATION];
     private static readonly TelemetryClientConstantAttributesDto TelemetryConstants = new(default, default, default, default, default);
 
     private static readonly SonarQubeConnectionConfigurationDto SonarQubeConnection1 = new("sq1", true, "http://localhost/");
@@ -139,7 +139,7 @@ public class SLCoreInstanceHandleTests
             slCoreRpcFactory.StartNewRpcInstance();
             lifecycleManagement.Initialize(Arg.Is<InitializeParams>(parameters =>
                 parameters.clientConstantInfo == ClientConstantInfo
-                && parameters.featureFlags == FeatureFlags
+                && parameters.backendCapabilities == BackendCapabilities
                 && parameters.storageRoot == StorageRoot
                 && parameters.workDir == WorkDir
                 && parameters.embeddedPluginPaths == JarList
@@ -280,7 +280,7 @@ public class SLCoreInstanceHandleTests
         SetUpSLCoreRpcFactory(slCoreRpcFactory, out rpc);
         SetUpSLCoreServiceProvider(serviceProvider, out lifecycleManagement);
         constantsProvider.ClientConstants.Returns(ClientConstantInfo);
-        constantsProvider.FeatureFlags.Returns(FeatureFlags);
+        constantsProvider.BackendCapabilities.Returns(BackendCapabilities);
         constantsProvider.TelemetryConstants.Returns(TelemetryConstants);
 
         foldersProvider.GetWorkFolders().Returns(new SLCoreFolders(StorageRoot, WorkDir, UserHome));

--- a/src/SLCore.UnitTests/Service/Lifecycle/InitializeParamsTests.cs
+++ b/src/SLCore.UnitTests/Service/Lifecycle/InitializeParamsTests.cs
@@ -36,7 +36,15 @@ public class InitializeParamsTests
         var testSubject = new InitializeParams(
             new ClientConstantInfoDto("TESTname", "TESTagent"),
             new HttpConfigurationDto(new SslConfigurationDto()),
-            new FeatureFlagsDto(false, true, false, true, false, true, false, false, false, false),
+            [
+                BackendCapability.PROJECT_SYNCHRONIZATION,
+                BackendCapability.EMBEDDED_SERVER,
+                BackendCapability.SECURITY_HOTSPOTS,
+                BackendCapability.SERVER_SENT_EVENTS,
+                BackendCapability.FULL_SYNCHRONIZATION,
+                BackendCapability.TELEMETRY,
+                BackendCapability.MONITORING,
+            ],
             "storageRoot",
             "workDir",
             ["myplugin1", "myplugin2"],
@@ -70,18 +78,15 @@ public class InitializeParamsTests
                                         "httpConfiguration": {
                                           "sslConfiguration": {}
                                         },
-                                        "featureFlags": {
-                                          "taintVulnerabilitiesEnabled": false,
-                                          "shouldSynchronizeProjects": true,
-                                          "shouldManageLocalServer": false,
-                                          "enableSecurityHotspots": true,
-                                          "shouldManageServerSentEvents": false,
-                                          "enableDataflowBugDetection": true,
-                                          "shouldManageFullSynchronization": false,
-                                          "enableTelemetry": false,
-                                          "canOpenFixSuggestion": false,
-                                          "enableMonitoring": false
-                                        },
+                                        "backendCapabilities": [
+                                          "PROJECT_SYNCHRONIZATION",
+                                          "EMBEDDED_SERVER",
+                                          "SECURITY_HOTSPOTS",
+                                          "SERVER_SENT_EVENTS",
+                                          "FULL_SYNCHRONIZATION",
+                                          "TELEMETRY",
+                                          "MONITORING"
+                                        ],
                                         "storageRoot": "storageRoot",
                                         "workDir": "workDir",
                                         "embeddedPluginPaths": [

--- a/src/SLCore/Configuration/ISLCoreConstantsProvider.cs
+++ b/src/SLCore/Configuration/ISLCoreConstantsProvider.cs
@@ -25,6 +25,6 @@ namespace SonarLint.VisualStudio.SLCore.Configuration;
 public interface ISLCoreConstantsProvider
 {
     ClientConstantInfoDto ClientConstants { get; }
-    FeatureFlagsDto FeatureFlags { get; }
+    HashSet<BackendCapability> BackendCapabilities { get; }
     TelemetryClientConstantAttributesDto TelemetryConstants { get; }
 }

--- a/src/SLCore/ISLCoreInstanceHandle.cs
+++ b/src/SLCore/ISLCoreInstanceHandle.cs
@@ -109,7 +109,7 @@ internal sealed class SLCoreInstanceHandle : ISLCoreInstanceHandle
         lifecycleManagementSlCoreService.Initialize(new InitializeParams(
             constantsProvider.ClientConstants,
             new HttpConfigurationDto(new SslConfigurationDto()),
-            constantsProvider.FeatureFlags,
+            constantsProvider.BackendCapabilities,
             storageRoot,
             workDir,
             embeddedPluginPaths: slCoreEmbeddedPluginJarProvider.ListJarFiles(),

--- a/src/SLCore/Service/Lifecycle/InitializeParams.cs
+++ b/src/SLCore/Service/Lifecycle/InitializeParams.cs
@@ -31,7 +31,7 @@ namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle
     public record InitializeParams(
         ClientConstantInfoDto clientConstantInfo,
         HttpConfigurationDto httpConfiguration,
-        FeatureFlagsDto featureFlags,
+        HashSet<BackendCapability> backendCapabilities,
         string storageRoot,
         string workDir,
         List<string> embeddedPluginPaths,

--- a/src/SLCore/Service/Lifecycle/Models/BackendCapability.cs
+++ b/src/SLCore/Service/Lifecycle/Models/BackendCapability.cs
@@ -18,17 +18,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace SonarLint.VisualStudio.SLCore.Service.Lifecycle.Models;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum BackendCapability
 {
-    public record FeatureFlagsDto(
-        bool taintVulnerabilitiesEnabled,
-        bool shouldSynchronizeProjects,
-        bool shouldManageLocalServer,
-        bool enableSecurityHotspots,
-        bool shouldManageServerSentEvents,
-        bool enableDataflowBugDetection,
-        bool shouldManageFullSynchronization,
-        bool enableTelemetry,
-        bool canOpenFixSuggestion,
-        bool enableMonitoring);
+    SMART_NOTIFICATIONS,
+    PROJECT_SYNCHRONIZATION,
+    EMBEDDED_SERVER,
+    SECURITY_HOTSPOTS,
+    SERVER_SENT_EVENTS,
+    DATAFLOW_BUG_DETECTION,
+    FULL_SYNCHRONIZATION,
+    TELEMETRY,
+    MONITORING
 }


### PR DESCRIPTION
[SLVS-2021](https://sonarsource.atlassian.net/browse/SLVS-2021)



[SLVS-2021]: https://sonarsource.atlassian.net/browse/SLVS-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ