### PR TITLE
SLVS-2074 Fix inactive rules are no longer disabled on connected mode

### DIFF
--- a/src/ConnectedMode/Binding/SonarQubeRuleStatus.cs
+++ b/src/ConnectedMode/Binding/SonarQubeRuleStatus.cs
@@ -28,8 +28,14 @@ public class SonarQubeRoslynRuleStatus(SonarQubeRule sonarQubeRule, IEnvironment
 {
     public string Key => sonarQubeRule.Key;
 
-    public RuleAction GetSeverity() =>
-        GetVsSeverity(sonarQubeRule.SoftwareQualitySeverities?.Values) ?? GetVsSeverity(sonarQubeRule.Severity);
+    public RuleAction GetSeverity()
+    {
+        if (!sonarQubeRule.IsActive)
+        {
+            return RuleAction.None;
+        }
+        return GetVsSeverity(sonarQubeRule.SoftwareQualitySeverities?.Values) ?? GetVsSeverity(sonarQubeRule.Severity);
+    }
 
     private RuleAction? GetVsSeverity(ICollection<SonarQubeSoftwareQualitySeverity> severities) =>
         severities is not { Count: > 0 }

--- a/src/Integration/CSharpVB/GlobalConfigGenerator.cs
+++ b/src/Integration/CSharpVB/GlobalConfigGenerator.cs
@@ -34,7 +34,7 @@ public interface IGlobalConfigGenerator
 public class GlobalConfigGenerator : IGlobalConfigGenerator
 {
     [ImportingConstructor]
-    public GlobalConfigGenerator() {}
+    public GlobalConfigGenerator() { }
 
     public string Generate(IEnumerable<IRoslynRuleStatus> rules)
     {


### PR DESCRIPTION
After refactoring done in this [commit](https://github.com/SonarSource/sonarlint-visualstudio/commit/2929fab489126c6d6fbd41998f4178ecbd57da53#diff-254a46be7d88f94dac16d260e591af3f15d5ef294b16cae324b11e9ef250621bL63), the following code from the `GlobalConfigGenerator` has been removed and never replaced in a different place:

`var severityText = rule.IsActive ? GetActionText(GetVsSeverity(rule)) : inactiveRuleActionText;`

[SLVS-2074](https://sonarsource.atlassian.net/browse/SLVS-2074)



[SLVS-2074]: https://sonarsource.atlassian.net/browse/SLVS-2074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ