### PR TITLE
SLVS-2490 Catch exceptions thrown when handling a request

### DIFF
--- a/src/RoslynAnalyzerServer/Http/RoslynAnalysisHttpServer.cs
+++ b/src/RoslynAnalyzerServer/Http/RoslynAnalysisHttpServer.cs
@@ -138,6 +138,11 @@ internal sealed class RoslynAnalysisHttpServer(
             logger.LogVerbose(Resources.HttpRequestTimedOut, settings.RequestMillisecondsTimeout);
             httpRequestHandler.CloseRequest(context, HttpStatusCode.RequestTimeout);
         }
+        catch (Exception exception)
+        {
+            logger.LogVerbose(Resources.HttpRequestFailed, exception.Message + exception.StackTrace);
+            httpRequestHandler.CloseRequest(context, HttpStatusCode.InternalServerError);
+        }
     }
 
     private async Task HandleRequest(IHttpListenerContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
[SLVS-2490](https://sonarsource.atlassian.net/browse/SLVS-2490)

Part of SLVS-2424 


[SLVS-2490]: https://sonarsource.atlassian.net/browse/SLVS-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ