### PR TITLE
SLVS-2375 Add Change Status menu item command

### DIFF
--- a/src/Core/Analysis/IAnalysisIssue.cs
+++ b/src/Core/Analysis/IAnalysisIssue.cs
@@ -153,6 +153,14 @@ namespace SonarLint.VisualStudio.Core.Analysis
         ProhibitedLicense
     }
 
+    public enum DependencyRiskStatus
+    {
+        Open,
+        Confirmed,
+        Accepted,
+        Safe
+    }
+
     public static class IAnalysisIssueExtensions
     {
         public static bool IsFileLevel(this IAnalysisIssueBase issue)

--- a/src/IssueViz.Security.UnitTests/DependencyRisks/ChangeDependencyRiskStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/DependencyRisks/ChangeDependencyRiskStatusViewModelTest.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.DependencyRisks;
+
+[TestClass]
+public class ChangeDependencyRiskStatusViewModelTest
+{
+    private readonly List<DependencyRiskStatus> statusWithMandatoryComment = [DependencyRiskStatus.Accepted, DependencyRiskStatus.Safe];
+
+    [TestMethod]
+    public void Ctor_InitializesProperties()
+    {
+        var currentStatus = DependencyRiskStatus.Open;
+        List<DependencyRiskStatus> allowedStatuses = [DependencyRiskStatus.Open, DependencyRiskStatus.Confirmed];
+
+        var testSubject = new ChangeDependencyRiskStatusViewModel(currentStatus, allowedStatuses);
+
+        testSubject.AllStatusViewModels.Should().HaveCount(allowedStatuses.Count);
+        testSubject.AllStatusViewModels.Should().Contain(x => x.GetCurrentStatus<DependencyRiskStatus>() == DependencyRiskStatus.Open);
+        testSubject.AllStatusViewModels.Should().Contain(x => x.GetCurrentStatus<DependencyRiskStatus>() == DependencyRiskStatus.Confirmed);
+        testSubject.SelectedStatusViewModel.GetCurrentStatus<DependencyRiskStatus>().Should().Be(currentStatus);
+        testSubject.ShowComment.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Ctor_AcceptedAndSafeStatusHaveMandatoryComment()
+    {
+        var allowedStatuses = Enum.GetValues(typeof(DependencyRiskStatus)).Cast<DependencyRiskStatus>().ToList();
+
+        var testSubject = new ChangeDependencyRiskStatusViewModel(default, allowedStatuses);
+
+        testSubject.AllStatusViewModels.Should().HaveCount(allowedStatuses.Count);
+
+        var mandatoryComments = GetViewModelsWithStatusesWithMandatoryComments(testSubject);
+        mandatoryComments.All(vm => vm.IsCommentRequired).Should().BeTrue();
+
+        testSubject.AllStatusViewModels.Except(mandatoryComments).All(vm => !vm.IsCommentRequired).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void SelectedStatus_IsInListOfAllowedStatuses_InitializesCorrectly()
+    {
+        var currentStatus = DependencyRiskStatus.Accepted;
+        List<DependencyRiskStatus> allowedStatuses = [DependencyRiskStatus.Safe, DependencyRiskStatus.Accepted];
+
+        var testSubject = new ChangeDependencyRiskStatusViewModel(currentStatus, allowedStatuses);
+
+        testSubject.SelectedStatusViewModel.GetCurrentStatus<DependencyRiskStatus>().Should().Be(currentStatus);
+    }
+
+    [TestMethod]
+    public void SelectedStatus_IsNotInListOfAllowedStatuses_InitializesNull()
+    {
+        var currentStatus = DependencyRiskStatus.Open;
+        List<DependencyRiskStatus> allowedStatuses = [DependencyRiskStatus.Safe, DependencyRiskStatus.Accepted];
+
+        var testSubject = new ChangeDependencyRiskStatusViewModel(currentStatus, allowedStatuses);
+
+        testSubject.SelectedStatusViewModel.Should().BeNull();
+    }
+
+    private List<IStatusViewModel> GetViewModelsWithStatusesWithMandatoryComments(ChangeDependencyRiskStatusViewModel testSubject) =>
+        testSubject.AllStatusViewModels.Where(vm => statusWithMandatoryComment.Contains(vm.GetCurrentStatus<DependencyRiskStatus>())).ToList();
+}

--- a/src/IssueViz.Security.UnitTests/DependencyRisks/ChangeDependencyRiskStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/DependencyRisks/ChangeDependencyRiskStatusViewModelTest.cs
@@ -47,16 +47,14 @@ public class ChangeDependencyRiskStatusViewModelTest
     [TestMethod]
     public void Ctor_AcceptedAndSafeStatusHaveMandatoryComment()
     {
-        var allowedStatuses = Enum.GetValues(typeof(DependencyRiskStatus)).Cast<DependencyRiskStatus>().ToList();
+        var allStatuses = Enum.GetValues(typeof(DependencyRiskStatus)).Cast<DependencyRiskStatus>().ToList();
 
-        var testSubject = new ChangeDependencyRiskStatusViewModel(default, allowedStatuses);
+        var testSubject = new ChangeDependencyRiskStatusViewModel(default, allStatuses);
 
-        testSubject.AllStatusViewModels.Should().HaveCount(allowedStatuses.Count);
-
+        testSubject.AllStatusViewModels.Should().HaveCount(allStatuses.Count);
         var mandatoryComments = GetViewModelsWithStatusesWithMandatoryComments(testSubject);
-        mandatoryComments.All(vm => vm.IsCommentRequired).Should().BeTrue();
-
-        testSubject.AllStatusViewModels.Except(mandatoryComments).All(vm => !vm.IsCommentRequired).Should().BeTrue();
+        mandatoryComments.Should().OnlyContain(vm => vm.IsCommentRequired);
+        testSubject.AllStatusViewModels.Except(mandatoryComments).Should().OnlyContain(vm => !vm.IsCommentRequired);
     }
 
     [TestMethod]

--- a/src/IssueViz.Security.UnitTests/DependencyRisks/DependencyRiskViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/DependencyRisks/DependencyRiskViewModelTest.cs
@@ -33,6 +33,16 @@ public class DependencyRiskViewModelTest
     public void Initialize() => testSubject = new DependencyRiskViewModel();
 
     [TestMethod]
+    public void Ctor_InitializesProperties()
+    {
+        testSubject.Type.Should().Be(DependencyRiskType.Vulnerability);
+        testSubject.PackageName.Should().BeNull();
+        testSubject.PackageVersion.Should().BeNull();
+        testSubject.ImpactSeverity.Should().Be(DependencyRiskImpactSeverity.Info);
+        testSubject.Status.Should().Be(DependencyRiskStatus.Open);
+    }
+
+    [TestMethod]
     public void Type_Set_RaisesPropertyChanged()
     {
         var eventHandler = Substitute.For<PropertyChangedEventHandler>();

--- a/src/IssueViz.Security.UnitTests/DependencyRisks/DependencyRiskViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/DependencyRisks/DependencyRiskViewModelTest.cs
@@ -75,4 +75,15 @@ public class DependencyRiskViewModelTest
 
         eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.ImpactSeverity)));
     }
+
+    [TestMethod]
+    public void Status_Set_RaisesPropertyChanged()
+    {
+        var eventHandler = Substitute.For<PropertyChangedEventHandler>();
+        testSubject.PropertyChanged += eventHandler;
+
+        testSubject.Status = DependencyRiskStatus.Accepted;
+
+        eventHandler.Received(1).Invoke(Arg.Any<object>(), Arg.Is<PropertyChangedEventArgs>(p => p.PropertyName == nameof(testSubject.Status)));
+    }
 }

--- a/src/IssueViz.Security/DependencyRisks/ChangeDependencyRiskStatusViewModel.cs
+++ b/src/IssueViz.Security/DependencyRisks/ChangeDependencyRiskStatusViewModel.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
+
+internal class ChangeDependencyRiskStatusViewModel(DependencyRiskStatus currentStatus, IEnumerable<DependencyRiskStatus> allowedStatuses)
+    : ChangeStatusViewModel<DependencyRiskStatus>(currentStatus, GetAllowedStatuses(allowedStatuses), showComment: true)
+{
+    private static readonly IReadOnlyList<StatusViewModel<DependencyRiskStatus>> AllDependencyRiskStatusViewModels =
+    [
+        new(DependencyRiskStatus.Open, DependencyRiskStatus.Open.ToString(),
+            Resources.ChangeDependencyRiskStatus_OpenDescription, isCommentRequired: false),
+        new(DependencyRiskStatus.Confirmed, DependencyRiskStatus.Confirmed.ToString(),
+            Resources.ChangeDependencyRiskStatus_ConfirmedDescription, isCommentRequired: false),
+        new(DependencyRiskStatus.Accepted, DependencyRiskStatus.Accepted.ToString(),
+            Resources.ChangeDependencyRiskStatus_AcceptedDescription, isCommentRequired: true),
+        new(DependencyRiskStatus.Safe, DependencyRiskStatus.Safe.ToString(),
+            Resources.ChangeDependencyRiskStatus_SafeDescription, isCommentRequired: true)
+    ];
+
+    private static List<StatusViewModel<DependencyRiskStatus>> GetAllowedStatuses(IEnumerable<DependencyRiskStatus> allowedStatuses) =>
+        AllDependencyRiskStatusViewModels.Where(vm => allowedStatuses.Any(hotspotStatus => vm.GetCurrentStatus<DependencyRiskStatus>() == hotspotStatus)).ToList();
+}

--- a/src/IssueViz.Security/DependencyRisks/DependencyRiskViewModel.cs
+++ b/src/IssueViz.Security/DependencyRisks/DependencyRiskViewModel.cs
@@ -29,6 +29,7 @@ internal class DependencyRiskViewModel : ViewModelBase
     private string packageVersion;
     private DependencyRiskImpactSeverity impactSeverity;
     private DependencyRiskType type;
+    private DependencyRiskStatus status;
 
     public string PackageName
     {
@@ -66,6 +67,16 @@ internal class DependencyRiskViewModel : ViewModelBase
         set
         {
             type = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public DependencyRiskStatus Status
+    {
+        get => status;
+        set
+        {
+            status = value;
             RaisePropertyChanged();
         }
     }

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml
@@ -27,11 +27,8 @@
 
             <ContextMenu x:Key="RowContextMenu" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}" 
                          Visibility="{Binding Path=ExistsOnServer, Converter={StaticResource TrueToVisibleConverter}}">
-                <MenuItem Header="{x:Static res:Resources.HotspotsControl_ReviewHotspotTooltip}" Click="ReviewHotspotMenuItem_OnClick">
-                    <MenuItem.Icon>
-                        <imaging:CrispImage Source="/SonarLint.VisualStudio.IssueVisualization.Security;component/SharedUI/sonarqube_for_ide_logo_16px.png" />
-                    </MenuItem.Icon>
-                </MenuItem>
+                <MenuItem Header="{x:Static res:Resources.HotspotsControl_ReviewHotspotTooltip}" Click="ReviewHotspotMenuItem_OnClick" 
+                          Style="{StaticResource ChangeStatusMenuItemStyle}"/>
                 <MenuItem Click="ViewHotspotInBrowser_OnClick" 
                           DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=ViewModel}"
                           Style="{StaticResource ViewIssueInBrowserMenuItemStyle}" />

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml
@@ -122,6 +122,9 @@
             </Style>
 
             <ContextMenu x:Key="DependencyRiskContextMenu" Loaded="DependencyRiskContextMenu_OnLoaded">
+                <MenuItem Header="{x:Static res:Resources.ChangeStatusMenuItem}" 
+                          Click="ChangeScaStatusMenuItem_OnClick" 
+                          Style="{StaticResource ChangeStatusMenuItemStyle}"/>
                 <MenuItem Click="ViewDependencyRiskInBrowser_OnClick" Style="{StaticResource ViewIssueInBrowserMenuItemStyle}" />
             </ContextMenu>
         </ResourceDictionary>
@@ -132,7 +135,8 @@
         </Grid.RowDefinitions>
 
         <TreeView Grid.Row="0" Margin="0,5"  Visibility="{Binding Path=GroupDependencyRisk.HasRisks, Converter={StaticResource TrueToVisibleConverter}}">
-            <TreeViewItem DataContext="{Binding Path=GroupDependencyRisk}" ItemsSource="{Binding Path=Risks}"
+            <TreeViewItem x:Name="GroupDependencyRiskTreeViewItem" DataContext="{Binding Path=GroupDependencyRisk}" 
+                          ItemsSource="{Binding Path=Risks}"
                           PreviewMouseUp="TreeViewItem_OnPreviewMouseUp">
                 <TreeViewItem.Header>
                     <Grid Cursor="Hand">

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -23,19 +23,41 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using SonarLint.VisualStudio.ConnectedMode.UI;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
 
 [ExcludeFromCodeCoverage] // UI, not really unit-testable
 internal sealed partial class ReportViewControl : UserControl
 {
+    private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
+    private readonly IBrowserService browserService;
+    // TODO by https://sonarsource.atlassian.net/browse/SLVS-2376: get the allowed statuses returned by SlCore
+    private readonly DependencyRiskStatus[] allowedDependencyRiskStatuses = [DependencyRiskStatus.Open, DependencyRiskStatus.Confirmed, DependencyRiskStatus.Accepted, DependencyRiskStatus.Safe];
+    private readonly IReadOnlyList<StatusViewModel<DependencyRiskStatus>> allDependencyRiskStatusViewModels =
+    [
+        new(DependencyRiskStatus.Open, DependencyRiskStatus.Open.ToString(),
+            Security.Resources.ChangeDependencyRiskStatus_OpenDescription),
+        new(DependencyRiskStatus.Confirmed, DependencyRiskStatus.Confirmed.ToString(),
+            Security.Resources.ChangeDependencyRiskStatus_ConfirmedDescription),
+        new(DependencyRiskStatus.Accepted, DependencyRiskStatus.Accepted.ToString(),
+            Security.Resources.ChangeDependencyRiskStatus_AcceptedDescription),
+        new(DependencyRiskStatus.Safe, DependencyRiskStatus.Safe.ToString(),
+            Security.Resources.ChangeDependencyRiskStatus_SafeDescription)
+    ];
+
     public ReportViewModel ReportViewModel { get; }
     public IResourceFinder ResourceFinder { get; } = new ResourceFinder();
 
-    public ReportViewControl(IActiveSolutionBoundTracker activeSolutionBoundTracker)
+    public ReportViewControl(IActiveSolutionBoundTracker activeSolutionBoundTracker, IBrowserService browserService)
     {
+        this.activeSolutionBoundTracker = activeSolutionBoundTracker;
+        this.browserService = browserService;
         ReportViewModel = new ReportViewModel(activeSolutionBoundTracker);
         InitializeComponent();
     }
@@ -88,5 +110,34 @@ internal sealed partial class ReportViewControl : UserControl
         {
             treeViewItem.IsSelected = true;
         }
+    }
+
+    private void ChangeScaStatusMenuItem_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (GetSelectedTreeViewItem(GroupDependencyRiskTreeViewItem) is not { DataContext: DependencyRiskViewModel selectedDependencyRiskViewModel })
+        {
+            return;
+        }
+
+        var changeStatusViewModel = new ChangeStatusViewModel<DependencyRiskStatus>(selectedDependencyRiskViewModel.Status, allowedDependencyRiskStatuses, allDependencyRiskStatusViewModels,
+            showComment: true,
+            [DependencyRiskStatus.Accepted, DependencyRiskStatus.Safe]);
+        var dialog = new ChangeStatusWindow(changeStatusViewModel, browserService, activeSolutionBoundTracker);
+        if (dialog.ShowDialog(Application.Current.MainWindow) is true)
+        {
+            // TODO by https://sonarsource.atlassian.net/browse/SLVS-2376: implement actual status change
+        }
+    }
+
+    private static TreeViewItem GetSelectedTreeViewItem(TreeViewItem parent)
+    {
+        foreach (var child in parent.Items)
+        {
+            if (parent.ItemContainerGenerator.ContainerFromItem(child) is TreeViewItem { IsSelected: true } childContainer)
+            {
+                return childContainer;
+            }
+        }
+        return null;
     }
 }

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -39,17 +39,6 @@ internal sealed partial class ReportViewControl : UserControl
     private readonly IBrowserService browserService;
     // TODO by https://sonarsource.atlassian.net/browse/SLVS-2376: get the allowed statuses returned by SlCore
     private readonly DependencyRiskStatus[] allowedDependencyRiskStatuses = [DependencyRiskStatus.Open, DependencyRiskStatus.Confirmed, DependencyRiskStatus.Accepted, DependencyRiskStatus.Safe];
-    private readonly IReadOnlyList<StatusViewModel<DependencyRiskStatus>> allDependencyRiskStatusViewModels =
-    [
-        new(DependencyRiskStatus.Open, DependencyRiskStatus.Open.ToString(),
-            Security.Resources.ChangeDependencyRiskStatus_OpenDescription),
-        new(DependencyRiskStatus.Confirmed, DependencyRiskStatus.Confirmed.ToString(),
-            Security.Resources.ChangeDependencyRiskStatus_ConfirmedDescription),
-        new(DependencyRiskStatus.Accepted, DependencyRiskStatus.Accepted.ToString(),
-            Security.Resources.ChangeDependencyRiskStatus_AcceptedDescription),
-        new(DependencyRiskStatus.Safe, DependencyRiskStatus.Safe.ToString(),
-            Security.Resources.ChangeDependencyRiskStatus_SafeDescription)
-    ];
 
     public ReportViewModel ReportViewModel { get; }
     public IResourceFinder ResourceFinder { get; } = new ResourceFinder();
@@ -119,9 +108,7 @@ internal sealed partial class ReportViewControl : UserControl
             return;
         }
 
-        var changeStatusViewModel = new ChangeStatusViewModel<DependencyRiskStatus>(selectedDependencyRiskViewModel.Status, allowedDependencyRiskStatuses, allDependencyRiskStatusViewModels,
-            showComment: true,
-            [DependencyRiskStatus.Accepted, DependencyRiskStatus.Safe]);
+        var changeStatusViewModel = new ChangeDependencyRiskStatusViewModel(selectedDependencyRiskViewModel.Status, allowedDependencyRiskStatuses);
         var dialog = new ChangeStatusWindow(changeStatusViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {

--- a/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
@@ -22,6 +22,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
@@ -37,7 +38,8 @@ internal class ReportViewToolWindow : ToolWindowPane
     {
         var componentModel = serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
         var activeSolutionBoundTracker = componentModel?.GetService<IActiveSolutionBoundTracker>();
+        var browserService = componentModel?.GetService<IBrowserService>();
         Caption = Resources.ReportViewToolWindowCaption;
-        Content = new ReportViewControl(activeSolutionBoundTracker);
+        Content = new ReportViewControl(activeSolutionBoundTracker, browserService);
     }
 }

--- a/src/IssueViz.Security/Resources.Designer.cs
+++ b/src/IssueViz.Security/Resources.Designer.cs
@@ -61,6 +61,51 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This finding is valid, but it may not be fixed for a while..
+        /// </summary>
+        public static string ChangeDependencyRiskStatus_AcceptedDescription {
+            get {
+                return ResourceManager.GetString("ChangeDependencyRiskStatus_AcceptedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This finding has been reviewed and the risk is valid..
+        /// </summary>
+        public static string ChangeDependencyRiskStatus_ConfirmedDescription {
+            get {
+                return ResourceManager.GetString("ChangeDependencyRiskStatus_ConfirmedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This finding has not yet been reviewed..
+        /// </summary>
+        public static string ChangeDependencyRiskStatus_OpenDescription {
+            get {
+                return ResourceManager.GetString("ChangeDependencyRiskStatus_OpenDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This finding does not pose a risk. No fix is needed..
+        /// </summary>
+        public static string ChangeDependencyRiskStatus_SafeDescription {
+            get {
+                return ResourceManager.GetString("ChangeDependencyRiskStatus_SafeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change Status.
+        /// </summary>
+        public static string ChangeStatusMenuItem {
+            get {
+                return ResourceManager.GetString("ChangeStatusMenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add a comment:.
         /// </summary>
         public static string ChangeStatusWindow_CommentLabel {

--- a/src/IssueViz.Security/Resources.resx
+++ b/src/IssueViz.Security/Resources.resx
@@ -268,5 +268,20 @@ Please check the logs for more details.</value>
   </data>
   <data name="CommentRequiredErrorMessage" xml:space="preserve">
     <value>Comment is required.</value>
+   </data>
+  <data name="ChangeStatusMenuItem" xml:space="preserve">
+    <value>Change Status</value>
+  </data>
+  <data name="ChangeDependencyRiskStatus_AcceptedDescription" xml:space="preserve">
+    <value>This finding is valid, but it may not be fixed for a while.</value>
+  </data>
+  <data name="ChangeDependencyRiskStatus_ConfirmedDescription" xml:space="preserve">
+    <value>This finding has been reviewed and the risk is valid.</value>
+  </data>
+  <data name="ChangeDependencyRiskStatus_OpenDescription" xml:space="preserve">
+    <value>This finding has not yet been reviewed.</value>
+  </data>
+  <data name="ChangeDependencyRiskStatus_SafeDescription" xml:space="preserve">
+    <value>This finding does not pose a risk. No fix is needed.</value>
   </data>
 </root>

--- a/src/IssueViz.Security/SharedUI/SharedResources.xaml
+++ b/src/IssueViz.Security/SharedUI/SharedResources.xaml
@@ -4,7 +4,8 @@
                     xmlns:vsTheming="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
                     xmlns:core="clr-namespace:SonarLint.VisualStudio.Core.WPF;assembly=SonarLint.VisualStudio.Core"
                     xmlns:issueVisualizationControl="clr-namespace:SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl;assembly=SonarLint.VisualStudio.IssueVisualization"
-                    xmlns:res="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security">
+                    xmlns:res="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security"
+                    xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary
             Source="pack://application:,,,/SonarLint.VisualStudio.ConnectedMode;component/UI/Resources/Browse.xaml" />
@@ -214,7 +215,7 @@
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <ContentPresenter Grid.Column="0" x:Name="Icon" Margin="5,0,10,0" VerticalAlignment="Center" ContentSource="Icon"/>
-                            <ContentPresenter Grid.Column="1" x:Name="Header" ContentSource="Header" />
+                            <ContentPresenter Grid.Column="1" x:Name="Header" ContentSource="Header" VerticalAlignment="Center" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -229,7 +230,7 @@
     <Style x:Key="ViewIssueInBrowserMenuItemStyle" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
         <Setter Property="Icon">
             <Setter.Value>
-                <Image Source="{StaticResource BrowserLinkDrawingImage}"  />
+                <imaging:CrispImage Source="{StaticResource BrowserLinkDrawingImage}"  />
             </Setter.Value>
         </Setter>
         <Style.Triggers>
@@ -240,6 +241,13 @@
                 <Setter Property="Header" Value="{x:Static res:Resources.ViewIssueInSonarQubeServer}"/>
             </DataTrigger>
         </Style.Triggers>
+    </Style>
+    <Style x:Key="ChangeStatusMenuItemStyle" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+        <Setter Property="Icon">
+            <Setter.Value>
+                <imaging:CrispImage Source="/SonarLint.VisualStudio.IssueVisualization.Security;component/SharedUI/sonarqube_for_ide_logo_16px.png"/>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
[SLVS-2375](https://sonarsource.atlassian.net/browse/SLVS-2375)

Add Change Status menu item command and show the `ChangeStatusWindow` on click. Make sure comment field is shown and that it is mandatory for `Accepted` and `Safe` statuses.

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6330) in which the `ChangeStatusWindow` has been adapted to show comment and make it mandatory for some statuses.

**DO NOT MERGE** this PR until the target PR is merged into the feature branch

[SLVS-2375]: https://sonarsource.atlassian.net/browse/SLVS-2375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ