### PR TITLE
Filter out white space path list options

### DIFF
--- a/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
+++ b/src/Integration.Vsix.UnitTests/CFamily/CmdBuilderTests.cs
@@ -216,6 +216,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.CFamily
         [DataRow("StructMemberAlignment", "1Byte", "/Zp1 ")]
         [DataRow("AdditionalIncludeDirectories", "a;;b;c", "/I\"a\" /I\"b\" /I\"c\" ")]
         [DataRow("AdditionalIncludeDirectories", ";;;", "")]
+        [DataRow("AdditionalIncludeDirectories", "; ;;", "")]
         [DataRow("PreprocessorDefinitions", "a;;b;;c;", "/D\"a\" /D\"b\" /D\"c\" ")]
         [DataRow("UndefinePreprocessorDefinitions", ";a;;b;;c;", "/Ua /Ub /Uc ")]
         [DataRow("ForcedIncludeFiles", "a/;;b\\;c\\\\", "/FI\"a\" /FI\"b\" /FI\"c\" ")]

--- a/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
+++ b/src/Integration.Vsix/CFamily/VcxProject/CmdBuilder.cs
@@ -88,10 +88,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
 
             path = DoubleSeparatorRegEx.Replace(path, @"\");
 
-            if (path[path.Length - 1] == '\\')
-            {
-                path = path.Substring(0, path.Length - 1);
-            }
+            path = path.TrimEnd('\\');
             return AddQuote(path);
         }
 
@@ -193,7 +190,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.CFamily.VcxProject
         private void AddPathListOptions(IVCRulePropertyStorage ivcRulePropertyStorage, string vsOption, string compileOption, string[] separator)
         {
             var pathListOptions = ivcRulePropertyStorage.GetEvaluatedPropertyValue(vsOption);
-            string[] opts = pathListOptions.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+            var opts = pathListOptions.Split(separator, StringSplitOptions.RemoveEmptyEntries).Where(o => !string.IsNullOrWhiteSpace(o));
             foreach (string opt in opts)
             {
                 AddCmdOpt(compileOption + AdjustPath(opt));


### PR DESCRIPTION
Ignore white space path list options to avoid index-out-of-range exceptions.