### PR TITLE
SLVS-1996 Add extension method as a workaround to avoid await warning CS4014 for NSubstitute assertions

### DIFF
--- a/src/ConnectedMode.UnitTests/SlCoreConnectionAdapterTests.cs
+++ b/src/ConnectedMode.UnitTests/SlCoreConnectionAdapterTests.cs
@@ -77,7 +77,7 @@ public class SlCoreConnectionAdapterTests
 
         await slCoreConnectionAdapter.ValidateConnectionAsync(sonarQubeConnectionInfo, new TokenCredentialsModel("myToken".CreateSecureString()));
 
-        threadHandlingMock.Received(1).RunOnBackgroundThread(Arg.Any<Func<Task<ResponseStatus>>>()).IgnoreAwaitForNSubstituteAssertion();
+        threadHandlingMock.Received(1).RunOnBackgroundThread(Arg.Any<Func<Task<ResponseStatus>>>()).IgnoreAwaitForAssert();
     }
 
     [TestMethod]

--- a/src/ConnectedMode.UnitTests/SlCoreConnectionAdapterTests.cs
+++ b/src/ConnectedMode.UnitTests/SlCoreConnectionAdapterTests.cs
@@ -25,6 +25,7 @@ using SonarLint.VisualStudio.ConnectedMode.UI.OrganizationSelection;
 using SonarLint.VisualStudio.ConnectedMode.UI.ProjectSelection;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
+using SonarLint.VisualStudio.Integration.TestInfrastructure;
 using SonarLint.VisualStudio.SLCore;
 using SonarLint.VisualStudio.SLCore.Common.Models;
 using SonarLint.VisualStudio.SLCore.Core;
@@ -76,7 +77,7 @@ public class SlCoreConnectionAdapterTests
 
         await slCoreConnectionAdapter.ValidateConnectionAsync(sonarQubeConnectionInfo, new TokenCredentialsModel("myToken".CreateSecureString()));
 
-        await threadHandlingMock.Received(1).RunOnBackgroundThread(Arg.Any<Func<Task<ResponseStatus>>>());
+        threadHandlingMock.Received(1).RunOnBackgroundThread(Arg.Any<Func<Task<ResponseStatus>>>()).IgnoreAwaitForNSubstituteAssertion();
     }
 
     [TestMethod]

--- a/src/TestInfrastructure/NSubstituteHelpers.cs
+++ b/src/TestInfrastructure/NSubstituteHelpers.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace SonarLint.VisualStudio.Integration.TestInfrastructure;
+
+public static class NSubstituteHelpers
+{
+    [ExcludeFromCodeCoverage]
+    public static void IgnoreAwaitForNSubstituteAssertion(this Task task)
+    {
+        // workaround to avoid await warning CS4014 in NSubstitute assertions for async method
+    }
+}

--- a/src/TestInfrastructure/NSubstituteHelpers.cs
+++ b/src/TestInfrastructure/NSubstituteHelpers.cs
@@ -24,9 +24,13 @@ namespace SonarLint.VisualStudio.Integration.TestInfrastructure;
 
 public static class NSubstituteHelpers
 {
+    /// <summary>
+    /// Should be used for assertions to avoid warning regarding not awaiting methods when doing a call to .Received().AsyncMethod() with NSubstitute.
+    /// </summary>
+    /// <param name="task"></param>
     [ExcludeFromCodeCoverage]
-    public static void IgnoreAwaitForNSubstituteAssertion(this Task task)
+    public static void IgnoreAwaitForAssert(this Task task)
     {
-        // workaround to avoid await warning CS4014 in NSubstitute assertions for async method
+        // workaround to avoid await warning CS4014 in NSubstitute assertions for async methods
     }
 }


### PR DESCRIPTION
[SLVS-1996](https://sonarsource.atlassian.net/browse/SLVS-1996)



[SLVS-1996]: https://sonarsource.atlassian.net/browse/SLVS-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ