### PR TITLE
Split ReportViewModel into multiple classes

### DIFF
--- a/src/IssueViz.Security.UnitTests/DependencyRisks/DependencyRisksReportViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/DependencyRisks/DependencyRisksReportViewModelTest.cs
@@ -1,0 +1,163 @@
+﻿using System.Windows;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
+using SonarLint.VisualStudio.TestInfrastructure;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.DependencyRisks;
+
+[TestClass]
+public class DependencyRisksReportViewModelTest
+{
+    private IDependencyRisksStore dependencyRisksStore;
+    private IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler;
+    private IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler;
+    private IMessageBox messageBox;
+    private DependencyRisksReportViewModel testSubject;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        dependencyRisksStore = Substitute.For<IDependencyRisksStore>();
+        showDependencyRiskInBrowserHandler = Substitute.For<IShowDependencyRiskInBrowserHandler>();
+        changeDependencyRiskStatusHandler = Substitute.For<IChangeDependencyRiskStatusHandler>();
+        messageBox = Substitute.For<IMessageBox>();
+
+        testSubject = new DependencyRisksReportViewModel(dependencyRisksStore, showDependencyRiskInBrowserHandler, changeDependencyRiskStatusHandler, messageBox);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<DependencyRisksReportViewModel, IDependencyRisksReportViewModel>(
+            MefTestHelpers.CreateExport<IDependencyRisksStore>(),
+            MefTestHelpers.CreateExport<IShowDependencyRiskInBrowserHandler>(),
+            MefTestHelpers.CreateExport<IChangeDependencyRiskStatusHandler>(),
+            MefTestHelpers.CreateExport<IMessageBox>()
+        );
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<DependencyRisksReportViewModel>();
+
+    [TestMethod]
+    public void Constructor_SubscribesToIssuesChanged() => dependencyRisksStore.Received().DependencyRisksChanged += Arg.Any<EventHandler>();
+
+    [TestMethod]
+    public void Dispose_UnsubscribesFromIssuesChanged()
+    {
+        testSubject.Dispose();
+
+        dependencyRisksStore.Received().DependencyRisksChanged -= Arg.Any<EventHandler>();
+    }
+
+    [TestMethod]
+    public void ShowDependencyRiskInBrowser_CallsHandler()
+    {
+        var riskId = Guid.NewGuid();
+        var dependencyRisk = CreateDependencyRisk(riskId);
+
+        testSubject.ShowDependencyRiskInBrowser(dependencyRisk);
+
+        showDependencyRiskInBrowserHandler.Received(1).ShowInBrowser(riskId);
+    }
+
+    [TestMethod]
+    public async Task ChangeDependencyRiskStatusAsync_CallsHandler_Success()
+    {
+        var riskId = Guid.NewGuid();
+        var dependencyRisk = CreateDependencyRisk(riskId);
+        var transition = DependencyRiskTransition.Accept;
+        var comment = "test comment";
+        changeDependencyRiskStatusHandler.ChangeStatusAsync(riskId, transition, comment).Returns(true);
+
+        await testSubject.ChangeDependencyRiskStatusAsync(dependencyRisk, transition, comment);
+
+        await changeDependencyRiskStatusHandler.Received(1).ChangeStatusAsync(riskId, transition, comment);
+        messageBox.DidNotReceiveWithAnyArgs().Show(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<MessageBoxButton>(), Arg.Any<MessageBoxImage>());
+    }
+
+    [TestMethod]
+    public async Task ChangeDependencyRiskStatusAsync_CallsHandler_Failure_ShowsMessageBox()
+    {
+        var riskId = Guid.NewGuid();
+        var dependencyRisk = CreateDependencyRisk(riskId);
+        const DependencyRiskTransition transition = DependencyRiskTransition.Accept;
+        const string comment = "test comment";
+        changeDependencyRiskStatusHandler.ChangeStatusAsync(riskId, transition, comment).Returns(false);
+
+        await testSubject.ChangeDependencyRiskStatusAsync(dependencyRisk, transition, comment);
+
+        await changeDependencyRiskStatusHandler.Received(1).ChangeStatusAsync(riskId, transition, comment);
+        messageBox.Received(1).Show(Resources.DependencyRiskStatusChangeFailedTitle, Resources.DependencyRiskStatusChangeError, MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    [TestMethod]
+    public async Task ChangeDependencyRiskStatusAsync_NullTransition_DoesNotCallHandler_ShowsMessageBox()
+    {
+        var dependencyRisk = CreateDependencyRisk();
+        DependencyRiskTransition? transition = null;
+        const string comment = "test comment";
+
+        await testSubject.ChangeDependencyRiskStatusAsync(dependencyRisk, transition, comment);
+
+        await changeDependencyRiskStatusHandler.DidNotReceiveWithAnyArgs().ChangeStatusAsync(Arg.Any<Guid>(), Arg.Any<DependencyRiskTransition>(), Arg.Any<string>());
+        messageBox.Received(1).Show(Resources.DependencyRiskStatusChangeFailedTitle, Resources.DependencyRiskNullTransitionError, MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    [TestMethod]
+    public void GetDependencyRisksGroup_ReturnsGroup_WhenNotFixedRisksExist()
+    {
+        var risk1 = CreateDependencyRisk();
+        var risk2 = CreateDependencyRisk(isFixed: true);
+        var risk3 = CreateDependencyRisk();
+        dependencyRisksStore.GetAll().Returns([risk1, risk2, risk3]);
+
+        var group = testSubject.GetDependencyRisksGroup();
+
+        group.Should().NotBeNull();
+        group.FilteredIssues.Should().HaveCount(2);
+        group.FilteredIssues.Should().AllBeOfType<DependencyRiskViewModel>();
+        group.FilteredIssues.Cast<DependencyRiskViewModel>().Select(vm => vm.DependencyRisk).Should().Contain([risk1, risk3]);
+    }
+
+    [TestMethod]
+    public void GetDependencyRisksGroup_ReturnsNull_WhenAllRisksAreFixed()
+    {
+        var fixedRisk = CreateDependencyRisk(isFixed: true);
+        var fixedRisk2 = CreateDependencyRisk(isFixed: true);
+        dependencyRisksStore.GetAll().Returns([fixedRisk, fixedRisk2]);
+
+        var group = testSubject.GetDependencyRisksGroup();
+
+        group.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void GetDependencyRisksGroup_ReturnsNull_WhenNoRisks()
+    {
+        dependencyRisksStore.GetAll().Returns([]);
+
+        var group = testSubject.GetDependencyRisksGroup();
+
+        group.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void DependencyRisksChanged_RaisedOnStoreIssuesChanged()
+    {
+        var raised = false;
+        testSubject.DependencyRisksChanged += (_, _) => raised = true;
+
+        dependencyRisksStore.DependencyRisksChanged += Raise.Event<EventHandler>(null, null);
+
+        raised.Should().BeTrue();
+    }
+
+    private static IDependencyRisk CreateDependencyRisk(Guid? id = null, bool isFixed = false)
+    {
+        var risk = Substitute.For<IDependencyRisk>();
+        risk.Id.Returns(id ?? Guid.NewGuid());
+        risk.Transitions.Returns([]);
+        risk.Status.Returns(isFixed ? DependencyRiskStatus.Fixed : DependencyRiskStatus.Open);
+        return risk;
+    }
+}

--- a/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotsReportViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotsReportViewModelTest.cs
@@ -1,0 +1,139 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Models;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
+using SonarLint.VisualStudio.TestInfrastructure;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.ReportView.Hotspots;
+
+[TestClass]
+public class HotspotsReportViewModelTest
+{
+    private ILocalHotspotsStore localHotspotsStore;
+    private HotspotsReportViewModel testSubject;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        localHotspotsStore = Substitute.For<ILocalHotspotsStore>();
+        testSubject = new HotspotsReportViewModel(localHotspotsStore);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckIsExported() =>
+        MefTestHelpers.CheckTypeCanBeImported<HotspotsReportViewModel, IHotspotsReportViewModel>(
+            MefTestHelpers.CreateExport<ILocalHotspotsStore>());
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<HotspotsReportViewModel>();
+
+    [TestMethod]
+    public void Constructor_SubscribesToIssuesChanged() => localHotspotsStore.Received().IssuesChanged += Arg.Any<EventHandler<IssuesChangedEventArgs>>();
+
+    [TestMethod]
+    public void Dispose_UnsubscribesFromIssuesChanged()
+    {
+        testSubject.Dispose();
+
+        localHotspotsStore.Received().IssuesChanged -= Arg.Any<EventHandler<IssuesChangedEventArgs>>();
+    }
+
+    [TestMethod]
+    public void GetHotspotsGroupViewModels_GroupsByFilePath()
+    {
+        var file1 = "file1.cs";
+        var file2 = "file2.cs";
+        MockHotspotsInStore(CreateMockedHotspot(file1), CreateMockedHotspot(file1), CreateMockedHotspot(file2));
+
+        var groups = testSubject.GetHotspotsGroupViewModels();
+
+        groups.Should().HaveCount(2);
+        groups.Select(g => g.Title).Should().Contain([file1, file2]);
+        groups.First(g => g.Title == file1).FilteredIssues.Should().HaveCount(2);
+        groups.First(g => g.Title == file2).FilteredIssues.Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void GetHotspotsGroupViewModels_TwoHotspotsInSameFile_CreatesOneGroupVmWithTwoIssues()
+    {
+        var path = "myFile.cs";
+        var hotspot1 = CreateMockedHotspot(path);
+        var hotspot2 = CreateMockedHotspot(path);
+        MockHotspotsInStore(hotspot1, hotspot2);
+
+        var groups = testSubject.GetHotspotsGroupViewModels();
+
+        groups.Should().HaveCount(1);
+        VerifyExpectedHotspotGroupViewModel(groups[0] as GroupFileViewModel, hotspot1, hotspot2);
+    }
+
+    [TestMethod]
+    public void GetHotspotsGroupViewModels_TwoHotspotsInDifferentFiles_CreatesTwoGroupsWithOneIssueEach()
+    {
+        var hotspot1 = CreateMockedHotspot("myFile.cs");
+        var hotspot2 = CreateMockedHotspot("myFile.js");
+        MockHotspotsInStore(hotspot1, hotspot2);
+
+        var groups = testSubject.GetHotspotsGroupViewModels();
+
+        groups.Should().HaveCount(2);
+        VerifyExpectedHotspotGroupViewModel(groups[0] as GroupFileViewModel, hotspot1);
+        VerifyExpectedHotspotGroupViewModel(groups[1] as GroupFileViewModel, hotspot2);
+    }
+
+    [TestMethod]
+    public void HotspotsChanged_RaisedOnStoreIssuesChanged()
+    {
+        var raised = false;
+        testSubject.HotspotsChanged += (_, _) => raised = true;
+
+        localHotspotsStore.IssuesChanged += Raise.Event<EventHandler<IssuesChangedEventArgs>>(null, null);
+
+        raised.Should().BeTrue();
+    }
+
+    private static LocalHotspot CreateMockedHotspot(string filePath)
+    {
+        var analysisIssueVisualization = Substitute.For<IAnalysisIssueVisualization>();
+        var analysisIssueBase = Substitute.For<IAnalysisIssueBase>();
+        analysisIssueBase.PrimaryLocation.FilePath.Returns(filePath);
+        analysisIssueVisualization.Issue.Returns(analysisIssueBase);
+
+        return new LocalHotspot(analysisIssueVisualization, default, default);
+    }
+
+    private void MockHotspotsInStore(params LocalHotspot[] hotspots) => localHotspotsStore.GetAllLocalHotspots().Returns(hotspots);
+
+    private static void VerifyExpectedHotspotGroupViewModel(GroupFileViewModel groupFileVm, params LocalHotspot[] expectedHotspots)
+    {
+        groupFileVm.Should().NotBeNull();
+        groupFileVm.FilePath.Should().Be(expectedHotspots[0].Visualization.Issue.PrimaryLocation.FilePath);
+        groupFileVm.FilteredIssues.Should().HaveCount(expectedHotspots.Length);
+        foreach (var expectedHotspot in expectedHotspots)
+        {
+            groupFileVm.FilteredIssues.Should().ContainSingle(vm => ((HotspotViewModel)vm).LocalHotspot == expectedHotspot);
+        }
+    }
+}

--- a/src/IssueViz.Security.UnitTests/ReportView/ReportViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReportView/ReportViewModelTest.cs
@@ -26,10 +26,7 @@ using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.ViewModels.Commands;
-using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
-using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
-using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
 using SonarLint.VisualStudio.TestInfrastructure;
@@ -42,7 +39,7 @@ public class ReportViewModelTest
     private ReportViewModel testSubject;
     private IActiveSolutionBoundTracker activeSolutionBoundTracker;
     private IDependencyRisksStore dependencyRisksStore;
-    private ILocalHotspotsStore localHotspotsStore;
+    private IHotspotsReportViewModel hotspotsReportViewModel;
     private IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler;
     private IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler;
     private INavigateToRuleDescriptionCommand navigateToRuleDescriptionCommand;
@@ -57,7 +54,7 @@ public class ReportViewModelTest
     {
         activeSolutionBoundTracker = Substitute.For<IActiveSolutionBoundTracker>();
         dependencyRisksStore = Substitute.For<IDependencyRisksStore>();
-        localHotspotsStore = Substitute.For<ILocalHotspotsStore>();
+        hotspotsReportViewModel = Substitute.For<IHotspotsReportViewModel>();
         showDependencyRiskInBrowserHandler = Substitute.For<IShowDependencyRiskInBrowserHandler>();
         changeDependencyRiskStatusHandler = Substitute.For<IChangeDependencyRiskStatusHandler>();
         navigateToRuleDescriptionCommand = Substitute.For<INavigateToRuleDescriptionCommand>();
@@ -66,6 +63,7 @@ public class ReportViewModelTest
         telemetryManager = Substitute.For<ITelemetryManager>();
         threadHandling = Substitute.ForPartsOf<NoOpThreadHandler>();
         eventHandler = Substitute.For<PropertyChangedEventHandler>();
+        hotspotsReportViewModel.GetHotspotsGroupViewModels().Returns([]);
 
         testSubject = CreateTestSubject();
     }
@@ -76,7 +74,7 @@ public class ReportViewModelTest
     [TestMethod]
     public void Class_SubscribesToEvents()
     {
-        localHotspotsStore.Received(1).IssuesChanged += Arg.Any<EventHandler<IssuesChangedEventArgs>>();
+        hotspotsReportViewModel.Received(1).HotspotsChanged += Arg.Any<EventHandler>();
         dependencyRisksStore.Received(1).DependencyRisksChanged += Arg.Any<EventHandler>();
     }
 
@@ -100,46 +98,18 @@ public class ReportViewModelTest
     }
 
     [TestMethod]
-    public void Ctor_TwoHotspotsInSameFile_CreatesOneGroupVmWithTwoIssues()
-    {
-        var path = "myFile.cs";
-        var hotspot1 = CreateMockedHotspot(filePath: path);
-        var hotspot2 = CreateMockedHotspot(filePath: path);
-        MockHotspotsInStore(hotspot1, hotspot2);
-
-        testSubject = CreateTestSubject();
-
-        testSubject.GroupViewModels.Should().HaveCount(1);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[0] as GroupFileViewModel, hotspot1, hotspot2);
-    }
-
-    [TestMethod]
-    public void Ctor_TwoHotspotsInDifferentFiles_CreatesTwoGroupsWithOneIssueEach()
-    {
-        var hotspot1 = CreateMockedHotspot(filePath: "myFile.cs");
-        var hotspot2 = CreateMockedHotspot(filePath: "myFile.js");
-        MockHotspotsInStore(hotspot1, hotspot2);
-
-        testSubject = CreateTestSubject();
-
-        testSubject.GroupViewModels.Should().HaveCount(2);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[0] as GroupFileViewModel, hotspot1);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[1] as GroupFileViewModel, hotspot2);
-    }
-
-    [TestMethod]
     public void Ctor_MixedIssuesTypes_CreatesGroupViewModelsCorrectly()
     {
         var dependencyRisk = CreateDependencyRisk();
         MockRisksInStore(dependencyRisk);
-        var hotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        MockHotspotsInStore(hotspot);
+        var hotspotGroupViewModel = CreateMockedGroupViewModel(filePath: "myFile.cs");
+        hotspotsReportViewModel.GetHotspotsGroupViewModels().Returns([hotspotGroupViewModel]);
 
         testSubject = CreateTestSubject();
 
         testSubject.GroupViewModels.Should().HaveCount(2);
         VerifyExpectedDependencyRiskGroupViewModel(testSubject.GroupViewModels[0] as GroupDependencyRiskViewModel, dependencyRisk);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[1] as GroupFileViewModel, hotspot);
+        testSubject.GroupViewModels[1].Should().Be(hotspotGroupViewModel);
     }
 
     [TestMethod]
@@ -159,7 +129,8 @@ public class ReportViewModelTest
         testSubject.Dispose();
 
         dependencyRisksStore.Received(1).DependencyRisksChanged -= Arg.Any<EventHandler>();
-        localHotspotsStore.Received(1).IssuesChanged -= Arg.Any<EventHandler<IssuesChangedEventArgs>>();
+        hotspotsReportViewModel.Received(1).HotspotsChanged -= Arg.Any<EventHandler>();
+        hotspotsReportViewModel.Received(1).Dispose();
     }
 
     [TestMethod]
@@ -282,101 +253,33 @@ public class ReportViewModelTest
     }
 
     [TestMethod]
-    public void HotspotsAddedInStore_ExistingFile_UpdatesExistingGroup()
+    public void HotspotsChanged_TwoGroups_UpdatesOnlyHotspotGroupViewModels()
     {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        var addedHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot], [initialHotspot, addedHotspot]);
-        testSubject = CreateTestSubject();
+        var group1 = CreateMockedGroupViewModel(filePath: "myFile.cs");
+        var group2 = CreateMockedGroupViewModel(filePath: "myFile.cs");
+        hotspotsReportViewModel.GetHotspotsGroupViewModels().Returns([group1, group2]);
+        dependencyRisksStore.ClearReceivedCalls();
 
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
-
-        testSubject.GroupViewModels.Should().HaveCount(1);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[0] as GroupFileViewModel, initialHotspot, addedHotspot);
-    }
-
-    [TestMethod]
-    public void HotspotsAddedInStore_NewFile_CreatesNewGroup()
-    {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        var addedHotspot = CreateMockedHotspot(filePath: "otherFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot], [initialHotspot, addedHotspot]);
-        testSubject = CreateTestSubject();
-
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
+        hotspotsReportViewModel.HotspotsChanged += Raise.EventWith(testSubject, EventArgs.Empty);
 
         testSubject.GroupViewModels.Should().HaveCount(2);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[0] as GroupFileViewModel, initialHotspot);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[1] as GroupFileViewModel, addedHotspot);
+        testSubject.GroupViewModels.Should().Contain(group1);
+        testSubject.GroupViewModels.Should().Contain(group2);
+        VerifyHasGroupsUpdated();
+        dependencyRisksStore.DidNotReceive().GetAll();
     }
 
     [TestMethod]
-    public void HotspotsAddedInStore_DoesNotUpdateDependencyRisks()
+    public void HotspotsChanged_NoGroups_RaisesProperty()
     {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        var addedHotspot = CreateMockedHotspot(filePath: "otherFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot], [initialHotspot, addedHotspot]);
-        testSubject = CreateTestSubject();
+        hotspotsReportViewModel.GetHotspotsGroupViewModels().Returns([]);
         dependencyRisksStore.ClearReceivedCalls();
 
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
-
-        dependencyRisksStore.DidNotReceive().GetAll();
-        VerifyHasGroupsUpdated();
-    }
-
-    [TestMethod]
-    public void HotspotsRemovedFromStore_DeletedHotspotFromExistingFile_UpdatesExistingGroup()
-    {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        var initialHotspot2 = CreateMockedHotspot(filePath: "myFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot, initialHotspot2], [initialHotspot]);
-        testSubject = CreateTestSubject();
-
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
-
-        testSubject.GroupViewModels.Should().HaveCount(1);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[0] as GroupFileViewModel, initialHotspot);
-    }
-
-    [TestMethod]
-    public void HotspotsRemovedFromStore_DeletedSingleHotspotFromExistingFile_RemovesGroup()
-    {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot], new LocalHotspot[] { });
-        testSubject = CreateTestSubject();
-
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
+        hotspotsReportViewModel.HotspotsChanged += Raise.EventWith(testSubject, EventArgs.Empty);
 
         testSubject.GroupViewModels.Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public void HotspotsRemovedFromStore_DeletedHotspotFromDifferentFile_UpdatesGroupCorrectly()
-    {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        var initialHotspot2 = CreateMockedHotspot(filePath: "otherFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot, initialHotspot2], [initialHotspot]);
-        testSubject = CreateTestSubject();
-
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
-
-        testSubject.GroupViewModels.Should().HaveCount(1);
-        VerifyExpectedHotspotGroupViewModel(testSubject.GroupViewModels[0] as GroupFileViewModel, initialHotspot);
-    }
-
-    [TestMethod]
-    public void HotspotsRemovedFromStore_DoesNotUpdateDependencyRisks()
-    {
-        var initialHotspot = CreateMockedHotspot(filePath: "myFile.cs");
-        localHotspotsStore.GetAllLocalHotspots().Returns([initialHotspot], []);
-        testSubject = CreateTestSubject();
-        dependencyRisksStore.ClearReceivedCalls();
-
-        localHotspotsStore.IssuesChanged += Raise.EventWith(testSubject, new IssuesChangedEventArgs([], []));
-
-        dependencyRisksStore.DidNotReceive().GetAll();
         VerifyHasGroupsUpdated();
+        dependencyRisksStore.DidNotReceive().GetAll();
     }
 
     [TestMethod]
@@ -412,11 +315,11 @@ public class ReportViewModelTest
         var addedRisk = CreateDependencyRisk();
         dependencyRisksStore.GetAll().Returns([], [addedRisk]);
         testSubject = CreateTestSubject();
-        dependencyRisksStore.ClearReceivedCalls();
+        hotspotsReportViewModel.ClearReceivedCalls();
 
         dependencyRisksStore.DependencyRisksChanged += Raise.Event<EventHandler>();
 
-        localHotspotsStore.DidNotReceive().GetAll();
+        hotspotsReportViewModel.DidNotReceive().GetHotspotsGroupViewModels();
         VerifyHasGroupsUpdated();
     }
 
@@ -452,11 +355,11 @@ public class ReportViewModelTest
         var initialRisk = CreateDependencyRisk();
         dependencyRisksStore.GetAll().Returns([initialRisk], new IDependencyRisk[] { });
         testSubject = CreateTestSubject();
-        dependencyRisksStore.ClearReceivedCalls();
+        hotspotsReportViewModel.ClearReceivedCalls();
 
         dependencyRisksStore.DependencyRisksChanged += Raise.Event<EventHandler>();
 
-        localHotspotsStore.DidNotReceive().GetAll();
+        hotspotsReportViewModel.DidNotReceive().GetHotspotsGroupViewModels();
         VerifyHasGroupsUpdated();
     }
 
@@ -505,11 +408,11 @@ public class ReportViewModelTest
     {
         var reportViewModel = new ReportViewModel(activeSolutionBoundTracker,
             dependencyRisksStore,
-            localHotspotsStore,
             showDependencyRiskInBrowserHandler,
             changeDependencyRiskStatusHandler,
             navigateToRuleDescriptionCommand,
             locationNavigator,
+            hotspotsReportViewModel,
             messageBox,
             telemetryManager,
             threadHandling);
@@ -526,30 +429,14 @@ public class ReportViewModelTest
         return risk;
     }
 
-    private static LocalHotspot CreateMockedHotspot(string filePath)
+    private static IGroupViewModel CreateMockedGroupViewModel(string filePath)
     {
-        var analysisIssueVisualization = Substitute.For<IAnalysisIssueVisualization>();
-        var analysisIssueBase = Substitute.For<IAnalysisIssueBase>();
-        analysisIssueBase.PrimaryLocation.FilePath.Returns(filePath);
-        analysisIssueVisualization.Issue.Returns(analysisIssueBase);
-
-        return new LocalHotspot(analysisIssueVisualization, default, default);
+        var group = Substitute.For<IGroupViewModel>();
+        group.Title.Returns(filePath);
+        return group;
     }
 
     private void MockRisksInStore(params IDependencyRisk[] dependencyRisks) => dependencyRisksStore.GetAll().Returns(dependencyRisks);
-
-    private void MockHotspotsInStore(params LocalHotspot[] hotspots) => localHotspotsStore.GetAllLocalHotspots().Returns(hotspots);
-
-    private static void VerifyExpectedHotspotGroupViewModel(GroupFileViewModel groupFileVm, params LocalHotspot[] expectedHotspots)
-    {
-        groupFileVm.Should().NotBeNull();
-        groupFileVm.FilePath.Should().Be(expectedHotspots[0].Visualization.Issue.PrimaryLocation.FilePath);
-        groupFileVm.FilteredIssues.Should().HaveCount(expectedHotspots.Length);
-        foreach (var expectedHotspot in expectedHotspots)
-        {
-            groupFileVm.FilteredIssues.Should().ContainSingle(vm => ((HotspotViewModel)vm).LocalHotspot == expectedHotspot);
-        }
-    }
 
     private static void VerifyExpectedDependencyRiskGroupViewModel(GroupDependencyRiskViewModel dependencyRiskGroupVm, params IDependencyRisk[] expectedDependencyRisks)
     {

--- a/src/IssueViz.Security/DependencyRisks/DependencyRisksReportViewModel.cs
+++ b/src/IssueViz.Security/DependencyRisks/DependencyRisksReportViewModel.cs
@@ -1,0 +1,95 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using System.Windows;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
+
+public interface IDependencyRisksReportViewModel : IDisposable
+{
+    IGroupViewModel GetDependencyRisksGroup();
+
+    Task ChangeDependencyRiskStatusAsync(IDependencyRisk dependencyRisk, DependencyRiskTransition? selectedTransition, string getNormalizedComment);
+
+    void ShowDependencyRiskInBrowser(IDependencyRisk dependencyRisk);
+
+    event EventHandler DependencyRisksChanged;
+}
+
+[Export(typeof(IDependencyRisksReportViewModel))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+internal sealed class DependencyRisksReportViewModel : IDependencyRisksReportViewModel
+{
+    private readonly IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler;
+    private readonly IDependencyRisksStore dependencyRisksStore;
+    private readonly IMessageBox messageBox;
+    private readonly IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler;
+
+    [ImportingConstructor]
+    public DependencyRisksReportViewModel(
+        IDependencyRisksStore dependencyRisksStore,
+        IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler,
+        IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler,
+        IMessageBox messageBox)
+    {
+        this.dependencyRisksStore = dependencyRisksStore;
+        this.showDependencyRiskInBrowserHandler = showDependencyRiskInBrowserHandler;
+        this.changeDependencyRiskStatusHandler = changeDependencyRiskStatusHandler;
+        this.messageBox = messageBox;
+        dependencyRisksStore.DependencyRisksChanged += DependencyRisksStore_DependencyRiskChanged;
+    }
+
+    public void Dispose() => dependencyRisksStore.DependencyRisksChanged -= DependencyRisksStore_DependencyRiskChanged;
+
+    public event EventHandler DependencyRisksChanged;
+
+    public IGroupViewModel GetDependencyRisksGroup()
+    {
+        var groupDependencyRisk = new GroupDependencyRiskViewModel(dependencyRisksStore);
+        groupDependencyRisk.InitializeRisks();
+        return groupDependencyRisk.FilteredIssues.Any() ? groupDependencyRisk : null;
+    }
+
+    public async Task ChangeDependencyRiskStatusAsync(IDependencyRisk dependencyRisk, DependencyRiskTransition? selectedTransition, string getNormalizedComment)
+    {
+        if (selectedTransition is not { } transition)
+        {
+            ShowFailureMessage(Resources.DependencyRiskNullTransitionError);
+            return;
+        }
+
+        var result = await changeDependencyRiskStatusHandler.ChangeStatusAsync(dependencyRisk.Id, transition, getNormalizedComment);
+
+        if (!result)
+        {
+            ShowFailureMessage(Resources.DependencyRiskStatusChangeError);
+        }
+    }
+
+    public void ShowDependencyRiskInBrowser(IDependencyRisk dependencyRisk) => showDependencyRiskInBrowserHandler.ShowInBrowser(dependencyRisk.Id);
+
+    private void ShowFailureMessage(string errorMessage) => messageBox.Show(Resources.DependencyRiskStatusChangeFailedTitle, errorMessage, MessageBoxButton.OK, MessageBoxImage.Error);
+
+    private void DependencyRisksStore_DependencyRiskChanged(object sender, EventArgs e) => DependencyRisksChanged?.Invoke(null, EventArgs.Empty);
+}

--- a/src/IssueViz.Security/ReportView/Hotspots/HotspotsReportViewModel.cs
+++ b/src/IssueViz.Security/ReportView/Hotspots/HotspotsReportViewModel.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
+
+internal interface IHotspotsReportViewModel : IDisposable
+{
+    ObservableCollection<IGroupViewModel> GetHotspotsGroupViewModels();
+
+    event EventHandler HotspotsChanged;
+}
+
+[Export(typeof(IHotspotsReportViewModel))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+internal sealed class HotspotsReportViewModel : IHotspotsReportViewModel
+{
+    private readonly ILocalHotspotsStore hotspotsStore;
+
+    [ImportingConstructor]
+    public HotspotsReportViewModel(ILocalHotspotsStore hotspotsStore)
+    {
+        this.hotspotsStore = hotspotsStore;
+        hotspotsStore.IssuesChanged += HotspotsStore_IssuesChanged;
+    }
+
+    public void Dispose() => hotspotsStore.IssuesChanged -= HotspotsStore_IssuesChanged;
+
+    public event EventHandler HotspotsChanged;
+
+    public ObservableCollection<IGroupViewModel> GetHotspotsGroupViewModels()
+    {
+        var hotspots = hotspotsStore.GetAllLocalHotspots().Select(x => new HotspotViewModel(x));
+        return GetGroupViewModel(hotspots);
+    }
+
+    private static ObservableCollection<IGroupViewModel> GetGroupViewModel(IEnumerable<IIssueViewModel> issueViewModels)
+    {
+        var issuesByFileGrouping = issueViewModels.GroupBy(vm => vm.FilePath);
+        var groupViewModels = new ObservableCollection<IGroupViewModel>();
+        foreach (var group in issuesByFileGrouping)
+        {
+            groupViewModels.Add(new GroupFileViewModel(group.Key, new ObservableCollection<IIssueViewModel>(group)));
+        }
+
+        return groupViewModels;
+    }
+
+    private void HotspotsStore_IssuesChanged(object sender, IssuesChangedEventArgs e) => HotspotsChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -31,7 +31,7 @@ using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.ViewModels.Commands;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
-using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
@@ -43,13 +43,14 @@ internal sealed partial class ReportViewControl : UserControl
     private readonly IBrowserService browserService;
 
     public ReportViewModel ReportViewModel { get; }
+    public IHotspotsReportViewModel HotspotsReportViewModel { get; }
     public IResourceFinder ResourceFinder { get; } = new ResourceFinder();
 
     public ReportViewControl(
         IActiveSolutionBoundTracker activeSolutionBoundTracker,
         IBrowserService browserService,
         IDependencyRisksStore dependencyRisksStore,
-        ILocalHotspotsStore hotspotsStore,
+        IHotspotsReportViewModel hotspotsReportViewModel,
         IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler,
         IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler,
         INavigateToRuleDescriptionCommand navigateToRuleDescriptionCommand,
@@ -60,13 +61,14 @@ internal sealed partial class ReportViewControl : UserControl
     {
         this.activeSolutionBoundTracker = activeSolutionBoundTracker;
         this.browserService = browserService;
+        HotspotsReportViewModel = hotspotsReportViewModel;
         ReportViewModel = new ReportViewModel(activeSolutionBoundTracker,
             dependencyRisksStore,
-            hotspotsStore,
             showDependencyRiskInBrowserHandler,
             changeDependencyRiskStatusHandler,
             navigateToRuleDescriptionCommand,
             locationNavigator,
+            HotspotsReportViewModel,
             messageBox,
             telemetryManager,
             threadHandling);

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -44,32 +44,28 @@ internal sealed partial class ReportViewControl : UserControl
 
     public ReportViewModel ReportViewModel { get; }
     public IHotspotsReportViewModel HotspotsReportViewModel { get; }
+    public IDependencyRisksReportViewModel DependencyRisksReportViewModel { get; }
     public IResourceFinder ResourceFinder { get; } = new ResourceFinder();
 
     public ReportViewControl(
         IActiveSolutionBoundTracker activeSolutionBoundTracker,
         IBrowserService browserService,
-        IDependencyRisksStore dependencyRisksStore,
         IHotspotsReportViewModel hotspotsReportViewModel,
-        IShowDependencyRiskInBrowserHandler showDependencyRiskInBrowserHandler,
-        IChangeDependencyRiskStatusHandler changeDependencyRiskStatusHandler,
+        IDependencyRisksReportViewModel dependencyRisksReportViewModel,
         INavigateToRuleDescriptionCommand navigateToRuleDescriptionCommand,
         ILocationNavigator locationNavigator,
-        IMessageBox messageBox,
         ITelemetryManager telemetryManager,
         IThreadHandling threadHandling)
     {
         this.activeSolutionBoundTracker = activeSolutionBoundTracker;
         this.browserService = browserService;
         HotspotsReportViewModel = hotspotsReportViewModel;
+        DependencyRisksReportViewModel = dependencyRisksReportViewModel;
         ReportViewModel = new ReportViewModel(activeSolutionBoundTracker,
-            dependencyRisksStore,
-            showDependencyRiskInBrowserHandler,
-            changeDependencyRiskStatusHandler,
             navigateToRuleDescriptionCommand,
             locationNavigator,
             HotspotsReportViewModel,
-            messageBox,
+            DependencyRisksReportViewModel,
             telemetryManager,
             threadHandling);
         InitializeComponent();
@@ -114,7 +110,7 @@ internal sealed partial class ReportViewControl : UserControl
             return;
         }
 
-        ReportViewModel.ShowInBrowser(selectedDependencyRiskViewModel.DependencyRisk);
+        DependencyRisksReportViewModel.ShowDependencyRiskInBrowser(selectedDependencyRiskViewModel.DependencyRisk);
     }
 
     private void DependencyRiskContextMenu_OnLoaded(object sender, RoutedEventArgs e)
@@ -145,7 +141,8 @@ internal sealed partial class ReportViewControl : UserControl
         var dialog = new ChangeStatusWindow(changeStatusViewModel, browserService, activeSolutionBoundTracker);
         if (dialog.ShowDialog(Application.Current.MainWindow) is true)
         {
-            await ReportViewModel.ChangeStatusAsync(selectedDependencyRiskViewModel.DependencyRisk, changeStatusViewModel.GetSelectedTransition(), changeStatusViewModel.GetNormalizedComment());
+            await DependencyRisksReportViewModel.ChangeDependencyRiskStatusAsync(selectedDependencyRiskViewModel.DependencyRisk, changeStatusViewModel.GetSelectedTransition(),
+                changeStatusViewModel.GetNormalizedComment());
         }
     }
 

--- a/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
@@ -28,7 +28,7 @@ using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.ViewModels.Commands;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
-using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
 
@@ -43,11 +43,12 @@ internal class ReportViewToolWindow : ToolWindowPane
     {
         var componentModel = serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
         Caption = Resources.ReportViewToolWindowCaption;
+        var hotspotsReportViewModel = componentModel?.GetService<IHotspotsReportViewModel>();
         Content = new ReportViewControl(
             componentModel?.GetService<IActiveSolutionBoundTracker>(),
             componentModel?.GetService<IBrowserService>(),
             componentModel?.GetService<IDependencyRisksStore>(),
-            componentModel?.GetService<ILocalHotspotsStore>(),
+            hotspotsReportViewModel,
             componentModel?.GetService<IShowDependencyRiskInBrowserHandler>(),
             componentModel?.GetService<IChangeDependencyRiskStatusHandler>(),
             componentModel?.GetService<INavigateToRuleDescriptionCommand>(),

--- a/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewToolWindow.cs
@@ -43,17 +43,13 @@ internal class ReportViewToolWindow : ToolWindowPane
     {
         var componentModel = serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
         Caption = Resources.ReportViewToolWindowCaption;
-        var hotspotsReportViewModel = componentModel?.GetService<IHotspotsReportViewModel>();
         Content = new ReportViewControl(
             componentModel?.GetService<IActiveSolutionBoundTracker>(),
             componentModel?.GetService<IBrowserService>(),
-            componentModel?.GetService<IDependencyRisksStore>(),
-            hotspotsReportViewModel,
-            componentModel?.GetService<IShowDependencyRiskInBrowserHandler>(),
-            componentModel?.GetService<IChangeDependencyRiskStatusHandler>(),
+            componentModel?.GetService<IHotspotsReportViewModel>(),
+            componentModel?.GetService<IDependencyRisksReportViewModel>(),
             componentModel?.GetService<INavigateToRuleDescriptionCommand>(),
             componentModel?.GetService<ILocationNavigator>(),
-            componentModel?.GetService<IMessageBox>(),
             componentModel?.GetService<ITelemetryManager>(),
             componentModel?.GetService<IThreadHandling>()
         );


### PR DESCRIPTION
Part of SLVS-2517

Split `ReportViewModel` into multiple classes to avoid it from becoming a god class. The class was quite crowded and a lot of functionality is missing, including for taints (and, in the future, for normal issues)