### PR TITLE
SLVS-2510 Rename properties specific to SqvsRoslynPlugin

### DIFF
--- a/src/RoslynAnalyzerServer.UnitTests/Http/HttpServerConfigurationProviderTest.cs
+++ b/src/RoslynAnalyzerServer.UnitTests/Http/HttpServerConfigurationProviderTest.cs
@@ -104,8 +104,8 @@ public class HttpServerConfigurationProviderTest
     [TestMethod]
     public void MapToInferredProperties_ReturnsExpectedProperties()
     {
-        var portKey = "sonar.cs.internal.roslynAnalyzerServerPort";
-        var tokenKey = "sonar.cs.internal.roslynAnalyzerServerToken";
+        var portKey = "sonar.sqvsRoslynPlugin.internal.serverPort";
+        var tokenKey = "sonar.sqvsRoslynPlugin.internal.serverToken";
 
         var analysisProperties = testSubject.CurrentConfiguration.MapToInferredProperties();
 

--- a/src/RoslynAnalyzerServer/Http/HttpServerConfigurationProvider.cs
+++ b/src/RoslynAnalyzerServer/Http/HttpServerConfigurationProvider.cs
@@ -70,8 +70,8 @@ internal class HttpServerConfigurationProvider : IHttpServerConfigurationProvide
     private sealed class HttpServerConfiguration : IHttpServerConfiguration
     {
         private const int TokenByteLength = 32;
-        private const string PortAnalysisPropertyKey = "sonar.cs.internal.roslynAnalyzerServerPort";
-        private const string TokenAnalysisPropertyKey = "sonar.cs.internal.roslynAnalyzerServerToken";
+        private const string PortAnalysisPropertyKey = "sonar.sqvsRoslynPlugin.internal.serverPort";
+        private const string TokenAnalysisPropertyKey = "sonar.sqvsRoslynPlugin.internal.serverToken";
 
         public int Port { get; } = GetAvailablePort();
         public SecureString Token { get; } = GenerateSecureToken();


### PR DESCRIPTION
[SLVS-2510](https://sonarsource.atlassian.net/browse/SLVS-2510)

Rename properties specific to SqvsRoslynPlugin to not match the pattern for C# analysis properties


[SLVS-2510]: https://sonarsource.atlassian.net/browse/SLVS-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ