### PR TITLE
SLVS-2347 Quick fix cannot be reapplied after same issue re-appearance

### DIFF
--- a/src/IssueViz.UnitTests/Editor/QuickActions/QuickFixes/QuickFixActionsSourceTests.cs
+++ b/src/IssueViz.UnitTests/Editor/QuickActions/QuickFixes/QuickFixActionsSourceTests.cs
@@ -360,7 +360,7 @@ public class QuickFixActionsSourceTests
         return new QuickFixActionsSource(lightBulbBroker,
             bufferTagAggregatorFactoryService.Object,
             textView,
-            textBuffer.CurrentSnapshot,
+            textBuffer,
             Mock.Of<IQuickFixesTelemetryManager>(),
             logger,
             threadHandling);

--- a/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSource.cs
+++ b/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSource.cs
@@ -33,7 +33,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions.QuickFix
 internal sealed class QuickFixActionsSource : ISuggestedActionsSource
 {
     private readonly ILightBulbBroker lightBulbBroker;
-    private readonly ITextSnapshot textSnapshot;
+    private readonly ITextBuffer textBuffer;
     private readonly ITextView textView;
     private readonly ILogger logger;
     private readonly IThreadHandling threadHandling;
@@ -43,19 +43,19 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
     public QuickFixActionsSource(ILightBulbBroker lightBulbBroker,
         IBufferTagAggregatorFactoryService bufferTagAggregatorFactoryService,
         ITextView textView,
-        ITextSnapshot textSnapshot,
+        ITextBuffer textBuffer,
         IQuickFixesTelemetryManager quickFixesTelemetryManager,
         ILogger logger,
         IThreadHandling threadHandling)
     {
         this.lightBulbBroker = lightBulbBroker;
-        this.textSnapshot = textSnapshot;
+        this.textBuffer = textBuffer;
         this.textView = textView;
         this.quickFixesTelemetryManager = quickFixesTelemetryManager;
         this.logger = logger;
         this.threadHandling = threadHandling;
 
-        issueLocationsTagAggregator = bufferTagAggregatorFactoryService.CreateTagAggregator<IIssueLocationTag>(textSnapshot.TextBuffer);
+        issueLocationsTagAggregator = bufferTagAggregatorFactoryService.CreateTagAggregator<IIssueLocationTag>(textBuffer);
         issueLocationsTagAggregator.TagsChanged += TagAggregator_TagsChanged;
     }
 
@@ -74,9 +74,9 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
             {
                 foreach (var issueViz in issuesWithFixes)
                 {
-                    var applicableFixes = issueViz.QuickFixes.Where(x => x.CanBeApplied(textSnapshot));
+                    var applicableFixes = issueViz.QuickFixes.Where(x => x.CanBeApplied(textBuffer.CurrentSnapshot));
 
-                    allActions.AddRange(applicableFixes.Select(fix => new QuickFixSuggestedAction(fix, textSnapshot.TextBuffer, issueViz, quickFixesTelemetryManager, logger)));
+                    allActions.AddRange(applicableFixes.Select(fix => new QuickFixSuggestedAction(fix, textBuffer, issueViz, quickFixesTelemetryManager, logger)));
                 }
             }
         }
@@ -112,7 +112,7 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
             .Select(x => x.Tag.Location)
             .OfType<IAnalysisIssueVisualization>()
             .Where(x =>
-                x.QuickFixes.Any(fix => fix.CanBeApplied(textSnapshot)));
+                x.QuickFixes.Any(fix => fix.CanBeApplied(textBuffer.CurrentSnapshot)));
 
         return issuesWithFixes.Any();
     }

--- a/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSourceProvider.cs
+++ b/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSourceProvider.cs
@@ -60,7 +60,7 @@ internal class QuickFixActionsSourceProvider(
         return new QuickFixActionsSource(lightBulbBroker,
             bufferTagAggregatorFactoryService,
             textView,
-            textBuffer.CurrentSnapshot,
+            textBuffer,
             quickFixesTelemetryManager,
             logger,
             threadHandling);


### PR DESCRIPTION
[SLVS-2347](https://sonarsource.atlassian.net/browse/SLVS-2347)

The application of the QuickFix was based on an older Snapshot, which resulted to be falsely detected as not applicable when there were changes on the current document.

[SLVS-2347]: https://sonarsource.atlassian.net/browse/SLVS-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ