### PR TITLE
SLVS-2495 Load CodeFixProvider-s from analyzer assemblies

### DIFF
--- a/src/RoslynAnalyzerServer.UnitTests/Analysis/Configuration/SonarLintXmlProviderTests.cs
+++ b/src/RoslynAnalyzerServer.UnitTests/Analysis/Configuration/SonarLintXmlProviderTests.cs
@@ -51,7 +51,7 @@ public class SonarLintXmlProviderTests
     [TestMethod]
     public void Create_ReturnsExpectedXml()
     {
-        var profile = new RoslynAnalysisProfile(default, [], []);
+        var profile = new RoslynAnalysisProfile(default, null!, [], []);
 
         var result = testSubject.Create(profile);
 
@@ -65,7 +65,7 @@ public class SonarLintXmlProviderTests
     public void Create_WithMultipleRulesAndProperties_ExpectedConfigurationSerialized()
     {
         var analysisProperties = new Dictionary<string, string> { { "prop1", "value1" }, { "prop2", "value2" } };
-        var result = testSubject.Create(new RoslynAnalysisProfile(default, [RuleWithoutParameters, RuleWithParameters], analysisProperties));
+        var result = testSubject.Create(new RoslynAnalysisProfile(default, null!, [RuleWithoutParameters, RuleWithParameters], analysisProperties));
 
         result.Should().NotBeNull();
 
@@ -80,7 +80,7 @@ public class SonarLintXmlProviderTests
     [TestMethod]
     public void Create_WithRuleNoParametersNoProperties_SerializesCorrectRules()
     {
-        var profile = new RoslynAnalysisProfile(default, [RuleWithoutParameters], []);
+        var profile = new RoslynAnalysisProfile(default, null!, [RuleWithoutParameters], []);
 
         var result = testSubject.Create(profile);
 
@@ -92,7 +92,7 @@ public class SonarLintXmlProviderTests
     [TestMethod]
     public void Create_WithRuleWithParameters_SerializesCorrectRules()
     {
-        var profile = new RoslynAnalysisProfile(default, [RuleWithParameters], []);
+        var profile = new RoslynAnalysisProfile(default, null!, [RuleWithParameters], []);
 
         var result = testSubject.Create(profile);
 
@@ -116,7 +116,7 @@ public class SonarLintXmlProviderTests
     {
         const string inactiveRuleKey = "inactiveRule";
         var rules = new List<RoslynRuleConfiguration> { RuleWithoutParameters, CreateRuleConfig(inactiveRuleKey, false), RuleWithParameters };
-        var profile = new RoslynAnalysisProfile(default, rules, []);
+        var profile = new RoslynAnalysisProfile(default, null!, rules, []);
 
         var result = testSubject.Create(profile);
 

--- a/src/RoslynAnalyzerServer.UnitTests/Analysis/RoslynProjectCompilationProviderTests.cs
+++ b/src/RoslynAnalyzerServer.UnitTests/Analysis/RoslynProjectCompilationProviderTests.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarLint.VisualStudio.Core;
@@ -38,6 +39,7 @@ public class RoslynProjectCompilationProviderTests
     private DiagnosticAnalyzer analyzer3 = null!;
     private AnalyzerOptions analyzerOptions = null!;
     private ImmutableArray<DiagnosticAnalyzer> analyzers;
+    private ImmutableDictionary<string, IReadOnlyCollection<CodeFixProvider>> codeFixProviders = null!;
     private IRoslynCompilationWrapper compilation = null!;
     private CompilationOptions compilationOptions = null!;
     private IRoslynCompilationWithAnalyzersWrapper compilationWithAnalyzers = null!;
@@ -58,13 +60,15 @@ public class RoslynProjectCompilationProviderTests
         SetUpAdditionalFiles();
         SetUpProject();
         SetUpAnalyzers();
+        SetUpCodeFixProviders();
         diagnosticOptions = ImmutableDictionary<string, ReportDiagnostic>.Empty
             .Add("SomeId", ReportDiagnostic.Warn);
         configurations = ImmutableDictionary<Language, RoslynAnalysisConfiguration>.Empty
             .Add(Language.CSharp, new RoslynAnalysisConfiguration(
                 sonarLintXml,
                 diagnosticOptions,
-                analyzers));
+                analyzers,
+                codeFixProviders));
         testSubject = new RoslynProjectCompilationProvider(logger);
     }
 
@@ -145,6 +149,11 @@ public class RoslynProjectCompilationProviderTests
         analyzer2 = Substitute.For<DiagnosticAnalyzer>();
         analyzer3 = Substitute.For<DiagnosticAnalyzer>();
         analyzers = ImmutableArray.Create(analyzer1, analyzer2, analyzer3);
+    }
+
+    private void SetUpCodeFixProviders()
+    {
+        codeFixProviders = ImmutableDictionary<string, IReadOnlyCollection<CodeFixProvider>>.Empty.Add("1", [Substitute.For<CodeFixProvider>()]);
     }
 
     private void SetUpProject()

--- a/src/RoslynAnalyzerServer.UnitTests/RoslynAnalyzerServer.UnitTests.csproj
+++ b/src/RoslynAnalyzerServer.UnitTests/RoslynAnalyzerServer.UnitTests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>SonarLint.VisualStudio.RoslynAnalyzerServer.UnitTests</AssemblyName>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RequiresLanguageServices>true</RequiresLanguageServices>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/RoslynAnalyzerServer.UnitTests/packages.lock.json
+++ b/src/RoslynAnalyzerServer.UnitTests/packages.lock.json
@@ -38,6 +38,19 @@
           "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Direct",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "YAbH4LCJfh8DhDGwYzSHqvnF06lKkVwblr8C+GwIYCv0i3Rzqjnbversat+i2n9k8twQ43yxVGTYK5p/mIOj4w==",
+        "dependencies": {
+          "Humanizer.Core": "2.2.0",
+          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Common": "[3.11.0]",
+          "System.Composition": "1.0.31",
+          "System.IO.Pipelines": "5.0.1"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[16.6.1, )",
@@ -144,6 +157,11 @@
         "type": "Transitive",
         "resolved": "1.4.1",
         "contentHash": "D5AcNr0yPFz5dqftJYKnMtwg6AEMUics+UysxTXKVuZtresqWUcHIrnscM+KsAIreG7wvdumWzjdIXRIMekCLg=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "rsYXB7+iUPP8AHgQ8JP2UZI2xK2KhjcdGr9E6zX3CsZaTLCaw8M35vaAJRo1rfxeaZEVMuXeaquLVCkZ7JcZ5Q=="
       },
       "MessagePack": {
         "type": "Transitive",
@@ -993,6 +1011,54 @@
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "+iB9FoZnfdqMEGq6np28X6YNSUrse16CakmIhV3h6PxEWt7jYxUN3Txs1D8MZhhf4QmyvK0F/EcIN0f4gGN0dA=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "I+D26qpYdoklyAVUdqwUBrEIckMNjAYnuPJy/h9dsQItpQwVREkDFs4b4tkBza0kT2Yk48Lcfsv2QQ9hWsh9Iw==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "1.0.31",
+          "System.Composition.Convention": "1.0.31",
+          "System.Composition.Hosting": "1.0.31",
+          "System.Composition.Runtime": "1.0.31",
+          "System.Composition.TypedParts": "1.0.31"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "NHWhkM3ZkspmA0XJEsKdtTt1ViDYuojgSND3yHhTzwxepiwqZf+BCWuvCbjUt4fe0NxxQhUDGJ5km6sLjo9qnQ=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "GLjh2Ju71k6C0qxMMtl4efHa68NmWeIUYh4fkUI8xbjQrEBvFmRwMDFcylT8/PR9SQbeeL48IkFxU/+gd0nYEQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "1.0.31"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "fN1bT4RX4vUqjbgoyuJFVUizAl2mYF5VAb+bVIxIYZSSc0BdnX+yGAxcavxJuDDCQ1K+/mdpgyEFc8e9ikjvrg==",
+        "dependencies": {
+          "System.Composition.Runtime": "1.0.31"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "0LEJN+2NVM89CE4SekDrrk5tHV5LeATltkp+9WNYrR+Huiyt0vaCqHbbHtVAjPyeLWIc8dOz/3kthRBj32wGQg=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "1.0.31",
+        "contentHash": "0Zae/FtzeFgDBBuILeIbC/T9HMYbW4olAmi8XqqAGosSOWvXfiQLfARZEhiGd0LVXaYgXr0NhxiU1LldRP1fpQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "1.0.31",
+          "System.Composition.Hosting": "1.0.31",
+          "System.Composition.Runtime": "1.0.31"
+        }
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",

--- a/src/RoslynAnalyzerServer/Analysis/Configuration/IRoslynAnalysisProfilesProvider.cs
+++ b/src/RoslynAnalyzerServer/Analysis/Configuration/IRoslynAnalysisProfilesProvider.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.RoslynAnalyzerServer.Http.Models;
@@ -28,9 +29,13 @@ namespace SonarLint.VisualStudio.RoslynAnalyzerServer.Analysis.Configuration;
 internal interface IRoslynAnalysisProfilesProvider
 {
     Dictionary<RoslynLanguage, RoslynAnalysisProfile> GetAnalysisProfilesByLanguage(
-        ImmutableDictionary<RoslynLanguage, AnalyzerAssemblyContents> supportedRulesByLanguage,
+        ImmutableDictionary<RoslynLanguage, AnalyzerAssemblyContents> analyzerAssemblyContents,
         List<ActiveRuleDto> activeRules,
         Dictionary<string, string>? analysisProperties);
 }
 
-internal record struct RoslynAnalysisProfile(ImmutableArray<DiagnosticAnalyzer> Analyzers, List<RoslynRuleConfiguration> Rules, Dictionary<string, string> AnalysisProperties);
+internal record struct RoslynAnalysisProfile(
+    ImmutableArray<DiagnosticAnalyzer> Analyzers,
+    ImmutableDictionary<string, IReadOnlyCollection<CodeFixProvider>> CodeFixProvidersByRuleKey,
+    List<RoslynRuleConfiguration> Rules,
+    Dictionary<string, string> AnalysisProperties);

--- a/src/RoslynAnalyzerServer/Analysis/Configuration/IRoslynAnalyzerLoader.cs
+++ b/src/RoslynAnalyzerServer/Analysis/Configuration/IRoslynAnalyzerLoader.cs
@@ -18,11 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace SonarLint.VisualStudio.RoslynAnalyzerServer.Analysis.Configuration;
 
 internal interface IRoslynAnalyzerLoader
 {
-    IReadOnlyCollection<DiagnosticAnalyzer> LoadAnalyzers(string filePath);
+    LoadedAnalyzerClasses LoadAnalyzerAssembly(string filePath);
 }
+
+internal readonly record struct LoadedAnalyzerClasses(IReadOnlyCollection<DiagnosticAnalyzer> Analyzers, IReadOnlyCollection<CodeFixProvider> CodeFixProviders);

--- a/src/RoslynAnalyzerServer/Analysis/Configuration/IRoslynAnalyzerProvider.cs
+++ b/src/RoslynAnalyzerServer/Analysis/Configuration/IRoslynAnalyzerProvider.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarLint.VisualStudio.Core;
 
@@ -26,7 +27,10 @@ namespace SonarLint.VisualStudio.RoslynAnalyzerServer.Analysis.Configuration;
 
 internal interface IRoslynAnalyzerProvider
 {
-    ImmutableDictionary<RoslynLanguage, AnalyzerAssemblyContents> LoadAnalyzerAssemblies();
+    ImmutableDictionary<RoslynLanguage, AnalyzerAssemblyContents> LoadAndProcessAnalyzerAssemblies();
 }
 
-internal record struct AnalyzerAssemblyContents(ImmutableArray<DiagnosticAnalyzer> Analyzers, ImmutableHashSet<string> SupportedRuleKeys);
+internal readonly record struct AnalyzerAssemblyContents(
+    ImmutableArray<DiagnosticAnalyzer> Analyzers,
+    ImmutableHashSet<string> SupportedRuleKeys,
+    ImmutableDictionary<string, IReadOnlyCollection<CodeFixProvider>> CodeFixProvidersByRuleKey);

--- a/src/RoslynAnalyzerServer/Analysis/Configuration/RoslynAnalysisConfigurationProvider.cs
+++ b/src/RoslynAnalyzerServer/Analysis/Configuration/RoslynAnalysisConfigurationProvider.cs
@@ -40,7 +40,7 @@ internal class RoslynAnalysisConfigurationProvider(
     {
         // todo add caching https://sonarsource.atlassian.net/browse/SLVS-2481
 
-        var analysisProfilesByLanguage = analyzerProfilesProvider.GetAnalysisProfilesByLanguage(roslynAnalyzerProvider.LoadAnalyzerAssemblies(), activeRules, analysisProperties);
+        var analysisProfilesByLanguage = analyzerProfilesProvider.GetAnalysisProfilesByLanguage(roslynAnalyzerProvider.LoadAndProcessAnalyzerAssemblies(), activeRules, analysisProperties);
 
         var configurations = new Dictionary<Language, RoslynAnalysisConfiguration>();
         foreach (var analyzerAndLanguage in analysisProfilesByLanguage)
@@ -67,7 +67,8 @@ internal class RoslynAnalysisConfigurationProvider(
                 new RoslynAnalysisConfiguration(
                     sonarLintXmlProvider.Create(analysisProfile),
                     analysisProfile.Rules.ToImmutableDictionary(x => x.RuleId.RuleKey, y => y.ReportDiagnostic),
-                    analysisProfile.Analyzers));
+                    analysisProfile.Analyzers,
+                    analysisProfile.CodeFixProvidersByRuleKey));
         }
 
         return configurations;

--- a/src/RoslynAnalyzerServer/Analysis/Configuration/RoslynAnalyzerLoader.cs
+++ b/src/RoslynAnalyzerServer/Analysis/Configuration/RoslynAnalyzerLoader.cs
@@ -63,6 +63,7 @@ internal class RoslynAnalyzerLoader(ILogger logger) : IRoslynAnalyzerLoader
         }
     }
 
+    [ExcludeFromCodeCoverage]
     private bool TryLoadType<T>(Type type, [NotNullWhen(true)] out T? value) where T : class
     {
         value = null;

--- a/src/RoslynAnalyzerServer/Analysis/RoslynAnalysisConfiguration.cs
+++ b/src/RoslynAnalyzerServer/Analysis/RoslynAnalysisConfiguration.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarLint.VisualStudio.RoslynAnalyzerServer.Analysis.Configuration;
 
@@ -28,4 +29,5 @@ namespace SonarLint.VisualStudio.RoslynAnalyzerServer.Analysis;
 internal record struct RoslynAnalysisConfiguration(
     SonarLintXmlConfigurationFile SonarLintXml,
     ImmutableDictionary<string, ReportDiagnostic> DiagnosticOptions,
-    ImmutableArray<DiagnosticAnalyzer> Analyzers);
+    ImmutableArray<DiagnosticAnalyzer> Analyzers,
+    ImmutableDictionary<string, IReadOnlyCollection<CodeFixProvider>> CodeFixProvidersByRuleKey);

--- a/src/RoslynAnalyzerServer/Resources.Designer.cs
+++ b/src/RoslynAnalyzerServer/Resources.Designer.cs
@@ -177,6 +177,15 @@ namespace SonarLint.VisualStudio.RoslynAnalyzerServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to load class {0} from {1}: {2}.
+        /// </summary>
+        internal static string RoslynAnalysisAnalyzerClassLoaderFailedToLoad {
+            get {
+                return ResourceManager.GetString("RoslynAnalysisAnalyzerClassLoaderFailedToLoad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to load analyzer {0}: {1}.
         /// </summary>
         internal static string RoslynAnalysisAnalyzerLoaderFailedToLoad {

--- a/src/RoslynAnalyzerServer/Resources.resx
+++ b/src/RoslynAnalyzerServer/Resources.resx
@@ -174,4 +174,7 @@
   <data name="RoslynAnalysisAnalyzerLoaderFailedToLoad" xml:space="preserve">
     <value>Failed to load analyzer {0}: {1}</value>
   </data>
+  <data name="RoslynAnalysisAnalyzerClassLoaderFailedToLoad" xml:space="preserve">
+    <value>Failed to load class {0} from {1}: {2}</value>
+  </data>
 </root>


### PR DESCRIPTION
[SLVS-2495](https://sonarsource.atlassian.net/browse/SLVS-2495)

Part of SLVS-2406

[SLVS-2495]: https://sonarsource.atlassian.net/browse/SLVS-2495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ