### PR TITLE
SLVS-2076 File exclusion improvements

### DIFF
--- a/src/Core.UnitTests/UserRuleSettings/AnalysisSettingsTests.cs
+++ b/src/Core.UnitTests/UserRuleSettings/AnalysisSettingsTests.cs
@@ -227,7 +227,7 @@ public class AnalysisSettingsTests
         var testSubject = new AnalysisSettings([], [invalidPath]);
 
         testSubject.UserDefinedFileExclusions.Should().BeEquivalentTo(invalidPath);
-        testSubject.NormalizedFileExclusions.Should().BeEquivalentTo(invalidPath);
+        testSubject.NormalizedFileExclusions.Should().BeEquivalentTo(invalidPath?.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
     }
 
     public static object[][] GetInvalidPaths =>

--- a/src/Core/UserRuleSettings/AnalysisSettings.cs
+++ b/src/Core/UserRuleSettings/AnalysisSettings.cs
@@ -95,11 +95,15 @@ public class AnalysisSettings
 
     private static string NormalizePath(string path)
     {
-        // rooted paths without drive letter are unmodified, but SLCore doesn't match them well
-        var isRooted = HasInvalidPathChars(path) || Path.IsPathRooted(path);
-
         path = path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        // if path is invalid, the Path.IsPathRooted check will throw an exception
+        if (HasInvalidPathChars(path))
+        {
+            return path;
+        }
 
+        // rooted paths without drive letter are unmodified, but SLCore doesn't match them well
+        var isRooted = Path.IsPathRooted(path);
         if (!isRooted && !path.StartsWith(AnyRootPrefix))
         {
             path = AnyRootPrefix + path;

--- a/src/Core/UserRuleSettings/AnalysisSettings.cs
+++ b/src/Core/UserRuleSettings/AnalysisSettings.cs
@@ -95,14 +95,8 @@ public class AnalysisSettings
 
     private static string NormalizePath(string path)
     {
-        var invalidChars = Path.GetInvalidPathChars();
-        if (path.IndexOfAny(invalidChars) >= 0)
-        {
-            return path;
-        }
-
         // rooted paths without drive letter are unmodified, but SLCore doesn't match them well
-        var isRooted = Path.IsPathRooted(path);
+        var isRooted = HasInvalidPathChars(path) || Path.IsPathRooted(path);
 
         path = path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
@@ -112,6 +106,12 @@ public class AnalysisSettings
         }
 
         return path;
+    }
+
+    private static bool HasInvalidPathChars(string path)
+    {
+        var invalidChars = Path.GetInvalidPathChars();
+        return path.IndexOfAny(invalidChars) >= 0;
     }
 }
 

--- a/src/Core/UserRuleSettings/AnalysisSettings.cs
+++ b/src/Core/UserRuleSettings/AnalysisSettings.cs
@@ -95,6 +95,12 @@ public class AnalysisSettings
 
     private static string NormalizePath(string path)
     {
+        var invalidChars = Path.GetInvalidPathChars();
+        if (path.IndexOfAny(invalidChars) >= 0)
+        {
+            return path;
+        }
+
         // rooted paths without drive letter are unmodified, but SLCore doesn't match them well
         var isRooted = Path.IsPathRooted(path);
 

--- a/src/Integration.Vsix/Settings/FileExclusions/AddExclusionDialog.xaml
+++ b/src/Integration.Vsix/Settings/FileExclusions/AddExclusionDialog.xaml
@@ -15,16 +15,20 @@
         x:Name="This">
     <Window.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/SonarLint.VisualStudio.ConnectedMode;component/UI/Resources/Styles.xaml" />
-            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="Button">
+                <Setter Property="MinHeight" Value="25" />
+                <Setter Property="MinWidth" Value="75" />
+                <Setter Property="Margin" Value="10,0,0,0" />
+                <Setter Property="Padding" Value="5,2"/>
+            </Style>
+            <Style TargetType="TextBox">
+                <Setter Property="Height" Value="30" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+            </Style>
             <wpf:BoolToVisibilityConverter x:Key="TrueToVisibleConverter" FalseValue="Hidden" TrueValue="Visible"/>
             <wpf:BoolNegatingConverter x:Key="BoolNegatingConverter"/>
         </ResourceDictionary>
     </Window.Resources>
-    <Window.Style>
-        <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}" />
-    </Window.Style>
 
     <Grid DataContext="{Binding ElementName=This, Path=ViewModel}" Margin="15">
         <Grid.RowDefinitions>


### PR DESCRIPTION
[SLVS-2076](https://sonarsource.atlassian.net/browse/SLVS-2076)

- The "AddExclusionDialog" changes background color on dark mode. The Options page does not change its color, so we should keep it consistent
- Fix exception when normalizing paths and path contains invalid characters

[SLVS-2076]: https://sonarsource.atlassian.net/browse/SLVS-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ