### PR TITLE
SLVS-2144 Fix issues can not be muted in some cases the first time a solution is opened

### DIFF
--- a/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
+++ b/src/SLCore.UnitTests/SLCoreInstanceHandleTests.cs
@@ -153,6 +153,7 @@ public class SLCoreInstanceHandleTests
                 && parameters.languageSpecificRequirements.jsTsRequirements.clientNodeJsPath == nodeJsPath
                 && parameters.languageSpecificRequirements.jsTsRequirements.bundlePath == esLintBridgePath
                 && parameters.telemetryMigration == telemetryMigrationDto));
+            activeSolutionBoundTracker.InitializationProcessor.InitializeAsync();
             configScopeUpdater.UpdateConfigScopeForCurrentSolution(Binding);
         });
     }

--- a/src/SLCore/ISLCoreInstanceHandle.cs
+++ b/src/SLCore/ISLCoreInstanceHandle.cs
@@ -132,6 +132,7 @@ internal sealed class SLCoreInstanceHandle : ISLCoreInstanceHandle
 
     private async Task UpdateConfigurationScopeForCurrentSolutionAsync()
     {
+        // this case does not follow the pattern of implementing the IRequireInitialization as it would not be worth the effort 
         await activeSolutionBoundTracker.InitializationProcessor.InitializeAsync();
         configScopeUpdater.UpdateConfigScopeForCurrentSolution(activeSolutionBoundTracker.CurrentConfiguration.Project);
     }

--- a/src/SLCore/ISLCoreInstanceHandle.cs
+++ b/src/SLCore/ISLCoreInstanceHandle.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.VisualStudio.Threading;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.ConfigurationScope;
@@ -126,6 +127,12 @@ internal sealed class SLCoreInstanceHandle : ISLCoreInstanceHandle
             telemetryMigrationProvider.Get(),
             new LanguageSpecificRequirements(new JsTsRequirementsDto(nodeLocator.Get(), esLintBridgeLocator.Get()))));
 
+        UpdateConfigurationScopeForCurrentSolutionAsync().Forget();
+    }
+
+    private async Task UpdateConfigurationScopeForCurrentSolutionAsync()
+    {
+        await activeSolutionBoundTracker.InitializationProcessor.InitializeAsync();
         configScopeUpdater.UpdateConfigScopeForCurrentSolution(activeSolutionBoundTracker.CurrentConfiguration.Project);
     }
 


### PR DESCRIPTION
[SLVS-2144](https://sonarsource.atlassian.net/browse/SLVS-2144)

Fix issues can not be muted in some cases the first time a solution is opened by making sure that the `ActiveSolutionBoundTracker` is initialized before updating the configuration scope for the current solution.

[SLVS-2144]: https://sonarsource.atlassian.net/browse/SLVS-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ