### PR TITLE
SLVS-2395 Extend the ChangeStatusWindow to allow showing a comment 

### DIFF
--- a/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/ViewModels/ChangeHotspotStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/ViewModels/ChangeHotspotStatusViewModelTest.cs
@@ -42,6 +42,17 @@ public class ChangeHotspotStatusViewModelTest
     }
 
     [TestMethod]
+    public void Ctor_NoStatusHasMandatoryComment()
+    {
+        var allowedStatuses = Enum.GetValues(typeof(HotspotStatus)).Cast<HotspotStatus>().ToList();
+
+        var testSubject = new ChangeHotspotStatusViewModel(default, allowedStatuses);
+
+        testSubject.AllStatusViewModels.Should().HaveCount(allowedStatuses.Count);
+        testSubject.AllStatusViewModels.All(vm => !vm.IsCommentRequired).Should().BeTrue();
+    }
+
+    [TestMethod]
     public void SelectedStatus_IsInListOfAllowedStatuses_InitializesCorrectly()
     {
         var currentStatus = HotspotStatus.Acknowledged;

--- a/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/ViewModels/ChangeHotspotStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/ViewModels/ChangeHotspotStatusViewModelTest.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.Hotspots.HotspotsList.ViewModels;
+
+[TestClass]
+public class ChangeHotspotStatusViewModelTest
+{
+    [TestMethod]
+    public void Ctor_InitializesProperties()
+    {
+        var currentStatus = HotspotStatus.Fixed;
+        List<HotspotStatus> allowedStatuses = [HotspotStatus.Fixed, HotspotStatus.Acknowledged];
+
+        var testSubject = new ChangeHotspotStatusViewModel(currentStatus, allowedStatuses);
+
+        testSubject.AllStatusViewModels.Should().HaveCount(allowedStatuses.Count);
+        testSubject.AllStatusViewModels.Should().Contain(x => x.GetCurrentStatus<HotspotStatus>() == HotspotStatus.Fixed);
+        testSubject.AllStatusViewModels.Should().Contain(x => x.GetCurrentStatus<HotspotStatus>() == HotspotStatus.Acknowledged);
+        testSubject.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>().Should().Be(currentStatus);
+        testSubject.ShowComment.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void SelectedStatus_IsInListOfAllowedStatuses_InitializesCorrectly()
+    {
+        var currentStatus = HotspotStatus.Acknowledged;
+        List<HotspotStatus> allowedStatuses = [HotspotStatus.Fixed, HotspotStatus.Acknowledged];
+
+        var testSubject = new ChangeHotspotStatusViewModel(currentStatus, allowedStatuses);
+
+        testSubject.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>().Should().Be(currentStatus);
+    }
+
+    [TestMethod]
+    public void SelectedStatus_IsNotInListOfAllowedStatuses_InitializesNull()
+    {
+        var currentStatus = HotspotStatus.Safe;
+        List<HotspotStatus> allowedStatuses = [HotspotStatus.Fixed, HotspotStatus.Acknowledged];
+
+        var testSubject = new ChangeHotspotStatusViewModel(currentStatus, allowedStatuses);
+
+        testSubject.SelectedStatusViewModel.Should().BeNull();
+    }
+}

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -92,7 +92,7 @@ public class ChangeStatusViewModelTest
 
         testSubject.SelectedStatusViewModel = new StatusViewModel<HotspotStatus>(HotspotStatus.Acknowledged, StatusTitle, StatusDescription);
 
-        testSubject.Error.Should().NotBeNull();
+        GetCommentValidationError().Should().NotBeNull();
         testSubject.IsSubmitButtonEnabled.Should().BeFalse();
     }
 
@@ -129,7 +129,7 @@ public class ChangeStatusViewModelTest
 
         testSubject.Comment = string.Empty;
 
-        testSubject.Error.Should().Be(Resources.CommentRequiredErrorMessage);
+        GetCommentValidationError().Should().Be(Resources.CommentRequiredErrorMessage);
     }
 
     [TestMethod]
@@ -143,7 +143,7 @@ public class ChangeStatusViewModelTest
 
         testSubject.Comment = string.Empty;
 
-        testSubject.Error.Should().BeNull();
+        GetCommentValidationError().Should().BeNull();
     }
 
     [TestMethod]
@@ -154,9 +154,11 @@ public class ChangeStatusViewModelTest
 
         testSubject.Comment = string.Empty;
 
-        testSubject.Error.Should().BeNull();
+        GetCommentValidationError().Should().BeNull();
     }
 
     private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment, IEnumerable<HotspotStatus> statusesWithMandatoryComment) =>
         new(status, allowedStatuses, statusesWithMandatoryComment, allStatusViewModels, showComment);
+
+    private string GetCommentValidationError() => testSubject[nameof(testSubject.Comment)];
 }

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -92,4 +92,15 @@ public class ChangeStatusViewModelTest
         eventHandler.Received().Invoke(testSubject, Arg.Is<PropertyChangedEventArgs>(x => x.PropertyName == nameof(testSubject.SelectedStatusViewModel)));
         eventHandler.Received().Invoke(testSubject, Arg.Is<PropertyChangedEventArgs>(x => x.PropertyName == nameof(testSubject.IsSubmitButtonEnabled)));
     }
+
+    [TestMethod]
+    public void Comment_Set_RaisesEvents()
+    {
+        var eventHandler = Substitute.For<PropertyChangedEventHandler>();
+        testSubject.PropertyChanged += eventHandler;
+
+        testSubject.Comment = "test";
+
+        eventHandler.Received().Invoke(testSubject, Arg.Is<PropertyChangedEventArgs>(x => x.PropertyName == nameof(testSubject.Comment)));
+    }
 }

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -30,13 +30,11 @@ public class ChangeStatusViewModelTest
     private const string StatusTitle = "title";
     private const string StatusDescription = "description";
     private ChangeStatusViewModel<HotspotStatus> testSubject;
-    private HotspotStatus[] allowedStatuses;
     private List<StatusViewModel<HotspotStatus>> allStatusViewModels;
 
     [TestInitialize]
     public void TestInitialize()
     {
-        allowedStatuses = [HotspotStatus.Acknowledged, HotspotStatus.Safe];
         allStatusViewModels = Enum.GetValues(typeof(HotspotStatus))
             .Cast<HotspotStatus>()
             .Select(status => new StatusViewModel<HotspotStatus>(status, status.ToString(), status.ToString(), isCommentRequired: false)).ToList();
@@ -47,26 +45,14 @@ public class ChangeStatusViewModelTest
     [TestMethod]
     [DataRow(HotspotStatus.Acknowledged, true)]
     [DataRow(HotspotStatus.Safe, false)]
-    public void Ctor_InitializesProperties(HotspotStatus status, bool showComment)
+    public void Ctor_InitializesProperties(HotspotStatus currentStatus, bool showComment)
     {
-        testSubject = CreateTestSubject(status, showComment);
-        testSubject.AllowedStatusViewModels.Should().HaveCount(allowedStatuses.Length);
-        foreach (var allowedStatus in allowedStatuses)
-        {
-            testSubject.AllowedStatusViewModels.Should().ContainSingle(x => x.GetCurrentStatus<HotspotStatus>() == allowedStatus);
-        }
+        testSubject = CreateTestSubject(currentStatus, showComment);
 
-        testSubject.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>().Should().Be(status);
+        testSubject.AllStatusViewModels.Should().HaveCount(allStatusViewModels.Count);
+        testSubject.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>().Should().Be(currentStatus);
         testSubject.SelectedStatusViewModel.IsChecked.Should().BeTrue();
         testSubject.ShowComment.Should().Be(showComment);
-    }
-
-    [TestMethod]
-    public void Ctor_CurrentStatusNotInListOfAllowedStatuses_SetsSelectionToNull()
-    {
-        testSubject = CreateTestSubject(HotspotStatus.ToReview);
-
-        testSubject.SelectedStatusViewModel.Should().BeNull();
     }
 
     [TestMethod]
@@ -157,7 +143,7 @@ public class ChangeStatusViewModelTest
         eventHandler.Received().Invoke(testSubject, Arg.Is<PropertyChangedEventArgs>(x => x.PropertyName == nameof(testSubject.IsSubmitButtonEnabled)));
     }
 
-    private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment = false) => new(status, allowedStatuses, allStatusViewModels, showComment);
+    private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment = false) => new(status, allStatusViewModels, showComment);
 
     private string GetCommentValidationError() => testSubject[nameof(testSubject.Comment)];
 

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -130,6 +130,7 @@ public class ChangeStatusViewModelTest
         testSubject.Comment = string.Empty;
 
         GetCommentValidationError().Should().Be(Resources.CommentRequiredErrorMessage);
+        testSubject.Error.Should().Be(Resources.CommentRequiredErrorMessage);
     }
 
     [TestMethod]
@@ -144,6 +145,7 @@ public class ChangeStatusViewModelTest
         testSubject.Comment = string.Empty;
 
         GetCommentValidationError().Should().BeNull();
+        testSubject.Error.Should().BeNull();
     }
 
     [TestMethod]
@@ -155,6 +157,7 @@ public class ChangeStatusViewModelTest
         testSubject.Comment = string.Empty;
 
         GetCommentValidationError().Should().BeNull();
+        testSubject.Error.Should().BeNull();
     }
 
     private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment, IEnumerable<HotspotStatus> statusesWithMandatoryComment) =>

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -29,7 +29,6 @@ public class ChangeStatusViewModelTest
 {
     private ChangeStatusViewModel<HotspotStatus> testSubject;
     private HotspotStatus[] allowedStatuses;
-    private readonly HotspotStatus currentStatus = HotspotStatus.Safe;
     private List<StatusViewModel<HotspotStatus>> allStatusViewModels;
 
     [TestInitialize]
@@ -40,26 +39,30 @@ public class ChangeStatusViewModelTest
             .Cast<HotspotStatus>()
             .Select(status => new StatusViewModel<HotspotStatus>(status, status.ToString(), status.ToString())).ToList();
 
-        testSubject = new ChangeStatusViewModel<HotspotStatus>(currentStatus, allowedStatuses, allStatusViewModels);
+        testSubject = CreateTestSubject(HotspotStatus.Safe, showComment: false);
     }
 
     [TestMethod]
-    public void Ctor_InitializesProperties()
+    [DataRow(HotspotStatus.Acknowledged, true)]
+    [DataRow(HotspotStatus.Safe, false)]
+    public void Ctor_InitializesProperties(HotspotStatus status, bool showComment)
     {
+        testSubject = CreateTestSubject(status, showComment);
         testSubject.AllowedStatusViewModels.Should().HaveCount(allowedStatuses.Length);
         foreach (var allowedStatus in allowedStatuses)
         {
             testSubject.AllowedStatusViewModels.Should().ContainSingle(x => x.GetCurrentStatus<HotspotStatus>() == allowedStatus);
         }
 
-        testSubject.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>().Should().Be(currentStatus);
+        testSubject.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>().Should().Be(status);
         testSubject.SelectedStatusViewModel.IsChecked.Should().BeTrue();
+        testSubject.ShowComment.Should().Be(showComment);
     }
 
     [TestMethod]
     public void Ctor_CurrentStatusNotInListOfAllowedStatuses_SetsSelectionToNull()
     {
-        testSubject = new ChangeStatusViewModel<HotspotStatus>(HotspotStatus.ToReview, allowedStatuses, allStatusViewModels);
+        testSubject = CreateTestSubject(HotspotStatus.ToReview, showComment: false);
 
         testSubject.SelectedStatusViewModel.Should().BeNull();
     }
@@ -103,4 +106,6 @@ public class ChangeStatusViewModelTest
 
         eventHandler.Received().Invoke(testSubject, Arg.Is<PropertyChangedEventArgs>(x => x.PropertyName == nameof(testSubject.Comment)));
     }
+
+    private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment) => new(status, allowedStatuses, allStatusViewModels, showComment);
 }

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -160,6 +160,17 @@ public class ChangeStatusViewModelTest
         testSubject.Error.Should().BeNull();
     }
 
+    [TestMethod]
+    public void Error_RaisesEvents()
+    {
+        var eventHandler = Substitute.For<PropertyChangedEventHandler>();
+        testSubject.PropertyChanged += eventHandler;
+
+        GetCommentValidationError();
+
+        eventHandler.Received().Invoke(testSubject, Arg.Is<PropertyChangedEventArgs>(x => x.PropertyName == nameof(testSubject.IsSubmitButtonEnabled)));
+    }
+
     private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment = false, IEnumerable<HotspotStatus> statusesWithMandatoryComment = null) =>
         new(status, allowedStatuses, allStatusViewModels, showComment, statusesWithMandatoryComment);
 

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/ChangeStatusViewModelTest.cs
@@ -41,7 +41,7 @@ public class ChangeStatusViewModelTest
             .Cast<HotspotStatus>()
             .Select(status => new StatusViewModel<HotspotStatus>(status, status.ToString(), status.ToString())).ToList();
 
-        testSubject = CreateTestSubject(HotspotStatus.Safe, showComment: false, statusesWithMandatoryComment: []);
+        testSubject = CreateTestSubject(HotspotStatus.Safe);
     }
 
     [TestMethod]
@@ -49,7 +49,7 @@ public class ChangeStatusViewModelTest
     [DataRow(HotspotStatus.Safe, false)]
     public void Ctor_InitializesProperties(HotspotStatus status, bool showComment)
     {
-        testSubject = CreateTestSubject(status, showComment, statusesWithMandatoryComment: []);
+        testSubject = CreateTestSubject(status, showComment);
         testSubject.AllowedStatusViewModels.Should().HaveCount(allowedStatuses.Length);
         foreach (var allowedStatus in allowedStatuses)
         {
@@ -64,7 +64,7 @@ public class ChangeStatusViewModelTest
     [TestMethod]
     public void Ctor_CurrentStatusNotInListOfAllowedStatuses_SetsSelectionToNull()
     {
-        testSubject = CreateTestSubject(HotspotStatus.ToReview, showComment: false, statusesWithMandatoryComment: []);
+        testSubject = CreateTestSubject(HotspotStatus.ToReview);
 
         testSubject.SelectedStatusViewModel.Should().BeNull();
     }
@@ -160,8 +160,8 @@ public class ChangeStatusViewModelTest
         testSubject.Error.Should().BeNull();
     }
 
-    private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment, IEnumerable<HotspotStatus> statusesWithMandatoryComment) =>
-        new(status, allowedStatuses, statusesWithMandatoryComment, allStatusViewModels, showComment);
+    private ChangeStatusViewModel<HotspotStatus> CreateTestSubject(HotspotStatus status, bool showComment = false, IEnumerable<HotspotStatus> statusesWithMandatoryComment = null) =>
+        new(status, allowedStatuses, allStatusViewModels, showComment, statusesWithMandatoryComment);
 
     private string GetCommentValidationError() => testSubject[nameof(testSubject.Comment)];
 }

--- a/src/IssueViz.Security.UnitTests/ReviewStatus/StatusViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReviewStatus/StatusViewModelTest.cs
@@ -31,24 +31,29 @@ public class StatusViewModelTest
     private const string StatusDescription = "description";
 
     [TestMethod]
-    [DataRow(HotspotStatus.ToReview, "to review", "description1")]
-    [DataRow(HotspotStatus.Acknowledged, "acknowledges", "description\ndescription2")]
-    [DataRow(HotspotStatus.Fixed, "fixed", "description3")]
-    [DataRow(HotspotStatus.Safe, "safe", "description\n\tdescription4")]
-    public void Ctor_InitializesProperties(HotspotStatus status, string title, string description)
+    [DataRow(HotspotStatus.ToReview, "to review", "description1", false)]
+    [DataRow(HotspotStatus.Acknowledged, "acknowledges", "description\ndescription2", true)]
+    [DataRow(HotspotStatus.Fixed, "fixed", "description3", false)]
+    [DataRow(HotspotStatus.Safe, "safe", "description\n\tdescription4", true)]
+    public void Ctor_InitializesProperties(
+        HotspotStatus status,
+        string title,
+        string description,
+        bool isCommentRequired)
     {
-        var testSubject = new StatusViewModel<HotspotStatus>(status, title, description);
+        var testSubject = new StatusViewModel<HotspotStatus>(status, title, description, isCommentRequired);
 
         testSubject.Status.Should().Be(status);
         testSubject.Title.Should().Be(title);
         testSubject.Description.Should().Be(description);
         testSubject.IsChecked.Should().BeFalse();
+        testSubject.IsCommentRequired.Should().Be(isCommentRequired);
     }
 
     [TestMethod]
     public void IsChecked_Set_RaisesEvents()
     {
-        var testSubject = new StatusViewModel<HotspotStatus>(default, StatusTitle, StatusDescription);
+        var testSubject = CreateStatusViewModel(default);
         var eventHandler = Substitute.For<PropertyChangedEventHandler>();
         testSubject.PropertyChanged += eventHandler;
         eventHandler.ReceivedCalls().Should().BeEmpty();
@@ -61,7 +66,7 @@ public class StatusViewModelTest
     [TestMethod]
     public void GetCurrentStatus_ReturnsCurrentStatus_WhenTypeIsCorrect()
     {
-        var testSubject = new StatusViewModel<HotspotStatus>(HotspotStatus.Fixed, StatusTitle, StatusDescription);
+        var testSubject = CreateStatusViewModel(HotspotStatus.Fixed);
 
         var result = testSubject.GetCurrentStatus<HotspotStatus>();
 
@@ -71,11 +76,13 @@ public class StatusViewModelTest
     [TestMethod]
     public void GetCurrentStatus_Throws_WhenTypeIsIncorrect()
     {
-        var testSubject = new StatusViewModel<HotspotStatus>(HotspotStatus.Fixed, StatusTitle, StatusDescription);
+        var testSubject = CreateStatusViewModel(HotspotStatus.Fixed);
 
         Action action = () => testSubject.GetCurrentStatus<DependencyRiskType>();
 
         action.Should().Throw<InvalidOperationException>()
             .WithMessage($"Cannot get status of type {typeof(DependencyRiskType)} from {nameof(IStatusViewModel)} of type {typeof(HotspotStatus)}.");
     }
+
+    private static StatusViewModel<HotspotStatus> CreateStatusViewModel(HotspotStatus status) => new(status, StatusTitle, StatusDescription, isCommentRequired: false);
 }

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -66,7 +66,7 @@ internal sealed partial class HotspotsControl : UserControl
             return;
         }
 
-        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, allStatusViewModels, showComment: false);
+        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, statusesWithMandatoryComment: [], allStatusViewModels, showComment: false);
         var dialog = new ChangeStatusWindow(statusListViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -66,7 +66,7 @@ internal sealed partial class HotspotsControl : UserControl
             return;
         }
 
-        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, statusesWithMandatoryComment: [], allStatusViewModels, showComment: false);
+        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, allStatusViewModels);
         var dialog = new ChangeStatusWindow(statusListViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -55,11 +55,11 @@ internal sealed partial class HotspotsControl : UserControl
             return;
         }
 
-        var statusListViewModel = new ChangeHotspotStatusViewModel(hotspotViewModel.HotspotStatus, allowedStatuses);
-        var dialog = new ChangeStatusWindow(statusListViewModel, browserService, activeSolutionBoundTracker);
+        var changeHotspotStatusViewModel = new ChangeHotspotStatusViewModel(hotspotViewModel.HotspotStatus, allowedStatuses);
+        var dialog = new ChangeStatusWindow(changeHotspotStatusViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {
-            await ViewModel.ChangeHotspotStatusAsync(statusListViewModel.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>());
+            await ViewModel.ChangeHotspotStatusAsync(changeHotspotStatusViewModel.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>());
         }
     }
 

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -35,17 +35,6 @@ internal sealed partial class HotspotsControl : UserControl
 {
     private readonly IBrowserService browserService;
     private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
-    private readonly IReadOnlyList<StatusViewModel<HotspotStatus>> allStatusViewModels =
-    [
-        new(HotspotStatus.ToReview, Security.Resources.ReviewHotspotWindow_ToReviewTitle,
-            Security.Resources.ReviewHotspotWindow_ToReviewContent, isCommentRequired: false),
-        new(HotspotStatus.Acknowledged, Security.Resources.ReviewHotspotWindow_AcknowledgeTitle,
-            Security.Resources.ReviewHotspotWindow_AcknowledgeContent, isCommentRequired: false),
-        new(HotspotStatus.Fixed, Security.Resources.ReviewHotspotWindow_FixedTitle,
-            Security.Resources.ReviewHotspotWindow_FixedContent, isCommentRequired: false),
-        new(HotspotStatus.Safe, Security.Resources.ReviewHotspotWindow_SafeTitle,
-            Security.Resources.ReviewHotspotWindow_SafeContent, isCommentRequired: false)
-    ];
 
     public HotspotsControlViewModel ViewModel { get; }
 
@@ -66,7 +55,7 @@ internal sealed partial class HotspotsControl : UserControl
             return;
         }
 
-        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, allStatusViewModels);
+        var statusListViewModel = new ChangeHotspotStatusViewModel(hotspotViewModel.HotspotStatus, allowedStatuses);
         var dialog = new ChangeStatusWindow(statusListViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -38,13 +38,13 @@ internal sealed partial class HotspotsControl : UserControl
     private readonly IReadOnlyList<StatusViewModel<HotspotStatus>> allStatusViewModels =
     [
         new(HotspotStatus.ToReview, Security.Resources.ReviewHotspotWindow_ToReviewTitle,
-            Security.Resources.ReviewHotspotWindow_ToReviewContent),
+            Security.Resources.ReviewHotspotWindow_ToReviewContent, isCommentRequired: false),
         new(HotspotStatus.Acknowledged, Security.Resources.ReviewHotspotWindow_AcknowledgeTitle,
-            Security.Resources.ReviewHotspotWindow_AcknowledgeContent),
+            Security.Resources.ReviewHotspotWindow_AcknowledgeContent, isCommentRequired: false),
         new(HotspotStatus.Fixed, Security.Resources.ReviewHotspotWindow_FixedTitle,
-            Security.Resources.ReviewHotspotWindow_FixedContent),
+            Security.Resources.ReviewHotspotWindow_FixedContent, isCommentRequired: false),
         new(HotspotStatus.Safe, Security.Resources.ReviewHotspotWindow_SafeTitle,
-            Security.Resources.ReviewHotspotWindow_SafeContent)
+            Security.Resources.ReviewHotspotWindow_SafeContent, isCommentRequired: false)
     ];
 
     public HotspotsControlViewModel ViewModel { get; }

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -66,7 +66,7 @@ internal sealed partial class HotspotsControl : UserControl
             return;
         }
 
-        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, allStatusViewModels);
+        var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, allStatusViewModels, showComment: false);
         var dialog = new ChangeStatusWindow(statusListViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsControl.xaml.cs
@@ -21,7 +21,9 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Controls;
+using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 using static SonarLint.VisualStudio.ConnectedMode.UI.WindowExtensions;
@@ -31,6 +33,8 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
 [ExcludeFromCodeCoverage] // UI, not really unit-testable
 internal sealed partial class HotspotsControl : UserControl
 {
+    private readonly IBrowserService browserService;
+    private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
     private readonly IReadOnlyList<StatusViewModel<HotspotStatus>> allStatusViewModels =
     [
         new(HotspotStatus.ToReview, Security.Resources.ReviewHotspotWindow_ToReviewTitle,
@@ -45,8 +49,10 @@ internal sealed partial class HotspotsControl : UserControl
 
     public HotspotsControlViewModel ViewModel { get; }
 
-    public HotspotsControl(HotspotsControlViewModel viewModel)
+    public HotspotsControl(HotspotsControlViewModel viewModel, IBrowserService browserService, IActiveSolutionBoundTracker activeSolutionBoundTracker)
     {
+        this.browserService = browserService;
+        this.activeSolutionBoundTracker = activeSolutionBoundTracker;
         ViewModel = viewModel;
 
         InitializeComponent();
@@ -61,7 +67,7 @@ internal sealed partial class HotspotsControl : UserControl
         }
 
         var statusListViewModel = new ChangeStatusViewModel<HotspotStatus>(hotspotViewModel.HotspotStatus, allowedStatuses, allStatusViewModels);
-        var dialog = new ChangeStatusWindow(statusListViewModel);
+        var dialog = new ChangeStatusWindow(statusListViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {
             await ViewModel.ChangeHotspotStatusAsync(statusListViewModel.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>());

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsToolWindow.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsToolWindow.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
@@ -35,6 +36,7 @@ using SonarLint.VisualStudio.IssueVisualization.Selection;
 namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList
 {
     [Guid(ToolWindowIdAsString)]
+    [ExcludeFromCodeCoverage]
     public class HotspotsToolWindow : ToolWindowPane
     {
         private const string ToolWindowIdAsString = "4BCD4392-DBCF-4AA2-9852-01129D229CD8";

--- a/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsToolWindow.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/HotspotsToolWindow.cs
@@ -56,11 +56,12 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
             var messageBox = componentModel.GetService<IMessageBox>();
             var activeDocumentLocator = componentModel.GetService<IActiveDocumentLocator>();
             var activeDocumentTracker = componentModel.GetService<IActiveDocumentTracker>();
+            var browserService = componentModel.GetService<IBrowserService>();
 
             var viewModel = new HotspotsControlViewModel(store, navigateToRuleDescriptionCommand, locationNavigator, selectionService, threadHandling, activeSolutionBoundTracker,
                 reviewHotspotsService, messageBox, activeDocumentLocator, activeDocumentTracker);
             viewModel.UpdateHotspotsListAsync().Forget();
-            var hotspotsControl = new HotspotsControl(viewModel);
+            var hotspotsControl = new HotspotsControl(viewModel, browserService, activeSolutionBoundTracker);
 
             Content = hotspotsControl;
         }

--- a/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/ChangeHotspotStatusViewModel.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/ChangeHotspotStatusViewModel.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
+
+internal class ChangeHotspotStatusViewModel(HotspotStatus currentStatus, IEnumerable<HotspotStatus> allowedStatuses)
+    : ChangeStatusViewModel<HotspotStatus>(currentStatus,
+        GetAllowedStatuses(allowedStatuses), showComment: false)
+{
+    private static readonly IReadOnlyList<StatusViewModel<HotspotStatus>> StatusViewModels =
+    [
+        new(HotspotStatus.ToReview, Resources.ReviewHotspotWindow_ToReviewTitle,
+            Resources.ReviewHotspotWindow_ToReviewContent, isCommentRequired: false),
+        new(HotspotStatus.Acknowledged, Resources.ReviewHotspotWindow_AcknowledgeTitle,
+            Resources.ReviewHotspotWindow_AcknowledgeContent, isCommentRequired: false),
+        new(HotspotStatus.Fixed, Resources.ReviewHotspotWindow_FixedTitle,
+            Resources.ReviewHotspotWindow_FixedContent, isCommentRequired: false),
+        new(HotspotStatus.Safe, Resources.ReviewHotspotWindow_SafeTitle,
+            Resources.ReviewHotspotWindow_SafeContent, isCommentRequired: false)
+    ];
+
+    private static List<StatusViewModel<HotspotStatus>> GetAllowedStatuses(IEnumerable<HotspotStatus> allowedStatuses) =>
+        StatusViewModels.Where(vm => allowedStatuses.Any(hotspotStatus => vm.GetCurrentStatus<HotspotStatus>() == hotspotStatus)).ToList();
+}

--- a/src/IssueViz.Security/Resources.Designer.cs
+++ b/src/IssueViz.Security/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comment is required..
+        /// </summary>
+        public static string CommentRequiredErrorMessage {
+            get {
+                return ResourceManager.GetString("CommentRequiredErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Severity impact:.
         /// </summary>
         public static string DependencyRiskImpactSeverityTooltip {

--- a/src/IssueViz.Security/Resources.Designer.cs
+++ b/src/IssueViz.Security/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add a comment:.
+        /// </summary>
+        public static string ChangeStatusWindow_CommentLabel {
+            get {
+                return ResourceManager.GetString("ChangeStatusWindow_CommentLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to : *Bold*, ``Code``, * Bullet point.
+        /// </summary>
+        public static string ChangeStatusWindow_FormattingHelpExamples {
+            get {
+                return ResourceManager.GetString("ChangeStatusWindow_FormattingHelpExamples", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Formatting Help.
+        /// </summary>
+        public static string ChangeStatusWindow_FormattingHelpLink {
+            get {
+                return ResourceManager.GetString("ChangeStatusWindow_FormattingHelpLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Severity impact:.
         /// </summary>
         public static string DependencyRiskImpactSeverityTooltip {

--- a/src/IssueViz.Security/Resources.resx
+++ b/src/IssueViz.Security/Resources.resx
@@ -257,4 +257,13 @@ Please check the logs for more details.</value>
   <data name="IssueText" xml:space="preserve">
     <value>issue</value>
   </data>
+  <data name="ChangeStatusWindow_CommentLabel" xml:space="preserve">
+    <value>Add a comment:</value>
+  </data>
+  <data name="ChangeStatusWindow_FormattingHelpExamples" xml:space="preserve">
+    <value>: *Bold*, ``Code``, * Bullet point</value>
+  </data>
+  <data name="ChangeStatusWindow_FormattingHelpLink" xml:space="preserve">
+    <value>Formatting Help</value>
+  </data>
 </root>

--- a/src/IssueViz.Security/Resources.resx
+++ b/src/IssueViz.Security/Resources.resx
@@ -266,4 +266,7 @@ Please check the logs for more details.</value>
   <data name="ChangeStatusWindow_FormattingHelpLink" xml:space="preserve">
     <value>Formatting Help</value>
   </data>
+  <data name="CommentRequiredErrorMessage" xml:space="preserve">
+    <value>Comment is required.</value>
+  </data>
 </root>

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -25,19 +25,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
 public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel where T : struct, Enum
 {
-    private readonly IReadOnlyList<StatusViewModel<T>> allStatusViewModels;
     private IStatusViewModel selectedStatusViewModel;
     private string comment;
     private string validationError;
 
     public ChangeStatusViewModel(
         T currentStatus,
-        IEnumerable<T> allowedStatuses,
         IReadOnlyList<StatusViewModel<T>> allStatusViewModels,
         bool showComment = false)
     {
-        this.allStatusViewModels = allStatusViewModels;
-        InitializeStatuses(allowedStatuses);
+        AllStatusViewModels = new ObservableCollection<IStatusViewModel>(allStatusViewModels);
         InitializeCurrentStatus(currentStatus);
         ShowComment = showComment;
     }
@@ -85,18 +82,11 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
     public string Error => validationError;
     public bool ShowComment { get; }
     public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null && Error is null;
-    public ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; set; } = [];
-
-    private void InitializeStatuses(IEnumerable<T> allowedStatuses)
-    {
-        AllowedStatusViewModels.Clear();
-        allStatusViewModels.ToList().ForEach(vm => vm.IsChecked = false);
-        allStatusViewModels.Where(x => allowedStatuses.Contains(x.Status)).ToList().ForEach(vm => AllowedStatusViewModels.Add(vm));
-    }
+    public ObservableCollection<IStatusViewModel> AllStatusViewModels { get; }
 
     private void InitializeCurrentStatus(T currentStatus)
     {
-        SelectedStatusViewModel = AllowedStatusViewModels.FirstOrDefault(x => Equals(x.GetCurrentStatus<T>(), currentStatus));
+        SelectedStatusViewModel = AllStatusViewModels.FirstOrDefault(x => Equals(x.GetCurrentStatus<T>(), currentStatus));
         if (SelectedStatusViewModel == null)
         {
             return;

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -68,6 +68,9 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         }
     }
 
+    /// <summary>
+    /// Implementation of <see cref="System.ComponentModel.IDataErrorInfo "/> needed for view validation 
+    /// </summary>
     public string this[string columnName]
     {
         get

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -81,7 +81,7 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         }
     }
 
-    public string Error => null;
+    public string Error => validationError;
     public bool ShowComment { get; }
     public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null && this[nameof(Comment)] is null;
     public ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; set; } = [];

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -80,9 +80,9 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         }
     }
 
-    public string Error => validationError;
+    public string Error => null;
     public bool ShowComment { get; }
-    public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null && Error is null;
+    public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null && this[nameof(Comment)] is null;
     public ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; set; } = [];
 
     private void InitializeStatuses(IEnumerable<T> allowedStatuses)

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -34,9 +34,9 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
     public ChangeStatusViewModel(
         T currentStatus,
         IEnumerable<T> allowedStatuses,
-        IEnumerable<T> statusesWithMandatoryComment,
         IReadOnlyList<StatusViewModel<T>> allStatusViewModels,
-        bool showComment)
+        bool showComment = false,
+        IEnumerable<T> statusesWithMandatoryComment = null)
     {
         this.statusesWithMandatoryComment = statusesWithMandatoryComment;
         this.allStatusViewModels = allStatusViewModels;
@@ -103,5 +103,5 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         SelectedStatusViewModel.IsChecked = true;
     }
 
-    private bool IsCommentRequired() => statusesWithMandatoryComment.Any(x => SelectedStatusViewModel.HasStatus(x));
+    private bool IsCommentRequired() => statusesWithMandatoryComment != null && statusesWithMandatoryComment.Any(x => SelectedStatusViewModel.HasStatus(x));
 }

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -52,8 +52,9 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         {
             selectedStatusViewModel = value;
             RaisePropertyChanged();
+            // order matters here, we want to validate the comment before checking if the submit button is enabled
+            RaisePropertyChanged(nameof(Comment));
             RaisePropertyChanged(nameof(IsSubmitButtonEnabled));
-            RaisePropertyChanged(nameof(Comment)); // enforce comment validation
         }
     }
 

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -29,11 +29,16 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
     private IStatusViewModel selectedStatusViewModel;
     private string comment;
 
-    public ChangeStatusViewModel(T currentStatus, IEnumerable<T> allowedStatuses, IReadOnlyList<StatusViewModel<T>> allStatusViewModels)
+    public ChangeStatusViewModel(
+        T currentStatus,
+        IEnumerable<T> allowedStatuses,
+        IReadOnlyList<StatusViewModel<T>> allStatusViewModels,
+        bool showComment)
     {
         this.allStatusViewModels = allStatusViewModels;
         InitializeStatuses(allowedStatuses);
         InitializeCurrentStatus(currentStatus);
+        ShowComment = showComment;
     }
 
     public IStatusViewModel SelectedStatusViewModel
@@ -57,6 +62,7 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         }
     }
 
+    public bool ShowComment { get; }
     public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null;
 
     public ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; set; } = [];

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -77,13 +77,14 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
             {
                 validationError = Resources.CommentRequiredErrorMessage;
             }
+            RaisePropertyChanged(nameof(IsSubmitButtonEnabled));
             return validationError;
         }
     }
 
     public string Error => validationError;
     public bool ShowComment { get; }
-    public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null && this[nameof(Comment)] is null;
+    public bool IsSubmitButtonEnabled => SelectedStatusViewModel != null && Error is null;
     public ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; set; } = [];
 
     private void InitializeStatuses(IEnumerable<T> allowedStatuses)

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -104,5 +104,5 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         SelectedStatusViewModel.IsChecked = true;
     }
 
-    private bool IsCommentRequired() => statusesWithMandatoryComment != null && statusesWithMandatoryComment.Any(x => SelectedStatusViewModel.HasStatus(x));
+    private bool IsCommentRequired() => statusesWithMandatoryComment != null && statusesWithMandatoryComment.Any(x => Equals(SelectedStatusViewModel.GetCurrentStatus<T>(), x));
 }

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -25,7 +25,6 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
 public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel where T : struct, Enum
 {
-    private readonly IEnumerable<T> statusesWithMandatoryComment;
     private readonly IReadOnlyList<StatusViewModel<T>> allStatusViewModels;
     private IStatusViewModel selectedStatusViewModel;
     private string comment;
@@ -35,10 +34,8 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         T currentStatus,
         IEnumerable<T> allowedStatuses,
         IReadOnlyList<StatusViewModel<T>> allStatusViewModels,
-        bool showComment = false,
-        IEnumerable<T> statusesWithMandatoryComment = null)
+        bool showComment = false)
     {
-        this.statusesWithMandatoryComment = statusesWithMandatoryComment;
         this.allStatusViewModels = allStatusViewModels;
         InitializeStatuses(allowedStatuses);
         InitializeCurrentStatus(currentStatus);
@@ -76,7 +73,7 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         get
         {
             validationError = null;
-            if (columnName == nameof(Comment) && string.IsNullOrEmpty(Comment) && IsCommentRequired())
+            if (columnName == nameof(Comment) && string.IsNullOrEmpty(Comment) && SelectedStatusViewModel.IsCommentRequired)
             {
                 validationError = Resources.CommentRequiredErrorMessage;
             }
@@ -106,6 +103,4 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
         }
         SelectedStatusViewModel.IsChecked = true;
     }
-
-    private bool IsCommentRequired() => statusesWithMandatoryComment != null && statusesWithMandatoryComment.Any(x => Equals(SelectedStatusViewModel.GetCurrentStatus<T>(), x));
 }

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusViewModel.cs
@@ -27,6 +27,7 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
 {
     private readonly IReadOnlyList<StatusViewModel<T>> allStatusViewModels;
     private IStatusViewModel selectedStatusViewModel;
+    private string comment;
 
     public ChangeStatusViewModel(T currentStatus, IEnumerable<T> allowedStatuses, IReadOnlyList<StatusViewModel<T>> allStatusViewModels)
     {
@@ -43,6 +44,16 @@ public class ChangeStatusViewModel<T> : ViewModelBase, IChangeStatusViewModel wh
             selectedStatusViewModel = value;
             RaisePropertyChanged();
             RaisePropertyChanged(nameof(IsSubmitButtonEnabled));
+        }
+    }
+
+    public string Comment
+    {
+        get => comment;
+        set
+        {
+            comment = value;
+            RaisePropertyChanged();
         }
     }
 

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
@@ -9,6 +9,7 @@
     WindowStartupLocation="CenterOwner"
     xmlns:resx="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security"
     xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:wpf="clr-namespace:SonarLint.VisualStudio.Core.WPF;assembly=SonarLint.VisualStudio.Core"
     x:Name="ReviewHotspotWindowName"
     Title="{x:Static security:Resources.ReviewHotspotWindow_Title}">
     <Window.Resources>
@@ -17,6 +18,7 @@
                 <ResourceDictionary
                     Source="pack://application:,,,/SonarLint.VisualStudio.ConnectedMode;component/UI/Resources/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <wpf:BoolToVisibilityConverter x:Key="TrueToVisibleConverter" FalseValue="Collapsed" TrueValue="Visible" />
 
             <Style x:Key="ChangeIssueStatusWithHandlerBorderStyle" TargetType="Border"
                    BasedOn="{StaticResource ChangeIssueStatusBorderStyle}">
@@ -77,7 +79,8 @@
             </ListBox.ItemTemplate>
         </ListBox>
 
-        <Grid Grid.Row="1" Margin="0, 10" HorizontalAlignment="Center">
+        <Grid Grid.Row="1" Margin="0, 10" HorizontalAlignment="Center" 
+              Visibility="{Binding Path=ShowComment, Converter={StaticResource TrueToVisibleConverter}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
@@ -7,6 +7,8 @@
     xmlns:security="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security"
     mc:Ignorable="d"
     WindowStartupLocation="CenterOwner"
+    xmlns:resx="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security"
+    xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
     x:Name="ReviewHotspotWindowName"
     Title="{x:Static security:Resources.ReviewHotspotWindow_Title}">
     <Window.Resources>
@@ -16,8 +18,28 @@
                     Source="pack://application:,,,/SonarLint.VisualStudio.ConnectedMode;component/UI/Resources/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <Style x:Key="ChangeIssueStatusWithHandlerBorderStyle" TargetType="Border" BasedOn="{StaticResource ChangeIssueStatusBorderStyle}">
+            <Style x:Key="ChangeIssueStatusWithHandlerBorderStyle" TargetType="Border"
+                   BasedOn="{StaticResource ChangeIssueStatusBorderStyle}">
                 <EventSetter Event="MouseLeftButtonDown" Handler="Border_MouseDown" />
+            </Style>
+
+            <Style x:Key="FormattingHelpBlock" TargetType="TextBlock"
+                   BasedOn="{StaticResource ChangeIssueStatusLabelStyle}">
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.CaptionTextKey}}" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+            <Style x:Key="CommentTextStyle" TargetType="TextBox">
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="Height" Value="60" />
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="Width" Value="500" />
+                <Setter Property="AcceptsReturn" Value="True" />
+                <Setter Property="AcceptsTab" Value="True" />
+                <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+                <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.CaptionTextKey}}" />
             </Style>
         </ResourceDictionary>
     </Window.Resources>
@@ -28,6 +50,7 @@
     <Grid Margin="10" DataContext="{Binding ElementName=ReviewHotspotWindowName, Path=ViewModel}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
@@ -46,15 +69,38 @@
                             <RadioButton Grid.Row="0" GroupName="StatusGroup" Content="{Binding Path=Title}"
                                          Style="{StaticResource ChangeIssueStatusRadioButtonStyle}"
                                          IsChecked="{Binding IsChecked}" Checked="RadioButton_OnChecked" />
-                            <TextBlock Grid.Row="1" Text="{Binding Path=Description}" 
-                                       Style="{StaticResource ChangeIssueStatusLabelStyle}"/>
+                            <TextBlock Grid.Row="1" Text="{Binding Path=Description}"
+                                       Style="{StaticResource ChangeIssueStatusLabelStyle}" />
                         </Grid>
                     </Border>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
 
-        <Grid Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,5, 0">
+        <Grid Grid.Row="1" Margin="0, 10" HorizontalAlignment="Center">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="{x:Static resx:Resources.ChangeStatusWindow_CommentLabel}"
+                       Style="{StaticResource ChangeIssueStatusLabelStyle}"
+                       Margin="0, 0,0,2" />
+            <TextBox Grid.Row="1" Text="{Binding Path=Comment, UpdateSourceTrigger=PropertyChanged}"
+                     Style="{StaticResource CommentTextStyle}"
+                     Margin="0" />
+            <TextBlock Grid.Row="2" Style="{StaticResource FormattingHelpBlock}"
+                       Margin="0, 2,0,0">
+                <Hyperlink Name="FormattingHelpHyperlink" NavigateUri=""
+                           RequestNavigate="FormattingHelpHyperlink_RequestNavigate">
+                    <Run Text="{x:Static resx:Resources.ChangeStatusWindow_FormattingHelpLink}" />
+                </Hyperlink>
+                <Run Text="{x:Static resx:Resources.ChangeStatusWindow_FormattingHelpExamples}" />
+            </TextBlock>
+        </Grid>
+
+        <Grid Grid.Row="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,5, 0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
@@ -10,6 +10,7 @@
     xmlns:resx="clr-namespace:SonarLint.VisualStudio.IssueVisualization.Security"
     xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
     xmlns:wpf="clr-namespace:SonarLint.VisualStudio.Core.WPF;assembly=SonarLint.VisualStudio.Core"
+    xmlns:ui="clr-namespace:SonarLint.VisualStudio.ConnectedMode.UI;assembly=SonarLint.VisualStudio.ConnectedMode"
     x:Name="ReviewHotspotWindowName"
     Title="{x:Static security:Resources.ReviewHotspotWindow_Title}">
     <Window.Resources>
@@ -19,6 +20,8 @@
                     Source="pack://application:,,,/SonarLint.VisualStudio.ConnectedMode;component/UI/Resources/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <wpf:BoolToVisibilityConverter x:Key="TrueToVisibleConverter" FalseValue="Collapsed" TrueValue="Visible" />
+            <wpf:BoolToVisibilityConverter x:Key="TrueToVisibleConverterWithHidden" FalseValue="Hidden"
+                                           TrueValue="Visible" />
 
             <Style x:Key="ChangeIssueStatusWithHandlerBorderStyle" TargetType="Border"
                    BasedOn="{StaticResource ChangeIssueStatusBorderStyle}">
@@ -79,18 +82,20 @@
             </ListBox.ItemTemplate>
         </ListBox>
 
-        <Grid Grid.Row="1" Margin="0, 10" HorizontalAlignment="Center" 
+        <Grid Grid.Row="1" Margin="0, 10" HorizontalAlignment="Center"
               Visibility="{Binding Path=ShowComment, Converter={StaticResource TrueToVisibleConverter}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Text="{x:Static resx:Resources.ChangeStatusWindow_CommentLabel}"
                        Style="{StaticResource ChangeIssueStatusLabelStyle}"
                        Margin="0, 0,0,2" />
-            <TextBox Grid.Row="1" Text="{Binding Path=Comment, UpdateSourceTrigger=PropertyChanged}"
+            <TextBox x:Name="CommentTextBox" Grid.Row="1"
+                     Text="{Binding Path=Comment, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}"
                      Style="{StaticResource CommentTextStyle}"
                      Margin="0" />
             <TextBlock Grid.Row="2" Style="{StaticResource FormattingHelpBlock}"
@@ -101,6 +106,10 @@
                 </Hyperlink>
                 <Run Text="{x:Static resx:Resources.ChangeStatusWindow_FormattingHelpExamples}" />
             </TextBlock>
+            <ui:WarningMessage Grid.Row="3"
+                               WarningText="{Binding Path=(Validation.Errors)[0].ErrorContent, ElementName=CommentTextBox}"
+                               Margin="0,5,0,0"
+                               Visibility="{Binding (Validation.HasError), ElementName=CommentTextBox, Converter={StaticResource TrueToVisibleConverterWithHidden}}" />
         </Grid>
 
         <Grid Grid.Row="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,5, 0">

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml
@@ -59,7 +59,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <ListBox Grid.Row="0" ItemsSource="{Binding AllowedStatusViewModels}"
+        <ListBox Grid.Row="0" ItemsSource="{Binding AllStatusViewModels}"
                  SelectedItem="{Binding Path=SelectedStatusViewModel}"
                  Style="{StaticResource ChangeIssueStatusListBoxStyle}"
                  ItemContainerStyle="{StaticResource NoSelectionListBoxItemStyle}">

--- a/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml.cs
+++ b/src/IssueViz.Security/ReviewStatus/ChangeStatusWindow.xaml.cs
@@ -22,6 +22,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Navigation;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Binding;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
@@ -31,11 +34,15 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 [ExcludeFromCodeCoverage]
 public partial class ChangeStatusWindow : Window
 {
+    private readonly IBrowserService browserService;
+    private readonly IActiveSolutionBoundTracker activeSolutionBoundTracker;
     public IChangeStatusViewModel ViewModel { get; }
 
-    public ChangeStatusWindow(IChangeStatusViewModel iChangeStatusViewModel)
+    public ChangeStatusWindow(IChangeStatusViewModel changeStatusViewModel, IBrowserService browserService, IActiveSolutionBoundTracker activeSolutionBoundTracker)
     {
-        ViewModel = iChangeStatusViewModel;
+        this.browserService = browserService;
+        this.activeSolutionBoundTracker = activeSolutionBoundTracker;
+        ViewModel = changeStatusViewModel;
 
         InitializeComponent();
     }
@@ -63,5 +70,14 @@ public partial class ChangeStatusWindow : Window
         {
             ViewModel.SelectedStatusViewModel = statusViewModel;
         }
+    }
+
+    private void FormattingHelpHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        var serverConnection = activeSolutionBoundTracker.CurrentConfiguration.Project.ServerConnection;
+        var serverUri = serverConnection.ServerUri.ToString();
+
+        browserService.Navigate(serverConnection is ServerConnection.SonarCloud ? $"{serverUri}markdown/help" : $"{serverUri}formatting/help");
+        e.Handled = true;
     }
 }

--- a/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
@@ -26,5 +26,6 @@ public interface IChangeStatusViewModel
 {
     IStatusViewModel SelectedStatusViewModel { get; set; }
     ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; }
+    string Comment { get; set; }
     bool IsSubmitButtonEnabled { get; }
 }

--- a/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
@@ -19,10 +19,11 @@
  */
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
-public interface IChangeStatusViewModel
+public interface IChangeStatusViewModel : IDataErrorInfo
 {
     IStatusViewModel SelectedStatusViewModel { get; set; }
     ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; }

--- a/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
@@ -26,6 +26,7 @@ public interface IChangeStatusViewModel
 {
     IStatusViewModel SelectedStatusViewModel { get; set; }
     ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; }
-    string Comment { get; set; }
+    public string Comment { get; set; }
+    public bool ShowComment { get; }
     bool IsSubmitButtonEnabled { get; }
 }

--- a/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/IChangeStatusViewModel.cs
@@ -26,7 +26,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 public interface IChangeStatusViewModel : IDataErrorInfo
 {
     IStatusViewModel SelectedStatusViewModel { get; set; }
-    ObservableCollection<IStatusViewModel> AllowedStatusViewModels { get; }
+    ObservableCollection<IStatusViewModel> AllStatusViewModels { get; }
     public string Comment { get; set; }
     public bool ShowComment { get; }
     bool IsSubmitButtonEnabled { get; }

--- a/src/IssueViz.Security/ReviewStatus/IStatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/IStatusViewModel.cs
@@ -25,6 +25,7 @@ public interface IStatusViewModel
     bool IsChecked { get; set; }
     string Title { get; }
     string Description { get; }
+    bool IsCommentRequired { get; }
 
     T GetCurrentStatus<T>() where T : struct, Enum;
 }

--- a/src/IssueViz.Security/ReviewStatus/StatusViewModel.cs
+++ b/src/IssueViz.Security/ReviewStatus/StatusViewModel.cs
@@ -22,13 +22,18 @@ using SonarLint.VisualStudio.Core.WPF;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
-public class StatusViewModel<T>(T status, string title, string description) : ViewModelBase, IStatusViewModel where T : struct, Enum
+public class StatusViewModel<T>(
+    T status,
+    string title,
+    string description,
+    bool isCommentRequired) : ViewModelBase, IStatusViewModel where T : struct, Enum
 {
     private bool isChecked;
 
     public T Status { get; } = status;
     public string Title { get; } = title;
     public string Description { get; } = description;
+    public bool IsCommentRequired { get; } = isCommentRequired;
 
     public bool IsChecked
     {


### PR DESCRIPTION
[SLVS-2395](https://sonarsource.atlassian.net/browse/SLVS-2395)

Extend the `ChangeStatusWindow` to allow showing a comment and to make the comment mandatory depending on configured statuses.

This targets the https://github.com/SonarSource/sonarlint-visualstudio/pull/6328 in which the `ChangeStatusWindow` has been added.

[SLVS-2395]: https://sonarsource.atlassian.net/browse/SLVS-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ