### PR TITLE
SLVS-2521 Implement navigation to the hotspot location

### DIFF
--- a/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotViewModelTests.cs
@@ -47,6 +47,7 @@ public class HotspotViewModelTests
         testSubject.Column.Should().Be(hotspot.Visualization.Issue.PrimaryLocation.TextRange.StartLineOffset);
         testSubject.Title.Should().Be(hotspot.Visualization.Issue.PrimaryLocation.Message);
         testSubject.FilePath.Should().Be(hotspot.Visualization.Issue.PrimaryLocation.FilePath);
+        testSubject.Issue.Should().Be(hotspot.Visualization);
     }
 
     private static LocalHotspot CreateMockedHotspot(

--- a/src/IssueViz.Security/ReportView/Hotspots/HotspotViewModel.cs
+++ b/src/IssueViz.Security/ReportView/Hotspots/HotspotViewModel.cs
@@ -19,11 +19,12 @@
  */
 
 using SonarLint.VisualStudio.Core.WPF;
+using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
 
-internal class HotspotViewModel : ViewModelBase, IIssueViewModel
+internal class HotspotViewModel : ViewModelBase, IAnalysisIssueViewModel
 {
     public LocalHotspot LocalHotspot { get; }
 
@@ -38,4 +39,5 @@ internal class HotspotViewModel : ViewModelBase, IIssueViewModel
     public string Title => LocalHotspot.Visualization.Issue.PrimaryLocation.Message;
     public string FilePath => LocalHotspot.Visualization.Issue.PrimaryLocation.FilePath;
     public RuleInfoViewModel RuleInfo { get; }
+    public IAnalysisIssueVisualization Issue => LocalHotspot.Visualization;
 }

--- a/src/IssueViz.Security/ReportView/IIssueViewModel.cs
+++ b/src/IssueViz.Security/ReportView/IIssueViewModel.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarLint.VisualStudio.IssueVisualization.Models;
+
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
 
 public interface IIssueViewModel
@@ -27,4 +29,9 @@ public interface IIssueViewModel
     string Title { get; }
     string FilePath { get; }
     RuleInfoViewModel RuleInfo { get; }
+}
+
+public interface IAnalysisIssueViewModel : IIssueViewModel
+{
+    IAnalysisIssueVisualization Issue { get; }
 }

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -28,6 +28,7 @@ using SonarLint.VisualStudio.ConnectedMode.UI;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Telemetry;
+using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.ViewModels.Commands;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
@@ -52,6 +53,7 @@ internal sealed partial class ReportViewControl : UserControl
         IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler,
         IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler,
         INavigateToRuleDescriptionCommand navigateToRuleDescriptionCommand,
+        ILocationNavigator locationNavigator,
         IMessageBox messageBox,
         ITelemetryManager telemetryManager,
         IThreadHandling threadHandling)
@@ -64,6 +66,7 @@ internal sealed partial class ReportViewControl : UserControl
             showDependencyRiskInBrowserHandler,
             changeDependencyRiskStatusHandler,
             navigateToRuleDescriptionCommand,
+            locationNavigator,
             messageBox,
             telemetryManager,
             threadHandling);
@@ -150,15 +153,32 @@ internal sealed partial class ReportViewControl : UserControl
 
     private void TreeViewItem_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        if ((sender as FrameworkElement)?.DataContext is not IIssueViewModel issueViewModel)
-        {
-            return;
-        }
+        NavigateToLocation(sender);
+        ShowRuleHelp(sender);
+    }
 
-        var commandParam = new NavigateToRuleDescriptionCommandParam { FullRuleKey = issueViewModel.RuleInfo.RuleKey, IssueId = issueViewModel.RuleInfo.IssueId };
-        if (ReportViewModel.NavigateToRuleDescriptionCommand.CanExecute(commandParam))
+    private void NavigateToLocation(object sender)
+    {
+        if ((sender as FrameworkElement)?.DataContext is IAnalysisIssueViewModel analysisIssueViewModel)
         {
-            ReportViewModel.NavigateToRuleDescriptionCommand.Execute(commandParam);
+            ExecuteCommandIfValid(ReportViewModel.NavigateToLocationCommand, analysisIssueViewModel);
+        }
+    }
+
+    private void ShowRuleHelp(object sender)
+    {
+        if ((sender as FrameworkElement)?.DataContext is IIssueViewModel issueViewModel)
+        {
+            var commandParam = new NavigateToRuleDescriptionCommandParam { FullRuleKey = issueViewModel.RuleInfo.RuleKey, IssueId = issueViewModel.RuleInfo.IssueId };
+            ExecuteCommandIfValid(ReportViewModel.NavigateToRuleDescriptionCommand, commandParam);
+        }
+    }
+
+    private static void ExecuteCommandIfValid(ICommand command, object parameter)
+    {
+        if (command.CanExecute(parameter))
+        {
+            command.Execute(parameter);
         }
     }
 }

--- a/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.Shell;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Telemetry;
+using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.ViewModels.Commands;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
@@ -50,6 +51,7 @@ internal class ReportViewToolWindow : ToolWindowPane
             componentModel?.GetService<IShowDependencyRiskInBrowserHandler>(),
             componentModel?.GetService<IChangeDependencyRiskStatusHandler>(),
             componentModel?.GetService<INavigateToRuleDescriptionCommand>(),
+            componentModel?.GetService<ILocationNavigator>(),
             componentModel?.GetService<IMessageBox>(),
             componentModel?.GetService<ITelemetryManager>(),
             componentModel?.GetService<IThreadHandling>()


### PR DESCRIPTION
[SLVS-2521](https://sonarsource.atlassian.net/browse/SLVS-2521)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6421) in which the double click event has been added to the `TreeViewItem`

[SLVS-2521]: https://sonarsource.atlassian.net/browse/SLVS-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ