### PR TITLE
Map new C++ LanguageStandard ('c++23preview' and 'c++23')

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/VcxProject/LanguageStandardConverterTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/VcxProject/LanguageStandardConverterTests.cs
@@ -31,6 +31,8 @@ public class LanguageStandardConverterTests
     [DataRow("Default", "")]
     [DataRow(null, "")]
     [DataRow("stdcpplatest", "/std:c++latest")]
+    [DataRow("stdcpp23", "/std:c++23")]
+    [DataRow("stdcpp23preview", "/std:c++23preview")]
     [DataRow("stdcpp20", "/std:c++20")]
     [DataRow("stdcpp17", "/std:c++17")]
     [DataRow("stdcpp14", "/std:c++14")]

--- a/src/Integration.Vsix/CFamily/VcxProject/LanguageStandardConverter.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/LanguageStandardConverter.cs
@@ -27,6 +27,8 @@ internal static class LanguageStandardConverter
         {
             null or "" or "Default" => string.Empty,
             "stdcpplatest" => "/std:c++latest",
+            "stdcpp23" => "/std:c++23",
+            "stdcpp23preview" => "/std:c++23preview",
             "stdcpp20" => "/std:c++20",
             "stdcpp17" => "/std:c++17",
             "stdcpp14" => "/std:c++14",


### PR DESCRIPTION
Part of 
CPP-6599
