### PR TITLE
SLVS-2397 Fix exception thrown when trying to review hotspot when no hotspot is selected

### DIFF
--- a/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
@@ -573,6 +573,16 @@ public class HotspotsControlViewModelTests
     }
 
     [TestMethod]
+    public async Task ViewHotspotInBrowserAsync_NoHotspotSelected_DoesNotThrowException()
+    {
+        testSubject.SelectedHotspot = null;
+
+        await testSubject.ViewHotspotInBrowserAsync();
+
+        await reviewHotspotsService.Received(1).OpenHotspotAsync(null);
+    }
+
+    [TestMethod]
     public void Dispose_UnsubscribesFromActiveSolutionBoundTrackerEvents()
     {
         testSubject.Dispose();

--- a/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/Hotspots/HotspotsList/HotspotsControlViewModelTests.cs
@@ -469,6 +469,19 @@ public class HotspotsControlViewModelTests
     }
 
     [TestMethod]
+    public async Task GetAllowedStatusesAsync_NoStatusSelected_ShowsMessageBoxAndReturnsNull()
+    {
+        testSubject.SelectedHotspot = null;
+
+        var result = await testSubject.GetAllowedStatusesAsync();
+
+        result.Should().BeNull();
+        messageBox.Received(1).Show(
+            Arg.Is<string>(x => x == string.Format(Resources.ReviewHotspotWindow_CheckReviewPermittedFailureMessage, Resources.ReviewHotspotWindow_NoStatusSelectedFailureMessage)),
+            Arg.Is<string>(x => x == Resources.ReviewHotspotWindow_FailureTitle), MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    [TestMethod]
     [DataRow(HotspotStatus.Fixed)]
     [DataRow(HotspotStatus.Safe)]
     public async Task ChangeHotspotStatusAsync_Succeeds_HotspotStatusFixed_RemovesViewModel(HotspotStatus newStatus)

--- a/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
@@ -164,7 +164,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
 
         public async Task<IEnumerable<HotspotStatus>> GetAllowedStatusesAsync()
         {
-            var response = await reviewHotspotsService.CheckReviewHotspotPermittedAsync(SelectedHotspot.Hotspot.Issue.IssueServerKey);
+            var response = SelectedHotspot == null
+                ? new ReviewHotspotNotPermittedArgs(Resources.ReviewHotspotWindow_NoStatusSelectedFailureMessage)
+                : await reviewHotspotsService.CheckReviewHotspotPermittedAsync(SelectedHotspot.Hotspot.Issue.IssueServerKey);
             switch (response)
             {
                 case ReviewHotspotPermittedArgs reviewHotspotPermittedArgs:

--- a/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
+++ b/src/IssueViz.Security/Hotspots/HotspotsList/ViewModels/HotspotsControlViewModel.cs
@@ -200,7 +200,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsLi
             RefreshFiltering();
         }
 
-        public Task ViewHotspotInBrowserAsync() => reviewHotspotsService.OpenHotspotAsync(SelectedHotspot.Hotspot.Issue.IssueServerKey);
+        public Task ViewHotspotInBrowserAsync() => reviewHotspotsService.OpenHotspotAsync(SelectedHotspot?.Hotspot.Issue.IssueServerKey);
 
         /// <summary>
         /// Allow the observable collection <see cref="Hotspots"/> to be modified from non-UI thread.

--- a/src/IssueViz.Security/Resources.Designer.cs
+++ b/src/IssueViz.Security/Resources.Designer.cs
@@ -350,6 +350,15 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No hotspot has been selected..
+        /// </summary>
+        public static string ReviewHotspotWindow_NoStatusSelectedFailureMessage {
+            get {
+                return ResourceManager.GetString("ReviewHotspotWindow_NoStatusSelectedFailureMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occurred while reviewing the hotspot. The status has not been changed.
         ///Please check the logs for more details..
         /// </summary>

--- a/src/IssueViz.Security/Resources.resx
+++ b/src/IssueViz.Security/Resources.resx
@@ -191,6 +191,9 @@ Please check the logs for more details.</value>
     <value>The hotspot can not be reviewed due to the following error: {0}
 Please check the logs for more details.</value>
   </data>
+  <data name="ReviewHotspotWindow_NoStatusSelectedFailureMessage" xml:space="preserve">
+    <value>No hotspot has been selected.</value>
+  </data>
   <data name="ReviewHotspotWindow_FailureTitle" xml:space="preserve">
     <value>Review Hotspot Failure</value>
   </data>


### PR DESCRIPTION
[SLVS-2397](https://sonarsource.atlassian.net/browse/SLVS-2397)

The behavior is not easy to reproduce, but it can happen when there is a race condition between the context menu being shown and the row in the DataGrid being selected. If the first action happens first, then the exception is thrown and the UI crashes.



[SLVS-2397]: https://sonarsource.atlassian.net/browse/SLVS-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ