### PR TITLE
SLVS-2430 Trigger analysis on pressed key with debounce

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -31,6 +31,7 @@ using SonarLint.VisualStudio.Core.Initialization;
 using SonarLint.VisualStudio.Integration.Vsix;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix.ErrorList;
+using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.Editor.LanguageDetection;
 
@@ -57,6 +58,7 @@ public class TaggerProviderTests
     private IAnalyzer analyzer;
     private IInitializationProcessorFactory initializationProcessorFactory;
     private IThreadHandling threadHandling;
+    private ITaskExecutorWithDebounceFactory taskExecutorWithDebounceFactory;
 
     private static readonly AnalysisLanguage[] DetectedLanguagesJsTs = [AnalysisLanguage.TypeScript, AnalysisLanguage.Javascript];
 
@@ -90,6 +92,8 @@ public class TaggerProviderTests
 
         threadHandling = Substitute.ForPartsOf<NoOpThreadHandler>();
 
+        taskExecutorWithDebounceFactory = Substitute.For<ITaskExecutorWithDebounceFactory>();
+
         testSubject = CreateAndInitializeTestSubject();
     }
 
@@ -121,7 +125,8 @@ public class TaggerProviderTests
         MefTestHelpers.CreateExport<IFileTracker>(),
         MefTestHelpers.CreateExport<IAnalyzer>(),
         MefTestHelpers.CreateExport<ILogger>(),
-        MefTestHelpers.CreateExport<IInitializationProcessorFactory>()
+        MefTestHelpers.CreateExport<IInitializationProcessorFactory>(),
+        MefTestHelpers.CreateExport<ITaskExecutorWithDebounceFactory>(),
     ];
 
     #endregion MEF tests
@@ -147,6 +152,7 @@ public class TaggerProviderTests
         tagger.Should().NotBeNull();
 
         VerifyCreateIssueConsumerWasCalled(doc);
+        taskExecutorWithDebounceFactory.Received(1).Create<ITextSnapshot>(debounceMilliseconds: 1000);
     }
 
     [TestMethod]
@@ -611,7 +617,7 @@ public class TaggerProviderTests
         var taggerProvider = new TaggerProvider(
             mockSonarErrorDataSource, dummyDocumentFactoryService, serviceProvider,
             mockSonarLanguageRecognizer, mockAnalysisRequester, vsProjectInfoProvider, issueConsumerFactory, issueConsumerStorage,
-            mockTaggableBufferIndicator, mockFileTracker, analyzer, logger, initializationProcessorFactory);
+            mockTaggableBufferIndicator, mockFileTracker, analyzer, logger, initializationProcessorFactory, taskExecutorWithDebounceFactory);
         taggerProvider.InitializationProcessor.InitializeAsync().GetAwaiter().GetResult();
         return taggerProvider;
     }

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -152,7 +152,7 @@ public class TaggerProviderTests
         tagger.Should().NotBeNull();
 
         VerifyCreateIssueConsumerWasCalled(doc);
-        taskExecutorWithDebounceFactory.Received(1).Create<ITextSnapshot>(debounceMilliseconds: 1000);
+        taskExecutorWithDebounceFactory.Received(1).Create<ITextSnapshot>(debounceMilliseconds: TimeSpan.FromMilliseconds(500));
     }
 
     [TestMethod]

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaggerProviderTests.cs
@@ -152,7 +152,7 @@ public class TaggerProviderTests
         tagger.Should().NotBeNull();
 
         VerifyCreateIssueConsumerWasCalled(doc);
-        taskExecutorWithDebounceFactory.Received(1).Create<ITextSnapshot>(debounceMilliseconds: TimeSpan.FromMilliseconds(500));
+        taskExecutorWithDebounceFactory.Received(1).Create(debounceMilliseconds: TimeSpan.FromMilliseconds(500));
     }
 
     [TestMethod]

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceFactoryTest.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceFactoryTest.cs
@@ -48,7 +48,7 @@ public class TaskExecutorWithDebounceFactoryTest
     [TestMethod]
     public void Create_ShouldReturnInstance()
     {
-        var result = testSubject.Create<ITextSnapshot>(1.0);
+        var result = testSubject.Create<ITextSnapshot>(TimeSpan.FromMilliseconds(1));
 
         result.Should().NotBeNull();
         result.Should().BeOfType<TaskExecutorWithDebounce<ITextSnapshot>>();

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceFactoryTest.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceFactoryTest.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.VisualStudio.Text;
 using SonarLint.VisualStudio.Core.Synchronization;
 using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
@@ -48,9 +47,9 @@ public class TaskExecutorWithDebounceFactoryTest
     [TestMethod]
     public void Create_ShouldReturnInstance()
     {
-        var result = testSubject.Create<ITextSnapshot>(TimeSpan.FromMilliseconds(1));
+        var result = testSubject.Create(TimeSpan.FromMilliseconds(1));
 
         result.Should().NotBeNull();
-        result.Should().BeOfType<TaskExecutorWithDebounce<ITextSnapshot>>();
+        result.Should().BeOfType<TaskExecutorWithDebounce>();
     }
 }

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceFactoryTest.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceFactoryTest.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.Text;
+using SonarLint.VisualStudio.Core.Synchronization;
+using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger;
+
+[TestClass]
+public class TaskExecutorWithDebounceFactoryTest
+{
+    private TaskExecutorWithDebounceFactory testSubject;
+    private IAsyncLockFactory asyncLockFactory;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        asyncLockFactory = Substitute.For<IAsyncLockFactory>();
+        testSubject = new TaskExecutorWithDebounceFactory(asyncLockFactory);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<TaskExecutorWithDebounceFactory, ITaskExecutorWithDebounceFactory>(
+            MefTestHelpers.CreateExport<IAsyncLockFactory>());
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<TaskExecutorWithDebounceFactory>();
+
+    [TestMethod]
+    public void Create_ShouldReturnInstance()
+    {
+        var result = testSubject.Create<ITextSnapshot>(1.0);
+
+        result.Should().NotBeNull();
+        result.Should().BeOfType<TaskExecutorWithDebounce<ITextSnapshot>>();
+    }
+}

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceTest.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceTest.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.Threading;
+using SonarLint.VisualStudio.Core.Synchronization;
+using SonarLint.VisualStudio.Integration.TestInfrastructure;
+using SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger;
+
+[TestClass]
+public class TaskExecutorWithDebounceTest
+{
+    private const int DebounceTimeInMs = 100;
+    private IAsyncLock asyncLock;
+    private IAsyncLockFactory asyncLockFactory;
+    private TaskExecutorWithDebounce<TestData> testSubject;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        asyncLockFactory = Substitute.For<IAsyncLockFactory>();
+        asyncLock = Substitute.For<IAsyncLock>();
+        asyncLockFactory.Create().Returns(asyncLock);
+        testSubject = new TaskExecutorWithDebounce<TestData>(asyncLockFactory, DebounceTimeInMs);
+    }
+
+    [TestMethod]
+    public async Task DebounceAsync_ExecutesTaskWithDebounce()
+    {
+        var currentState = new TestData { Value = 1 };
+        var tcs = new TaskCompletionSource<int>();
+        var stopwatch = Stopwatch.StartNew();
+
+        testSubject.DebounceAsync(currentState, state =>
+        {
+            UpdateState(state, 2, tcs);
+            stopwatch.Stop();
+        }).Forget();
+        await tcs.Task;
+
+        asyncLock.Received(1).AcquireAsync().IgnoreAwaitForAssert();
+        currentState.Value.Should().Be(2);
+        stopwatch.ElapsedMilliseconds.Should().BeGreaterOrEqualTo(DebounceTimeInMs);
+    }
+
+    [TestMethod]
+    public async Task DebounceAsync_MultipleTimes_UpdatesWithLatestState()
+    {
+        var currentState = new TestData { Value = 1 };
+        var tcs = new TaskCompletionSource<int>();
+
+        testSubject.DebounceAsync(currentState, state => UpdateState(state, 2)).Forget();
+        testSubject.DebounceAsync(currentState, state => UpdateState(state, 3)).Forget();
+        testSubject.DebounceAsync(currentState, state => UpdateState(state, 4, tcs)).Forget();
+        await tcs.Task;
+
+        asyncLock.Received(3).AcquireAsync().IgnoreAwaitForAssert();
+        currentState.Value.Should().Be(4);
+    }
+
+    private static void UpdateState(TestData date, int newValue, TaskCompletionSource<int> taskCompletionSource = null)
+    {
+        date.Value = newValue;
+        taskCompletionSource?.SetResult(1);
+    }
+
+    private record TestData
+    {
+        public int Value { get; set; }
+    }
+}

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceTest.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TaskExecutorWithDebounceTest.cs
@@ -28,7 +28,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarLintTagger;
 [TestClass]
 public class TaskExecutorWithDebounceTest
 {
-    private const int DebounceTimeInMs = 100;
+    private readonly TimeSpan debounceTimeInMs = TimeSpan.FromMilliseconds(100);
     private IAsyncLock asyncLock;
     private IAsyncLockFactory asyncLockFactory;
     private TaskExecutorWithDebounce<TestData> testSubject;
@@ -39,7 +39,7 @@ public class TaskExecutorWithDebounceTest
         asyncLockFactory = Substitute.For<IAsyncLockFactory>();
         asyncLock = Substitute.For<IAsyncLock>();
         asyncLockFactory.Create().Returns(asyncLock);
-        testSubject = new TaskExecutorWithDebounce<TestData>(asyncLockFactory, DebounceTimeInMs);
+        testSubject = new TaskExecutorWithDebounce<TestData>(asyncLockFactory, debounceTimeInMs);
     }
 
     [TestMethod]
@@ -58,7 +58,7 @@ public class TaskExecutorWithDebounceTest
 
         asyncLock.Received(1).AcquireAsync().IgnoreAwaitForAssert();
         currentState.Value.Should().Be(2);
-        stopwatch.ElapsedMilliseconds.Should().BeGreaterOrEqualTo(DebounceTimeInMs);
+        stopwatch.ElapsedMilliseconds.Should().BeGreaterOrEqualTo(debounceTimeInMs.Milliseconds);
     }
 
     [TestMethod]

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -75,7 +75,7 @@ public class TextBufferIssueTrackerTests
         javascriptLanguage = [AnalysisLanguage.Javascript];
         taskExecutorWithDebounceFactory = Substitute.For<ITaskExecutorWithDebounceFactory>();
         taskExecutorWithDebounce = Substitute.For<ITaskExecutorWithDebounce<ITextSnapshot>>();
-        taskExecutorWithDebounceFactory.Create<ITextSnapshot>(Arg.Any<double>()).Returns(taskExecutorWithDebounce);
+        taskExecutorWithDebounceFactory.Create<ITextSnapshot>(Arg.Any<TimeSpan>()).Returns(taskExecutorWithDebounce);
         MockIssueConsumerFactory(mockedJavascriptDocumentFooJs, issueConsumer);
 
         testSubject = CreateTestSubject(mockedJavascriptDocumentFooJs);
@@ -156,6 +156,7 @@ public class TextBufferIssueTrackerTests
         taggerProvider.ActiveTrackersForTesting.Should().BeEmpty();
 
         mockedJavascriptDocumentFooJs.Received(1).FileActionOccurred -= Arg.Any<EventHandler<TextDocumentFileActionEventArgs>>();
+        ((ITextBuffer2)mockDocumentTextBuffer).Received(1).ChangedOnBackground -= Arg.Any<EventHandler<TextContentChangedEventArgs>>();
     }
 
     [TestMethod]

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -56,6 +56,8 @@ public class TextBufferIssueTrackerTests
     private IIssueConsumerFactory issueConsumerFactory;
     private IIssueConsumerStorage issueConsumerStorage;
     private IIssueConsumer issueConsumer;
+    private ITaskExecutorWithDebounceFactory taskExecutorWithDebounceFactory;
+    private ITaskExecutorWithDebounce<ITextSnapshot> taskExecutorWithDebounce;
 
     [TestInitialize]
     public void SetUp()
@@ -71,6 +73,9 @@ public class TextBufferIssueTrackerTests
         mockDocumentTextBuffer = CreateTextBufferMock(mockTextSnapshot);
         mockedJavascriptDocumentFooJs = CreateDocumentMock("foo.js", mockDocumentTextBuffer);
         javascriptLanguage = [AnalysisLanguage.Javascript];
+        taskExecutorWithDebounceFactory = Substitute.For<ITaskExecutorWithDebounceFactory>();
+        taskExecutorWithDebounce = Substitute.For<ITaskExecutorWithDebounce<ITextSnapshot>>();
+        taskExecutorWithDebounceFactory.Create<ITextSnapshot>(Arg.Any<double>()).Returns(taskExecutorWithDebounce);
         MockIssueConsumerFactory(mockedJavascriptDocumentFooJs, issueConsumer);
 
         testSubject = CreateTestSubject(mockedJavascriptDocumentFooJs);
@@ -98,6 +103,7 @@ public class TextBufferIssueTrackerTests
         taggerProvider.ActiveTrackersForTesting.Should().BeEquivalentTo(testSubject);
 
         mockedJavascriptDocumentFooJs.Received(1).FileActionOccurred += Arg.Any<EventHandler<TextDocumentFileActionEventArgs>>();
+        ((ITextBuffer2)mockDocumentTextBuffer).Received(1).ChangedOnBackground += Arg.Any<EventHandler<TextContentChangedEventArgs>>();
 
         // Note: the test subject isn't responsible for adding the entry to the buffer.Properties
         // - that's done by the TaggerProvider.
@@ -196,7 +202,6 @@ public class TextBufferIssueTrackerTests
         var renamedEventHandler = Substitute.For<EventHandler<DocumentRenamedEventArgs>>();
         var savedEventHandler = Substitute.For<EventHandler<DocumentEventArgs>>();
         taggerProvider.OpenDocumentRenamed += renamedEventHandler;
-        taggerProvider.DocumentSaved += savedEventHandler;
 
         RaiseFileLoadedEvent(mockedJavascriptDocumentFooJs);
 
@@ -326,6 +331,21 @@ public class TextBufferIssueTrackerTests
             .WithMessage("this is a test");
     }
 
+    [TestMethod]
+    public void OnTextBufferChangedOnBackground_UpdatesAnalysisState()
+    {
+        var eventHandler = SubscribeToDocumentSaved();
+        var newContent = "new content";
+        var newSnapshot = CreateTextSnapshotMock(newContent);
+        var newAnalysisSnapshot = new AnalysisSnapshot(mockedJavascriptDocumentFooJs.FilePath, newSnapshot);
+        MockTaskExecutorWithDebounce(newSnapshot);
+        CreateTestSubject(mockedJavascriptDocumentFooJs);
+
+        RaiseTextBufferChangedOnBackground(currentTextBuffer: mockDocumentTextBuffer, newSnapshot);
+
+        VerifyAnalysisStateUpdated(mockedJavascriptDocumentFooJs, newAnalysisSnapshot, eventHandler, newContent);
+    }
+
     private void SetUpIssueConsumerStorageThrows(Exception exception) => issueConsumerStorage.When(x => x.Remove(Arg.Any<string>())).Do(x => throw exception);
 
     private static void VerifySingletonManagerDoesNotExist(ITextBuffer buffer) => FindSingletonManagerInPropertyCollection(buffer).Should().BeNull();
@@ -372,21 +392,21 @@ public class TextBufferIssueTrackerTests
         var analysisRequester = mockAnalysisRequester;
         var provider = new TaggerProvider(sonarErrorListDataSource, textDocumentFactoryService,
             serviceProvider, languageRecognizer, analysisRequester, vsProjectInfoProvider, issueConsumerFactory, issueConsumerStorage, Mock.Of<ITaggableBufferIndicator>(),
-            mockFileTracker, analyzer, logger, new InitializationProcessorFactory(Substitute.For<IAsyncLockFactory>(), new NoOpThreadHandler(), new TestLogger()));
+            mockFileTracker, analyzer, logger, new InitializationProcessorFactory(Substitute.For<IAsyncLockFactory>(), new NoOpThreadHandler(), new TestLogger()), taskExecutorWithDebounceFactory);
         return provider;
     }
 
-    private static ITextSnapshot CreateTextSnapshotMock()
+    private static ITextSnapshot CreateTextSnapshotMock(string content = TextContent)
     {
         var textSnapshot = Substitute.For<ITextSnapshot>();
-        textSnapshot.GetText().Returns(TextContent);
+        textSnapshot.GetText().Returns(content);
         return textSnapshot;
     }
 
     private static ITextBuffer CreateTextBufferMock(ITextSnapshot textSnapshot)
     {
         // Text buffer with a properties collection and current snapshot
-        var mockTextBuffer = Substitute.For<ITextBuffer>();
+        var mockTextBuffer = Substitute.For<ITextBuffer2>();
 
         var dummyProperties = new PropertyCollection();
         mockTextBuffer.Properties.Returns(dummyProperties);
@@ -446,12 +466,51 @@ public class TextBufferIssueTrackerTests
     private TextBufferIssueTracker CreateTestSubject(ITextDocument textDocument, ILogger logger) =>
         new(taggerProvider,
             textDocument, javascriptLanguage,
-            mockSonarErrorDataSource, vsProjectInfoProvider, issueConsumerFactory, issueConsumerStorage, logger);
+            mockSonarErrorDataSource, vsProjectInfoProvider, issueConsumerFactory, issueConsumerStorage, taskExecutorWithDebounce, logger);
 
     private void ClearIssueConsumerCalls()
     {
         issueConsumerStorage.ClearReceivedCalls();
         issueConsumerFactory.ClearReceivedCalls();
         vsProjectInfoProvider.ClearReceivedCalls();
+    }
+
+    private static void RaiseTextBufferChangedOnBackground(ITextBuffer currentTextBuffer, ITextSnapshot newTextSnapshot)
+    {
+        var args = new TextContentChangedEventArgs(Substitute.For<ITextSnapshot>(), newTextSnapshot, EditOptions.DefaultMinimalChange, null);
+        ((ITextBuffer2)currentTextBuffer).ChangedOnBackground += Raise.EventWith(null, args);
+    }
+
+    private EventHandler<DocumentEventArgs> SubscribeToDocumentSaved()
+    {
+        var eventHandler = Substitute.For<EventHandler<DocumentEventArgs>>();
+        taggerProvider.DocumentUpdated += eventHandler;
+        return eventHandler;
+    }
+
+    private void MockTaskExecutorWithDebounce(ITextSnapshot newSnapshot) =>
+        taskExecutorWithDebounce.When(x => x.DebounceAsync(Arg.Is<ITextSnapshot>(x => x == newSnapshot), Arg.Any<Action<ITextSnapshot>>())).Do(callInfo =>
+        {
+            var action = callInfo.Arg<Action<ITextSnapshot>>();
+            action(newSnapshot);
+        });
+
+    private void VerifyAnalysisStateUpdated(
+        ITextDocument textDocument,
+        AnalysisSnapshot newAnalysisSnapshot,
+        EventHandler<DocumentEventArgs> eventHandler,
+        string newContent)
+    {
+        issueConsumerStorage.Received().Remove(textDocument.FilePath);
+        vsProjectInfoProvider.Received().GetDocumentProjectInfo(newAnalysisSnapshot.FilePath);
+        issueConsumerFactory.Received().Create(textDocument, newAnalysisSnapshot.FilePath, newAnalysisSnapshot.TextSnapshot, Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<SnapshotChangedHandler>());
+        issueConsumerStorage.Received().Set(textDocument.FilePath, Arg.Any<IIssueConsumer>());
+        issueConsumer.Received().SetIssues(textDocument.FilePath, []);
+        issueConsumer.Received().SetHotspots(textDocument.FilePath, []);
+        eventHandler.Received().Invoke(taggerProvider,
+            Arg.Is<DocumentEventArgs>(x => x.Document.FullPath == textDocument.FilePath
+                                           && x.Document.DetectedLanguages == javascriptLanguage
+                                           && x.Content == newContent));
     }
 }

--- a/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarLintTagger/TextBufferIssueTrackerTests.cs
@@ -57,7 +57,7 @@ public class TextBufferIssueTrackerTests
     private IIssueConsumerStorage issueConsumerStorage;
     private IIssueConsumer issueConsumer;
     private ITaskExecutorWithDebounceFactory taskExecutorWithDebounceFactory;
-    private ITaskExecutorWithDebounce<ITextSnapshot> taskExecutorWithDebounce;
+    private ITaskExecutorWithDebounce taskExecutorWithDebounce;
 
     [TestInitialize]
     public void SetUp()
@@ -74,8 +74,8 @@ public class TextBufferIssueTrackerTests
         mockedJavascriptDocumentFooJs = CreateDocumentMock("foo.js", mockDocumentTextBuffer);
         javascriptLanguage = [AnalysisLanguage.Javascript];
         taskExecutorWithDebounceFactory = Substitute.For<ITaskExecutorWithDebounceFactory>();
-        taskExecutorWithDebounce = Substitute.For<ITaskExecutorWithDebounce<ITextSnapshot>>();
-        taskExecutorWithDebounceFactory.Create<ITextSnapshot>(Arg.Any<TimeSpan>()).Returns(taskExecutorWithDebounce);
+        taskExecutorWithDebounce = Substitute.For<ITaskExecutorWithDebounce>();
+        taskExecutorWithDebounceFactory.Create(Arg.Any<TimeSpan>()).Returns(taskExecutorWithDebounce);
         MockIssueConsumerFactory(mockedJavascriptDocumentFooJs, issueConsumer);
 
         testSubject = CreateTestSubject(mockedJavascriptDocumentFooJs);
@@ -339,7 +339,7 @@ public class TextBufferIssueTrackerTests
         var newContent = "new content";
         var newSnapshot = CreateTextSnapshotMock(newContent);
         var newAnalysisSnapshot = new AnalysisSnapshot(mockedJavascriptDocumentFooJs.FilePath, newSnapshot);
-        MockTaskExecutorWithDebounce(newSnapshot);
+        MockTaskExecutorWithDebounce();
         CreateTestSubject(mockedJavascriptDocumentFooJs);
 
         RaiseTextBufferChangedOnBackground(currentTextBuffer: mockDocumentTextBuffer, newSnapshot);
@@ -489,11 +489,11 @@ public class TextBufferIssueTrackerTests
         return eventHandler;
     }
 
-    private void MockTaskExecutorWithDebounce(ITextSnapshot newSnapshot) =>
-        taskExecutorWithDebounce.When(x => x.DebounceAsync(Arg.Is<ITextSnapshot>(x => x == newSnapshot), Arg.Any<Action<ITextSnapshot>>())).Do(callInfo =>
+    private void MockTaskExecutorWithDebounce() =>
+        taskExecutorWithDebounce.When(x => x.DebounceAsync(Arg.Any<Action>())).Do(callInfo =>
         {
-            var action = callInfo.Arg<Action<ITextSnapshot>>();
-            action(newSnapshot);
+            var action = callInfo.Arg<Action>();
+            action();
         });
 
     private void VerifyAnalysisStateUpdated(

--- a/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaggerProvider.cs
@@ -235,7 +235,7 @@ internal sealed class TaggerProvider : ITaggerProvider, IRequireInitialization, 
             vsProjectInfoProvider,
             issueConsumerFactory,
             issueConsumerStorage,
-            taskExecutorWithDebounceFactory.Create<ITextSnapshot>(debounceMilliseconds),
+            taskExecutorWithDebounceFactory.Create(debounceMilliseconds),
             logger);
 
     #endregion IViewTaggerProvider members

--- a/src/Integration.Vsix/SonarLintTagger/TaskExecutorWithDebounce.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaskExecutorWithDebounce.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Threading;
+using SonarLint.VisualStudio.Core.Synchronization;
+
+namespace SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
+
+internal interface ITaskExecutorWithDebounceFactory
+{
+    ITaskExecutorWithDebounce<T> Create<T>(double debounceMilliseconds);
+}
+
+internal interface ITaskExecutorWithDebounce<T>
+{
+    Task DebounceAsync(T state, Action<T> task);
+}
+
+[Export(typeof(ITaskExecutorWithDebounceFactory))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+[method: ImportingConstructor]
+internal class TaskExecutorWithDebounceFactory(IAsyncLockFactory asyncLockFactory) : ITaskExecutorWithDebounceFactory
+{
+    public ITaskExecutorWithDebounce<T> Create<T>(double debounceMilliseconds) => new TaskExecutorWithDebounce<T>(asyncLockFactory, debounceMilliseconds);
+}
+
+internal class TaskExecutorWithDebounce<T>(IAsyncLockFactory asyncLockFactory, double debounceMilliseconds) : ITaskExecutorWithDebounce<T>
+{
+    private sealed record Debounce(CancellationTokenSource CancellationTokenSource, T State);
+    private Debounce latestDebounceState;
+    private readonly IAsyncLock asyncLock = asyncLockFactory.Create();
+
+    public async Task DebounceAsync(T state, Action<T> task)
+    {
+        using (await asyncLock.AcquireAsync())
+        {
+            latestDebounceState?.CancellationTokenSource.Cancel();
+            latestDebounceState = new Debounce(new CancellationTokenSource(), state);
+        }
+
+        var latestState = latestDebounceState;
+        Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(debounceMilliseconds), latestState.CancellationTokenSource.Token);
+                if (!latestState.CancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    task(latestState.State);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // do nothing
+            }
+        }, latestState.CancellationTokenSource.Token).Forget();
+    }
+}

--- a/src/Integration.Vsix/SonarLintTagger/TaskExecutorWithDebounce.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TaskExecutorWithDebounce.cs
@@ -26,7 +26,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix.SonarLintTagger;
 
 internal interface ITaskExecutorWithDebounceFactory
 {
-    ITaskExecutorWithDebounce<T> Create<T>(double debounceMilliseconds);
+    ITaskExecutorWithDebounce<T> Create<T>(TimeSpan debounceMilliseconds);
 }
 
 internal interface ITaskExecutorWithDebounce<T>
@@ -39,10 +39,10 @@ internal interface ITaskExecutorWithDebounce<T>
 [method: ImportingConstructor]
 internal class TaskExecutorWithDebounceFactory(IAsyncLockFactory asyncLockFactory) : ITaskExecutorWithDebounceFactory
 {
-    public ITaskExecutorWithDebounce<T> Create<T>(double debounceMilliseconds) => new TaskExecutorWithDebounce<T>(asyncLockFactory, debounceMilliseconds);
+    public ITaskExecutorWithDebounce<T> Create<T>(TimeSpan debounceMilliseconds) => new TaskExecutorWithDebounce<T>(asyncLockFactory, debounceMilliseconds);
 }
 
-internal class TaskExecutorWithDebounce<T>(IAsyncLockFactory asyncLockFactory, double debounceMilliseconds) : ITaskExecutorWithDebounce<T>
+internal class TaskExecutorWithDebounce<T>(IAsyncLockFactory asyncLockFactory, TimeSpan debounceMilliseconds) : ITaskExecutorWithDebounce<T>
 {
     private sealed record Debounce(CancellationTokenSource CancellationTokenSource, T State);
     private Debounce latestDebounceState;
@@ -61,7 +61,7 @@ internal class TaskExecutorWithDebounce<T>(IAsyncLockFactory asyncLockFactory, d
         {
             try
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(debounceMilliseconds), latestState.CancellationTokenSource.Token);
+                await Task.Delay(debounceMilliseconds, latestState.CancellationTokenSource.Token);
                 if (!latestState.CancellationTokenSource.Token.IsCancellationRequested)
                 {
                     task(latestState.State);

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -109,6 +109,10 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         RemoveIssueConsumer(LastAnalysisFilePath);
         document.FileActionOccurred -= SafeOnFileActionOccurred;
         textBuffer.Properties.RemoveProperty(TaggerProvider.SingletonManagerPropertyCollectionKey);
+        if (textBuffer is ITextBuffer2 textBuffer2)
+        {
+            textBuffer2.ChangedOnBackground -= TextBuffer_OnChangedOnBackground;
+        }
         sonarErrorDataSource.RemoveFactory(Factory);
         Provider.OnDocumentClosed(this);
     }

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -100,7 +100,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
     public string LastAnalysisFilePath { get; private set; }
     public IEnumerable<AnalysisLanguage> DetectedLanguages { get; }
 
-    public void UpdateAnalysisState() => RefreshAnalysisState();
+    public void UpdateAnalysisState() => UpdateAnalysisState(null);
 
     public string GetText() => document.TextBuffer.CurrentSnapshot.GetText();
 
@@ -153,7 +153,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         }
     }
 
-    private void RefreshAnalysisState(ITextSnapshot newTextSnapshot = null)
+    private void UpdateAnalysisState(ITextSnapshot newTextSnapshot)
     {
         try
         {
@@ -201,7 +201,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
     private void TextBuffer_OnChangedOnBackground(object sender, TextContentChangedEventArgs e) =>
         taskExecutorWithDebounce.DebounceAsync(e.After, textSnapshot =>
         {
-            RefreshAnalysisState(textSnapshot);
+            UpdateAnalysisState(textSnapshot);
             Provider.OnDocumentUpdated(document.FilePath, textSnapshot.GetText(), DetectedLanguages);
         }).Forget();
 }

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -49,7 +49,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
     private readonly ITextDocument document;
     private readonly IIssueConsumerFactory issueConsumerFactory;
     private readonly IIssueConsumerStorage issueConsumerStorage;
-    private readonly ITaskExecutorWithDebounce<ITextSnapshot> taskExecutorWithDebounce;
+    private readonly ITaskExecutorWithDebounce taskExecutorWithDebounce;
     private readonly ILogger logger;
     private readonly ISonarErrorListDataSource sonarErrorDataSource;
     private readonly ITextBuffer textBuffer;
@@ -66,7 +66,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         IVsProjectInfoProvider vsProjectInfoProvider,
         IIssueConsumerFactory issueConsumerFactory,
         IIssueConsumerStorage issueConsumerStorage,
-        ITaskExecutorWithDebounce<ITextSnapshot> taskExecutorWithDebounce,
+        ITaskExecutorWithDebounce taskExecutorWithDebounce,
         ILogger logger)
     {
         Provider = provider;
@@ -199,8 +199,9 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
     }
 
     private void TextBuffer_OnChangedOnBackground(object sender, TextContentChangedEventArgs e) =>
-        taskExecutorWithDebounce.DebounceAsync(e.After, textSnapshot =>
+        taskExecutorWithDebounce.DebounceAsync(() =>
         {
+            var textSnapshot = e.After;
             UpdateAnalysisState(textSnapshot);
             Provider.OnDocumentUpdated(document.FilePath, textSnapshot.GetText(), DetectedLanguages);
         }).Forget();

--- a/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
+++ b/src/Integration.Vsix/SonarLintTagger/TextBufferIssueTracker.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Threading;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Integration.Vsix.Analysis;
@@ -48,10 +49,12 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
     private readonly ITextDocument document;
     private readonly IIssueConsumerFactory issueConsumerFactory;
     private readonly IIssueConsumerStorage issueConsumerStorage;
+    private readonly ITaskExecutorWithDebounce<ITextSnapshot> taskExecutorWithDebounce;
     private readonly ILogger logger;
     private readonly ISonarErrorListDataSource sonarErrorDataSource;
     private readonly ITextBuffer textBuffer;
     private readonly IVsProjectInfoProvider vsProjectInfoProvider;
+
     internal /* for testing */ TaggerProvider Provider { get; }
     internal /* for testing */ IssuesSnapshotFactory Factory { get; }
 
@@ -63,6 +66,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         IVsProjectInfoProvider vsProjectInfoProvider,
         IIssueConsumerFactory issueConsumerFactory,
         IIssueConsumerStorage issueConsumerStorage,
+        ITaskExecutorWithDebounce<ITextSnapshot> taskExecutorWithDebounce,
         ILogger logger)
     {
         Provider = provider;
@@ -72,6 +76,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         this.vsProjectInfoProvider = vsProjectInfoProvider;
         this.issueConsumerFactory = issueConsumerFactory;
         this.issueConsumerStorage = issueConsumerStorage;
+        this.taskExecutorWithDebounce = taskExecutorWithDebounce;
         this.logger = logger;
         logger.ForContext(nameof(TextBufferIssueTracker));
 
@@ -81,6 +86,10 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         Factory = new IssuesSnapshotFactory(LastAnalysisFilePath);
 
         document.FileActionOccurred += SafeOnFileActionOccurred;
+        if (textBuffer is ITextBuffer2 textBuffer2)
+        {
+            textBuffer2.ChangedOnBackground += TextBuffer_OnChangedOnBackground;
+        }
 
         sonarErrorDataSource.AddFactory(Factory);
         Provider.AddIssueTracker(this);
@@ -91,18 +100,7 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
     public string LastAnalysisFilePath { get; private set; }
     public IEnumerable<AnalysisLanguage> DetectedLanguages { get; }
 
-    public void UpdateAnalysisState()
-    {
-        try
-        {
-            RemoveIssueConsumer(LastAnalysisFilePath);
-            InitializeAnalysisState();
-        }
-        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
-        {
-            logger.WriteLine(Strings.Analysis_ErrorUpdatingAnalysisState, ex);
-        }
-    }
+    public void UpdateAnalysisState() => RefreshAnalysisState();
 
     public string GetText() => document.TextBuffer.CurrentSnapshot.GetText();
 
@@ -151,6 +149,19 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         }
     }
 
+    private void RefreshAnalysisState(ITextSnapshot newTextSnapshot = null)
+    {
+        try
+        {
+            RemoveIssueConsumer(LastAnalysisFilePath);
+            InitializeAnalysisState(newTextSnapshot);
+        }
+        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        {
+            logger.WriteLine(Strings.Analysis_ErrorUpdatingAnalysisState, ex);
+        }
+    }
+
     private void SnapToNewSnapshot(IIssuesSnapshot newSnapshot)
     {
         // Tell our factory to snap to a new snapshot.
@@ -159,11 +170,11 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         sonarErrorDataSource.RefreshErrorList(Factory);
     }
 
-    private AnalysisSnapshot GetAnalysisSnapshot() => new(LastAnalysisFilePath, document.TextBuffer.CurrentSnapshot);
+    private AnalysisSnapshot GetAnalysisSnapshot(ITextSnapshot newTextSnapshot = null) => new(LastAnalysisFilePath, newTextSnapshot ?? document.TextBuffer.CurrentSnapshot);
 
-    private void InitializeAnalysisState()
+    private void InitializeAnalysisState(ITextSnapshot newTextSnapshot = null)
     {
-        var analysisSnapshot = GetAnalysisSnapshot();
+        var analysisSnapshot = GetAnalysisSnapshot(newTextSnapshot);
         CreateIssueConsumer(analysisSnapshot);
     }
 
@@ -182,4 +193,11 @@ internal sealed class TextBufferIssueTracker : IIssueTracker, ITagger<IErrorTag>
         issueConsumer.SetIssues(filePath, []);
         issueConsumer.SetHotspots(filePath, []);
     }
+
+    private void TextBuffer_OnChangedOnBackground(object sender, TextContentChangedEventArgs e) =>
+        taskExecutorWithDebounce.DebounceAsync(e.After, textSnapshot =>
+        {
+            RefreshAnalysisState(textSnapshot);
+            Provider.OnDocumentUpdated(document.FilePath, textSnapshot.GetText(), DetectedLanguages);
+        }).Forget();
 }


### PR DESCRIPTION
[SLVS-2430](https://sonarsource.atlassian.net/browse/SLVS-2430)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6401) in which `DocumentUpdated` event was introduced

[SLVS-2430]: https://sonarsource.atlassian.net/browse/SLVS-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ