### PR TITLE
SLVS-2469 SLVS-2450 Enable "Text" language

### DIFF
--- a/src/Core.UnitTests/LanguageProviderTests.cs
+++ b/src/Core.UnitTests/LanguageProviderTests.cs
@@ -39,7 +39,7 @@ public class LanguageProviderTests
     [TestMethod]
     public void AllKnownLanguages_ShouldBeExpected()
     {
-        var expected = new[] { Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
+        var expected = new[] { Language.CSharp, Language.VBNET, Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql, Language.Text };
 
         testSubject.AllKnownLanguages.Should().BeEquivalentTo(expected);
     }
@@ -55,7 +55,7 @@ public class LanguageProviderTests
     [TestMethod]
     public void NonRoslynLanguages_ShouldBeExpected()
     {
-        var expected = new[] { Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql };
+        var expected = new[] { Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql, Language.Text };
 
         testSubject.NonRoslynLanguages.Should().BeEquivalentTo(expected);
     }
@@ -71,7 +71,7 @@ public class LanguageProviderTests
     [TestMethod]
     public void ExtraLanguagesInConnectedMode_ShouldBeExpected()
     {
-        var expected = new[] { Language.TSql };
+        var expected = new[] { Language.TSql, Language.Text };
 
         testSubject.ExtraLanguagesInConnectedMode.Should().BeEquivalentTo(expected);
     }
@@ -88,6 +88,7 @@ public class LanguageProviderTests
         var css = testSubject.GetLanguageFromLanguageKey("css");
         var html = testSubject.GetLanguageFromLanguageKey("Web");
         var tsql = testSubject.GetLanguageFromLanguageKey("tsql");
+        var text = testSubject.GetLanguageFromLanguageKey("text");
         var unknown = testSubject.GetLanguageFromLanguageKey("unknown");
 
         cs.Should().Be(Language.CSharp);
@@ -99,6 +100,7 @@ public class LanguageProviderTests
         css.Should().Be(Language.Css);
         html.Should().Be(Language.Html);
         tsql.Should().Be(Language.TSql);
+        text.Should().Be(Language.Text);
         unknown.Should().Be(null);
     }
 

--- a/src/Core.UnitTests/LanguageTests.cs
+++ b/src/Core.UnitTests/LanguageTests.cs
@@ -88,6 +88,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             LanguageHasExpectedRepoInfo(Language.Css, "css", "css");
             LanguageHasExpectedRepoInfo(Language.Html, "Web", "html");
             LanguageHasExpectedRepoInfo(Language.Secrets, "secrets", "secrets");
+            LanguageHasExpectedRepoInfo(Language.Text, "text", "text");
             LanguageHasExpectedRepoInfo(Language.TSql, "tsql", "tsql");
 
             DoesNotHaveRepoInfo(Language.Unknown.RepoInfo);
@@ -106,6 +107,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             DoesNotHaveRepoInfo(Language.Css.SecurityRepoInfo);
             DoesNotHaveRepoInfo(Language.Html.SecurityRepoInfo);
             DoesNotHaveRepoInfo(Language.Secrets.SecurityRepoInfo);
+            DoesNotHaveRepoInfo(Language.Text.SecurityRepoInfo);
             DoesNotHaveRepoInfo(Language.TSql.SecurityRepoInfo);
             DoesNotHaveRepoInfo(Language.Unknown.SecurityRepoInfo);
         }
@@ -142,6 +144,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             LanguageHasExpectedPlugin(Language.Css, "javascript", "sonar-javascript-plugin-(\\d+\\.\\d+\\.\\d+\\.\\d+)\\.jar");
 
             LanguageHasExpectedPlugin(Language.Secrets, "text", "sonar-text-plugin-(\\d+\\.\\d+\\.\\d+\\.\\d+)\\.jar");
+            LanguageHasExpectedPlugin(Language.Text, "text", "sonar-text-plugin-(\\d+\\.\\d+\\.\\d+\\.\\d+)\\.jar");
 
             LanguageHasExpectedPlugin(Language.Html, "web", "sonar-html-plugin-(\\d+\\.\\d+\\.\\d+\\.\\d+)\\.jar");
 
@@ -160,6 +163,7 @@ namespace SonarLint.VisualStudio.Core.UnitTests
             LanguageHasExpectedServerLanguageKey(Language.Css, "css");
             LanguageHasExpectedServerLanguageKey(Language.Html, "web");
             LanguageHasExpectedServerLanguageKey(Language.Secrets, "secrets");
+            LanguageHasExpectedServerLanguageKey(Language.Text, "text");
             LanguageHasExpectedServerLanguageKey(Language.TSql, "tsql");
         }
 

--- a/src/Core/ILanguageProvider.cs
+++ b/src/Core/ILanguageProvider.cs
@@ -55,11 +55,11 @@ public class LanguageProvider : ILanguageProvider
         LanguagesInStandaloneMode = AllKnownLanguages.Except(ExtraLanguagesInConnectedMode).ToList();
     }
 
-    public IReadOnlyList<Language> NonRoslynLanguages { get; } = [Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql];
+    public IReadOnlyList<Language> NonRoslynLanguages { get; } = [Language.C, Language.Cpp, Language.Js, Language.Ts, Language.Css, Language.Secrets, Language.Html, Language.TSql, Language.Text];
     public IReadOnlyList<Language> RoslynLanguages { get; } = [Language.CSharp, Language.VBNET];
     public IReadOnlyList<Language> AllKnownLanguages { get; }
     public IReadOnlyList<Language> LanguagesInStandaloneMode { get; }
-    public IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; } = [Language.TSql];
+    public IReadOnlyList<Language> ExtraLanguagesInConnectedMode { get; } = [Language.TSql, Language.Text];
 
     public Language GetLanguageFromLanguageKey(string languageKey) => AllKnownLanguages.FirstOrDefault(l => languageKey.Equals(l.ServerLanguageKey, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/Core/Language.cs
+++ b/src/Core/Language.cs
@@ -58,6 +58,7 @@ namespace SonarLint.VisualStudio.Core
         private static readonly RepoInfo CssRepo = new("css");
         private static readonly RepoInfo HtmlRepo = new("Web", "html"); //See https://github.com/SonarSource/sonarlint-visualstudio/issues/4586.
         private static readonly RepoInfo SecretsRepo = new("secrets");
+        private static readonly RepoInfo TextRepo = new("text");
         private static readonly RepoInfo TsqlRepo = new("tsql");
 
         public static readonly Language Unknown = new();
@@ -71,6 +72,7 @@ namespace SonarLint.VisualStudio.Core
         public static readonly Language Css = new("Css", "CSS", "css", JavascriptPlugin, CssRepo);
         public static readonly Language Html = new("Html", "HTML", "web", HtmlPlugin, HtmlRepo);
         public static readonly Language Secrets = new("Secrets", "Secrets", "secrets", SecretsPlugin, SecretsRepo);
+        public static readonly Language Text = new("Text", "Text", "text", SecretsPlugin, TextRepo);
         public static readonly Language TSql = new("TSql", "T-SQL", "tsql", TsqlPlugin, TsqlRepo);
 
         /// <summary>

--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -8,7 +8,7 @@
     <EmbeddedSonarCFamilyAnalyzerVersion>6.70.0.87073</EmbeddedSonarCFamilyAnalyzerVersion>
     <EmbeddedSonarJSAnalyzerVersion>11.2.0.34013</EmbeddedSonarJSAnalyzerVersion>
     <EmbeddedSonarHtmlAnalyzerVersion>3.19.0.5695</EmbeddedSonarHtmlAnalyzerVersion>
-    <EmbeddedSonarSecretsJarVersion>2.26.0.7517</EmbeddedSonarSecretsJarVersion>
+    <EmbeddedSonarSecretsJarVersion>2.27.0.7705</EmbeddedSonarSecretsJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->
     <EmbeddedSloopVersion>10.28.0.82014</EmbeddedSloopVersion>
     <EmbeddedEsLintBridgeVersion>1.0.0</EmbeddedEsLintBridgeVersion>

--- a/src/SLCore.UnitTests/Common/Helpers/LanguageExtensionsTests.cs
+++ b/src/SLCore.UnitTests/Common/Helpers/LanguageExtensionsTests.cs
@@ -65,6 +65,6 @@ public class LanguageExtensionsTests
     [
         [CoreLanguage.CSharp, SlCoreLanguage.CS], [CoreLanguage.VBNET, SlCoreLanguage.VBNET], [CoreLanguage.C, SlCoreLanguage.C], [CoreLanguage.Cpp, SlCoreLanguage.CPP],
         [CoreLanguage.Css, SlCoreLanguage.CSS], [CoreLanguage.Html, SlCoreLanguage.HTML], [CoreLanguage.Js, SlCoreLanguage.JS], [CoreLanguage.Secrets, SlCoreLanguage.SECRETS],
-        [CoreLanguage.Ts, SlCoreLanguage.TS], [CoreLanguage.TSql, SlCoreLanguage.TSQL]
+        [CoreLanguage.Ts, SlCoreLanguage.TS], [CoreLanguage.TSql, SlCoreLanguage.TSQL], [CoreLanguage.Text, SlCoreLanguage.TEXT]
     ];
 }

--- a/src/SLCore/Common/Helpers/LanguageExtensions.cs
+++ b/src/SLCore/Common/Helpers/LanguageExtensions.cs
@@ -37,6 +37,7 @@ internal static class LanguageExtensions
         { Secrets, Language.SECRETS },
         { Ts, Language.TS },
         { TSql, Language.TSQL },
+        { Text, Language.TEXT },
     };
 
     public static VisualStudio.Core.Language ConvertToCoreLanguage(this Language language)

--- a/src/SLCore/Common/Models/Language.cs
+++ b/src/SLCore/Common/Models/Language.cs
@@ -31,6 +31,7 @@ namespace SonarLint.VisualStudio.SLCore.Common.Models;
 public enum Language
 {
     ABAP,
+    ANSIBLE,
     APEX,
     AZURERESOURCEMANAGER,
     C,
@@ -44,6 +45,7 @@ public enum Language
     HTML,
     IPYTHON,
     JAVA,
+    JCL,
     JS,
     JSON,
     JSP,
@@ -58,6 +60,7 @@ public enum Language
     RUBY,
     SCALA,
     SECRETS,
+    TEXT,
     SWIFT,
     TERRAFORM,
     TS,


### PR DESCRIPTION
[SLVS-2469](https://sonarsource.atlassian.net/browse/SLVS-2469)
[SLVS-2450](https://sonarsource.atlassian.net/browse/SLVS-2450)

With the new "Text" language we should get some new Hotspots, like the one on the screenshot.

<img width="1453" height="67" alt="Screenshot 2025-08-15 153835" src="https://github.com/user-attachments/assets/fe03a379-2b73-4405-842d-8cd978a02d1d" />


[SLVS-2469]: https://sonarsource.atlassian.net/browse/SLVS-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SLVS-2450]: https://sonarsource.atlassian.net/browse/SLVS-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ