### PR TITLE
SLVS-2354 Send file content to SLCore

### DIFF
--- a/src/Core.UnitTests/SourceFileTests.cs
+++ b/src/Core.UnitTests/SourceFileTests.cs
@@ -23,29 +23,23 @@ namespace SonarLint.VisualStudio.Core.UnitTests;
 [TestClass]
 public class SourceFileTests
 {
-    private const string path = @"C:\Users\Project\JustASourceFile.cs";
-
     [TestMethod]
-    public void SourceFile_NoContent_ContentAndEncodingAreNull()
+    public void SourceFile_EncodingDefaultsToUTF8()
     {
-        var sourceFile = new SourceFile(path);
+        var sourceFile = new SourceFile(@"C:\Users\Project\JustASourceFile.cs");
 
-        sourceFile.FilePath.Should().Be(path);
-        sourceFile.Encoding.Should().BeNull();
-        sourceFile.Content.Should().BeNull();
+        sourceFile.Encoding.Should().Be("utf-8");
     }
 
     [DataTestMethod]
-    [DataRow("a", "windows-1250")]
-    [DataRow("b", "windows-1251")]
-    [DataRow("c", "windows-1252")]
-    [DataRow("d", "iso-8859-15")]
-    public void SourceFile_WithContent(string content, string encoding)
+    [DataRow("windows-1250")]
+    [DataRow("windows-1251")]
+    [DataRow("windows-1252")]
+    [DataRow("iso-8859-15")]
+    public void SourceFile_StoresFileEncoding(string encoding)
     {
-        var sourceFile = new SourceFile(path, new SourceFileContent(content, encoding));
+        var sourceFile = new SourceFile(@"C:\Users\Project\JustASourceFile.cs", encoding);
 
-        sourceFile.FilePath.Should().Be(path);
         sourceFile.Encoding.Should().Be(encoding);
-        sourceFile.Content.Should().Be(content);
     }
 }

--- a/src/Core/DocumentEvents.cs
+++ b/src/Core/DocumentEvents.cs
@@ -27,9 +27,15 @@ public class DocumentEventArgs(Document document) : EventArgs
     public Document Document { get; } = document;
 }
 
-public class DocumentSavedEventArgs(Document document) : DocumentEventArgs(document);
+public class DocumentSavedEventArgs(Document document, string newContent) : DocumentEventArgs(document)
+{
+    public string NewContent { get; } = newContent;
+}
 
-public class DocumentOpenedEventArgs(Document document) : DocumentEventArgs(document);
+public class DocumentOpenedEventArgs(Document document, string content) : DocumentEventArgs(document)
+{
+    public string Content { get; } = content;
+}
 
 public class DocumentRenamedEventArgs(Document document, string oldFilePath) : DocumentEventArgs(document)
 {

--- a/src/Core/SourceFile.cs
+++ b/src/Core/SourceFile.cs
@@ -26,12 +26,10 @@ public record SourceFile
     public string Content { get; }
     public string Encoding { get; }
 
-    public SourceFile(string filePath, SourceFileContent content = null)
+    public SourceFile(string filePath, string encoding = null, string content = null)
     {
         FilePath = filePath;
-        Content = content?.Content;
-        Encoding = content?.Encoding;
+        Content = content;
+        Encoding = encoding ?? System.Text.Encoding.UTF8.WebName;
     }
 }
-
-public record SourceFileContent(string Content, string Encoding);

--- a/src/Integration.Vsix.UnitTests/Analysis/DocumentEventsHandlerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Analysis/DocumentEventsHandlerTests.cs
@@ -175,7 +175,7 @@ public class DocumentEventsHandlerTests
     public void DocumentOpened_CFamily_VcxProject_AddFileToCompilationDbAndNotifiesSlCore()
     {
         CreateAndInitializeTestSubject();
-        var args = new DocumentOpenedEventArgs(CFamilyDocument);
+        var args = new DocumentOpenedEventArgs(CFamilyDocument, string.Empty);
 
         documentTracker.DocumentOpened += Raise.EventWith(documentTracker, args);
 
@@ -189,7 +189,7 @@ public class DocumentEventsHandlerTests
     {
         CreateAndInitializeTestSubject();
         MockCompilationDatabaseType(CompilationDatabaseType.CMake);
-        var args = new DocumentOpenedEventArgs(CFamilyDocument);
+        var args = new DocumentOpenedEventArgs(CFamilyDocument, "content");
 
         documentTracker.DocumentOpened += Raise.EventWith(documentTracker, args);
 
@@ -258,7 +258,7 @@ public class DocumentEventsHandlerTests
     public void DocumentOpened_NonCFamily_DoesNotAddFileToVcxCompilationDbButNotifiesSlCore()
     {
         CreateAndInitializeTestSubject();
-        var args = new DocumentOpenedEventArgs(NonCFamilyDocument);
+        var args = new DocumentOpenedEventArgs(NonCFamilyDocument, string.Empty);
 
         documentTracker.DocumentOpened += Raise.EventWith(documentTracker, args);
 
@@ -284,7 +284,7 @@ public class DocumentEventsHandlerTests
     public void DocumentSaved_CFamily_VcxProject_AddFileToCompilationDb()
     {
         CreateAndInitializeTestSubject();
-        var args = new DocumentSavedEventArgs(CFamilyDocument);
+        var args = new DocumentSavedEventArgs(CFamilyDocument, string.Empty);
 
         documentTracker.DocumentSaved += Raise.EventWith(documentTracker, args);
 
@@ -296,7 +296,7 @@ public class DocumentEventsHandlerTests
     {
         CreateAndInitializeTestSubject();
         MockCompilationDatabaseType(CompilationDatabaseType.CMake);
-        var args = new DocumentSavedEventArgs(CFamilyDocument);
+        var args = new DocumentSavedEventArgs(CFamilyDocument, "content");
 
         documentTracker.DocumentSaved += Raise.EventWith(documentTracker, args);
 
@@ -321,7 +321,7 @@ public class DocumentEventsHandlerTests
     [TestMethod]
     public void DocumentSaved_NonCFamily_DoesNothing()
     {
-        var args = new DocumentSavedEventArgs(NonCFamilyDocument);
+        var args = new DocumentSavedEventArgs(NonCFamilyDocument, string.Empty);
 
         documentTracker.DocumentSaved += Raise.EventWith(documentTracker, args);
 
@@ -334,7 +334,7 @@ public class DocumentEventsHandlerTests
     {
         CreateAndInitializeTestSubject();
         threadHandling.ClearReceivedCalls();
-        var args = new DocumentOpenedEventArgs(CFamilyDocument);
+        var args = new DocumentOpenedEventArgs(CFamilyDocument, string.Empty);
 
         documentTracker.DocumentOpened += Raise.EventWith(documentTracker, args);
 
@@ -389,7 +389,7 @@ public class DocumentEventsHandlerTests
     {
         CreateAndInitializeTestSubject();
         threadHandling.ClearReceivedCalls();
-        var args = new DocumentSavedEventArgs(CFamilyDocument);
+        var args = new DocumentSavedEventArgs(CFamilyDocument, "using System;");
 
         documentTracker.DocumentSaved += Raise.EventWith(documentTracker, args);
 
@@ -405,7 +405,7 @@ public class DocumentEventsHandlerTests
     {
         CreateAndInitializeTestSubject();
         MockFileRpcService(service: null, succeeds: false);
-        var args = new DocumentOpenedEventArgs(CFamilyDocument);
+        var args = new DocumentOpenedEventArgs(CFamilyDocument, string.Empty);
 
         documentTracker.DocumentOpened += Raise.EventWith(documentTracker, args);
 
@@ -448,7 +448,7 @@ public class DocumentEventsHandlerTests
     {
         CreateAndInitializeTestSubject();
         MockCurrentConfigScope(configurationScope: null);
-        var args = new DocumentOpenedEventArgs(CFamilyDocument);
+        var args = new DocumentOpenedEventArgs(CFamilyDocument, string.Empty);
 
         documentTracker.DocumentOpened += Raise.EventWith(documentTracker, args);
 

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -333,7 +333,8 @@ public class TaggerProviderTests
 
         eventHandler.Received(1).Invoke(testSubject, Arg.Is<DocumentOpenedEventArgs>(e =>
             e.Document.FullPath == filePath &&
-            e.Document.DetectedLanguages == DetectedLanguagesJsTs));
+            e.Document.DetectedLanguages == DetectedLanguagesJsTs &&
+            e.Content == content));
     }
 
     [TestMethod]
@@ -346,7 +347,7 @@ public class TaggerProviderTests
 
         testSubject.AddIssueTracker(issueTracker);
 
-        mockFileTracker.Received(1).AddFiles(new SourceFile(filePath, null));
+        mockFileTracker.Received(1).AddFiles(new SourceFile(filePath, encoding: null, content));
     }
 
     [TestMethod]
@@ -388,7 +389,7 @@ public class TaggerProviderTests
 
         RaiseFileEvent(doc, FileActionTypes.ContentSavedToDisk);
 
-        mockFileTracker.Received(1).AddFiles(new SourceFile(filePath, null));
+        mockFileTracker.Received(1).AddFiles(new SourceFile(filePath, encoding: null, content));
     }
 
     [TestMethod]
@@ -440,14 +441,12 @@ public class TaggerProviderTests
     public void AnalysisRequested_CallsAnalyzerRequestAnalysis()
     {
         List<string> filesToaAnalyze = ["file.js"];
-        var content = "content123";
         var analysisExecutingSignal = CreateAnalysisExecutingSignal(filesToaAnalyze);
-        CreateTaggerForDocument(CreateMockedDocument(filesToaAnalyze[0], DetectedLanguagesJsTs, content));
+        CreateTaggerForDocument(CreateMockedDocument(filesToaAnalyze[0], DetectedLanguagesJsTs));
 
         mockAnalysisRequester.AnalysisRequested += Raise.EventWith(this, new AnalysisRequestEventArgs(filesToaAnalyze));
         analysisExecutingSignal.WaitOne(AnalysisTimeout);
 
-        mockFileTracker.Received(1).AddFiles(new SourceFile(filesToaAnalyze[0], new(content, Encoding.UTF8.WebName)));
         analyzer.Received(1).ExecuteAnalysis(Arg.Is<List<string>>(x => x.SequenceEqual(filesToaAnalyze)));
     }
 

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -52,8 +52,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix;
 [PartCreationPolicy(CreationPolicy.Shared)]
 internal sealed class TaggerProvider : ITaggerProvider, IDocumentTracker
 {
-    private static readonly string DefaultContentEncoding = System.Text.Encoding.UTF8.WebName;
-
     internal static readonly Type SingletonManagerPropertyCollectionKey = typeof(SingletonDisposableTaggerManager<IErrorTag>);
     private readonly IAnalyzer analyzer;
     private readonly IFileTracker fileTracker;
@@ -131,7 +129,7 @@ internal sealed class TaggerProvider : ITaggerProvider, IDocumentTracker
                 .Select<IIssueTracker, Action>(it => it.UpdateAnalysisState)
                 .ToList(); // create a fixed list - the user could close a file before the reanalysis completes which would cause the enumeration to change
             var documentsToAnalyzeCount = operations.Count;
-            operations.Add(() => NotifyFileTrackerOpenFilesCurrentState(filteredIssueTrackers));
+            operations.Add(() => NotifyFileTracker(filteredIssueTrackers));
             operations.Add(() => ExecuteAnalysisAsync(filteredIssueTrackers).Forget());
 
             reanalysisProgressHandler = new StatusBarReanalysisProgressHandler(vsStatusBar, logger);
@@ -156,16 +154,15 @@ internal sealed class TaggerProvider : ITaggerProvider, IDocumentTracker
         return issueTrackers.Where(it => filePaths.Contains(it.LastAnalysisFilePath, StringComparer.OrdinalIgnoreCase));
     }
 
-    private void NotifyFileTrackerFileChanged(string filePath) => fileTracker.AddFiles(CreateSourceFile(filePath));
+    private void NotifyFileTracker(string filePath, string content) => fileTracker.AddFiles(CreateSourceFile(filePath, content));
 
-    private void NotifyFileTrackerOpenFilesCurrentState(IEnumerable<IIssueTracker> filteredIssueTrackers)
+    private void NotifyFileTracker(IEnumerable<IIssueTracker> filteredIssueTrackers)
     {
-        // still sending the content here because the files may be dirty in this case
-        var sourceFilesToUpdate = filteredIssueTrackers.Select(file => CreateSourceFile(file.LastAnalysisFilePath, file.GetText()));
+        var sourceFilesToUpdate = filteredIssueTrackers.Select(it => CreateSourceFile(it.LastAnalysisFilePath, it.GetText()));
         fileTracker.AddFiles(sourceFilesToUpdate.ToArray());
     }
 
-    private static SourceFile CreateSourceFile(string filePath, string content = null) => new(filePath, content is null ? null : new SourceFileContent(content, DefaultContentEncoding));
+    private static SourceFile CreateSourceFile(string filePath, string content) => new(filePath, content: content);
 
     #region IViewTaggerProvider members
 
@@ -237,19 +234,20 @@ internal sealed class TaggerProvider : ITaggerProvider, IDocumentTracker
         }
 
         var filePath = issueTracker.LastAnalysisFilePath;
+        var content = issueTracker.GetText();
 
-        NotifyFileTrackerFileChanged(filePath);
+        NotifyFileTracker(filePath, content);
         // The lifetime of an issue tracker is tied to a single document. A document is opened, then a tracker is created.
-        DocumentOpened?.Invoke(this, new DocumentOpenedEventArgs(new Document(filePath, issueTracker.DetectedLanguages)));
+        DocumentOpened?.Invoke(this, new DocumentOpenedEventArgs(new Document(filePath, issueTracker.DetectedLanguages), content));
     }
 
     public void OnOpenDocumentRenamed(string newFilePath, string oldFilePath, IEnumerable<AnalysisLanguage> detectedLanguages) =>
         OpenDocumentRenamed?.Invoke(this, new DocumentRenamedEventArgs(new Document(newFilePath, detectedLanguages), oldFilePath));
 
-    public void OnDocumentSaved(string fullPath, IEnumerable<AnalysisLanguage> detectedLanguages)
+    public void OnDocumentSaved(string fullPath, string newContent, IEnumerable<AnalysisLanguage> detectedLanguages)
     {
-        NotifyFileTrackerFileChanged(fullPath);
-        DocumentSaved?.Invoke(this, new DocumentSavedEventArgs(new Document(fullPath, detectedLanguages)));
+        NotifyFileTracker(fullPath, newContent);
+        DocumentSaved?.Invoke(this, new DocumentSavedEventArgs(new Document(fullPath, detectedLanguages), newContent));
     }
 
     public void OnDocumentClosed(IIssueTracker issueTracker)

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -130,7 +130,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
                 case FileActionTypes.ContentSavedToDisk:
                     {
                         UpdateAnalysisState();
-                        Provider.OnDocumentSaved(document.FilePath, DetectedLanguages);
+                        Provider.OnDocumentSaved(document.FilePath, GetText(), DetectedLanguages);
                         break;
                     }
                 case FileActionTypes.DocumentRenamed:

--- a/src/SLCore.UnitTests/Common/Helpers/ClientFileDtoFactoryTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/ClientFileDtoFactoryTests.cs
@@ -84,11 +84,10 @@ public class ClientFileDtoFactoryTests
     public void Create_WithContent_ConstructsValidDto()
     {
         const string content = "somecontent";
-        const string encoding = "someencoding";
 
-        var result = testSubject.CreateOrNull("CONFIG_SCOPE_ID", @"C:\", new SourceFile(@"C:\Code\Project\File1.js", new SourceFileContent(content, encoding)));
+        var result = testSubject.CreateOrNull("CONFIG_SCOPE_ID", @"C:\", new SourceFile(@"C:\Code\Project\File1.js", content: content));
 
-        ValidateDto(result, @"C:\Code\Project\File1.js", @"Code\Project\File1.js", expectedContent: content, expectedCharset: encoding);
+        ValidateDto(result, @"C:\Code\Project\File1.js", @"Code\Project\File1.js", expectedContent: content);
     }
 
     [TestMethod]
@@ -170,14 +169,14 @@ public class ClientFileDtoFactoryTests
         testLogger.AssertPartialOutputStringExists(string.Format(SLCoreStrings.ClientFile_NotRelative_Skipped, filePath, rootPath));
     }
 
-    private static void ValidateDto(ClientFileDto actual, string expectedFsPath, string expectedIdeRelativePath, string expectedContent = null, string expectedCharset = null)
+    private static void ValidateDto(ClientFileDto actual, string expectedFsPath, string expectedIdeRelativePath, string expectedContent = null)
     {
         actual.Should().BeEquivalentTo(new ClientFileDto(
             new FileUri(expectedFsPath),
             expectedIdeRelativePath,
             "CONFIG_SCOPE_ID",
             null,
-            expectedCharset,
+            "utf-8",
             expectedFsPath,
             expectedContent));
         actual.isUserDefined.Should().BeTrue();


### PR DESCRIPTION
Revert "SLVS-2326 Don't send file content for flushed files to SLCore (https://github.com/SonarSource/sonarlint-visualstudio/pull/6298)"

This reverts commit https://github.com/SonarSource/sonarlint-visualstudio/commit/53053c118e6de17beda6c93a6023eef03b01ce5b.

Revert "SLVS-2348 Fix: stop assuming encoding when it is not known (https://github.com/SonarSource/sonarlint-visualstudio/pull/6310)"

This reverts commit https://github.com/SonarSource/sonarlint-visualstudio/commit/27cf058c13732e95fdc4de44ce1e210030f5ee91.

[SLVS-2354](https://sonarsource.atlassian.net/browse/SLVS-2354)

Part of SLVS-2314


[SLVS-2354]: https://sonarsource.atlassian.net/browse/SLVS-2354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ