### PR TITLE
SLVS-2522 Add context menu for hotspot

### DIFF
--- a/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotViewModelTests.cs
+++ b/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotViewModelTests.cs
@@ -28,18 +28,20 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.UnitTests.ReportVie
 [TestClass]
 public class HotspotViewModelTests
 {
+    private readonly LocalHotspot hotspot = CreateMockedHotspot("csharp:101",
+        Guid.NewGuid(),
+        1,
+        66,
+        "remove todo comment",
+        "myClass.cs");
+    private HotspotViewModel testSubject;
+
+    [TestInitialize]
+    public void TestInitialize() => testSubject = new HotspotViewModel(hotspot);
+
     [TestMethod]
     public void Ctor_InitializesPropertiesAsExpected()
     {
-        var hotspot = CreateMockedHotspot("csharp:101",
-            Guid.NewGuid(),
-            1,
-            66,
-            "remove todo comment",
-            "myClass.cs");
-
-        var testSubject = new HotspotViewModel(hotspot);
-
         testSubject.LocalHotspot.Should().Be(hotspot);
         testSubject.RuleInfo.RuleKey.Should().Be(hotspot.Visualization.RuleId);
         testSubject.RuleInfo.IssueId.Should().Be(hotspot.Visualization.IssueId);
@@ -48,6 +50,22 @@ public class HotspotViewModelTests
         testSubject.Title.Should().Be(hotspot.Visualization.Issue.PrimaryLocation.Message);
         testSubject.FilePath.Should().Be(hotspot.Visualization.Issue.PrimaryLocation.FilePath);
         testSubject.Issue.Should().Be(hotspot.Visualization);
+    }
+
+    [TestMethod]
+    public void ExistsOnServer_LocalHotspot_ReturnsFalse()
+    {
+        hotspot.Visualization.Issue.IssueServerKey.Returns((string)null);
+
+        testSubject.ExistsOnServer.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void ExistsOnServer_ServerHotspot_ReturnsTrue()
+    {
+        hotspot.Visualization.Issue.IssueServerKey.Returns(Guid.NewGuid().ToString());
+
+        testSubject.ExistsOnServer.Should().BeTrue();
     }
 
     private static LocalHotspot CreateMockedHotspot(

--- a/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotsReportViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotsReportViewModelTest.cs
@@ -19,8 +19,10 @@
  */
 
 using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Integration.TestInfrastructure;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.ReviewHotspot;
 using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
@@ -33,12 +35,14 @@ public class HotspotsReportViewModelTest
 {
     private ILocalHotspotsStore localHotspotsStore;
     private HotspotsReportViewModel testSubject;
+    private IReviewHotspotsService reviewHotspotsService;
 
     [TestInitialize]
     public void TestInitialize()
     {
         localHotspotsStore = Substitute.For<ILocalHotspotsStore>();
-        testSubject = new HotspotsReportViewModel(localHotspotsStore);
+        reviewHotspotsService = Substitute.For<IReviewHotspotsService>();
+        testSubject = new HotspotsReportViewModel(localHotspotsStore, reviewHotspotsService);
     }
 
     [TestMethod]
@@ -112,6 +116,16 @@ public class HotspotsReportViewModelTest
         localHotspotsStore.IssuesChanged += Raise.Event<EventHandler<IssuesChangedEventArgs>>(null, null);
 
         raised.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task ShowHotspotInBrowserAsync_CallsHandler()
+    {
+        var hotspot = CreateMockedHotspot("myFile.cs");
+
+        await testSubject.ShowHotspotInBrowserAsync(hotspot);
+
+        reviewHotspotsService.Received(1).OpenHotspotAsync(hotspot.Visualization.Issue.IssueServerKey).IgnoreAwaitForAssert();
     }
 
     private static LocalHotspot CreateMockedHotspot(string filePath)

--- a/src/IssueViz.Security/ReportView/Hotspots/HotspotViewModel.cs
+++ b/src/IssueViz.Security/ReportView/Hotspots/HotspotViewModel.cs
@@ -27,6 +27,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots
 internal class HotspotViewModel : ViewModelBase, IAnalysisIssueViewModel
 {
     public LocalHotspot LocalHotspot { get; }
+    public bool ExistsOnServer => LocalHotspot.Visualization.Issue.IssueServerKey != null;
 
     public HotspotViewModel(LocalHotspot localHotspot)
     {

--- a/src/IssueViz.Security/ReportView/Hotspots/HotspotsReportViewModel.cs
+++ b/src/IssueViz.Security/ReportView/Hotspots/HotspotsReportViewModel.cs
@@ -20,6 +20,9 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
+using System.Windows;
+using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.ReviewHotspot;
 using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
@@ -32,6 +35,10 @@ internal interface IHotspotsReportViewModel : IDisposable
 
     Task ShowHotspotInBrowserAsync(LocalHotspot localHotspot);
 
+    Task<IEnumerable<HotspotStatus>> GetAllowedStatusesAsync(HotspotViewModel selectedHotspotViewModel);
+
+    Task<bool> ChangeHotspotStatusAsync(HotspotViewModel selectedHotspotViewModel, HotspotStatus newStatus);
+
     event EventHandler HotspotsChanged;
 }
 
@@ -41,12 +48,14 @@ internal sealed class HotspotsReportViewModel : IHotspotsReportViewModel
 {
     private readonly ILocalHotspotsStore hotspotsStore;
     private readonly IReviewHotspotsService reviewHotspotsService;
+    private readonly IMessageBox messageBox;
 
     [ImportingConstructor]
-    public HotspotsReportViewModel(ILocalHotspotsStore hotspotsStore, IReviewHotspotsService reviewHotspotsService)
+    public HotspotsReportViewModel(ILocalHotspotsStore hotspotsStore, IReviewHotspotsService reviewHotspotsService, IMessageBox messageBox)
     {
         this.hotspotsStore = hotspotsStore;
         this.reviewHotspotsService = reviewHotspotsService;
+        this.messageBox = messageBox;
         hotspotsStore.IssuesChanged += HotspotsStore_IssuesChanged;
     }
 
@@ -61,6 +70,33 @@ internal sealed class HotspotsReportViewModel : IHotspotsReportViewModel
     }
 
     public async Task ShowHotspotInBrowserAsync(LocalHotspot localHotspot) => await reviewHotspotsService.OpenHotspotAsync(localHotspot.Visualization.Issue.IssueServerKey);
+
+    public async Task<IEnumerable<HotspotStatus>> GetAllowedStatusesAsync(HotspotViewModel selectedHotspotViewModel)
+    {
+        var response = selectedHotspotViewModel == null
+            ? new ReviewHotspotNotPermittedArgs(Resources.ReviewHotspotWindow_NoStatusSelectedFailureMessage)
+            : await reviewHotspotsService.CheckReviewHotspotPermittedAsync(selectedHotspotViewModel.LocalHotspot.Visualization.Issue.IssueServerKey);
+        switch (response)
+        {
+            case ReviewHotspotPermittedArgs reviewHotspotPermittedArgs:
+                return reviewHotspotPermittedArgs.AllowedStatuses;
+            case ReviewHotspotNotPermittedArgs reviewHotspotNotPermittedArgs:
+                messageBox.Show(string.Format(Resources.ReviewHotspotWindow_CheckReviewPermittedFailureMessage, reviewHotspotNotPermittedArgs.Reason), Resources.ReviewHotspotWindow_FailureTitle,
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+        }
+        return null;
+    }
+
+    public async Task<bool> ChangeHotspotStatusAsync(HotspotViewModel selectedHotspotViewModel, HotspotStatus newStatus)
+    {
+        var wasChanged = await reviewHotspotsService.ReviewHotspotAsync(selectedHotspotViewModel.LocalHotspot.Visualization.Issue.IssueServerKey, newStatus);
+        if (!wasChanged)
+        {
+            messageBox.Show(Resources.ReviewHotspotWindow_ReviewFailureMessage, Resources.ReviewHotspotWindow_FailureTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        return wasChanged;
+    }
 
     private static ObservableCollection<IGroupViewModel> GetGroupViewModel(IEnumerable<IIssueViewModel> issueViewModels)
     {

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml
@@ -197,7 +197,7 @@
                           Click="ChangeHotspotStatusMenuItem_OnClick" 
                           Style="{StaticResource ChangeStatusMenuItemStyle}"/>
                 <MenuItem Click="ViewHotspotInBrowser_OnClick"
-                          Header="{x:Static res:Resources.ViewHotspotInBrowser}"
+                          Loaded="ShowHotspotInBrowserMenuItem_OnLoaded"
                           Style="{StaticResource ViewIssueInBrowserMenuItemStyle}" />
             </ContextMenu>
 

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml
@@ -191,6 +191,13 @@
                 <MenuItem Click="ViewDependencyRiskInBrowser_OnClick" Style="{StaticResource ViewIssueInBrowserMenuItemStyle}" />
             </ContextMenu>
 
+            <ContextMenu x:Key="HotspotContextMenu"    
+                         Visibility="{Binding Path=ExistsOnServer, Converter={StaticResource TrueToVisibleConverter}}">
+                <MenuItem Click="ViewHotspotInBrowser_OnClick"
+                          Header="{x:Static res:Resources.ViewHotspotInBrowser}"
+                          Style="{StaticResource ViewIssueInBrowserMenuItemStyle}" />
+            </ContextMenu>
+
             <Style x:Key="ResolutionFilterBorderStyle" TargetType="Button">
                 <Setter Property="Margin" Value="5, 3"/>
                 <Setter Property="Padding" Value="2"/>
@@ -362,7 +369,10 @@
 
                 <!--Hotspots styling-->
                 <DataTemplate DataType="{x:Type hotspots:HotspotViewModel}">
-                    <Grid Margin="5,2" MouseRightButtonDown="TreeViewItem_OnMouseRightButtonDown" ToolTip="{x:Static res:Resources.HotspotsControl_NavigationTooltip}">
+                    <Grid Margin="5,2" 
+                          ContextMenu="{StaticResource HotspotContextMenu}"
+                          MouseRightButtonDown="TreeViewItem_OnMouseRightButtonDown" 
+                          ToolTip="{x:Static res:Resources.HotspotsControl_NavigationTooltip}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml
@@ -193,6 +193,9 @@
 
             <ContextMenu x:Key="HotspotContextMenu"    
                          Visibility="{Binding Path=ExistsOnServer, Converter={StaticResource TrueToVisibleConverter}}">
+                <MenuItem Header="{x:Static res:Resources.ChangeStatusMenuItem}" 
+                          Click="ChangeHotspotStatusMenuItem_OnClick" 
+                          Style="{StaticResource ChangeStatusMenuItemStyle}"/>
                 <MenuItem Click="ViewHotspotInBrowser_OnClick"
                           Header="{x:Static res:Resources.ViewHotspotInBrowser}"
                           Style="{StaticResource ViewIssueInBrowserMenuItemStyle}" />

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -180,4 +180,12 @@ internal sealed partial class ReportViewControl : UserControl
             command.Execute(parameter);
         }
     }
+
+    private async void ViewHotspotInBrowser_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (ReportViewModel.SelectedItem is HotspotViewModel hotspotViewModel)
+        {
+            await HotspotsReportViewModel.ShowHotspotInBrowserAsync(hotspotViewModel.LocalHotspot);
+        }
+    }
 }

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -116,14 +116,19 @@ internal sealed partial class ReportViewControl : UserControl
         DependencyRisksReportViewModel.ShowDependencyRiskInBrowser(selectedDependencyRiskViewModel.DependencyRisk);
     }
 
-    private void DependencyRiskContextMenu_OnLoaded(object sender, RoutedEventArgs e)
+    private void DependencyRiskContextMenu_OnLoaded(object sender, RoutedEventArgs e) => SetDataContextToReportViewModel<ContextMenu>(sender);
+
+    private void SetDataContextToReportViewModel<T>(object sender) where T : FrameworkElement
     {
-        if (sender is ContextMenu contextMenu)
+        if (sender is T contextMenu)
         {
-            // setting the DataContext directly on the context menu does not work for the TreeViewItem
+            // workaround that allows setting the DataContext to the ReportViewModel, which is not accessible from the TreeViewItem context menu
+            // due to the fact that a context menu is a popup and is not part of the visual tree
             contextMenu.DataContext = ReportViewModel;
         }
     }
+
+    private void ShowHotspotInBrowserMenuItem_OnLoaded(object sender, RoutedEventArgs e) => SetDataContextToReportViewModel<MenuItem>(sender);
 
     private void TreeViewItem_OnMouseRightButtonDown(object sender, MouseButtonEventArgs e)
     {

--- a/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewControl.xaml.cs
@@ -26,13 +26,16 @@ using System.Windows.Media;
 using System.Windows.Navigation;
 using SonarLint.VisualStudio.ConnectedMode.UI;
 using SonarLint.VisualStudio.Core;
+using SonarLint.VisualStudio.Core.Analysis;
 using SonarLint.VisualStudio.Core.Binding;
 using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.IssueVisualization.Editor;
 using SonarLint.VisualStudio.IssueVisualization.IssueVisualizationControl.ViewModels.Commands;
 using SonarLint.VisualStudio.IssueVisualization.Security.DependencyRisks;
+using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.HotspotsList.ViewModels;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots;
 using SonarLint.VisualStudio.IssueVisualization.Security.ReviewStatus;
+using HotspotViewModel = SonarLint.VisualStudio.IssueVisualization.Security.ReportView.Hotspots.HotspotViewModel;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Security.ReportView;
 
@@ -186,6 +189,27 @@ internal sealed partial class ReportViewControl : UserControl
         if (ReportViewModel.SelectedItem is HotspotViewModel hotspotViewModel)
         {
             await HotspotsReportViewModel.ShowHotspotInBrowserAsync(hotspotViewModel.LocalHotspot);
+        }
+    }
+
+    private async void ChangeHotspotStatusMenuItem_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem { DataContext: HotspotViewModel hotspotViewModel } ||
+            await HotspotsReportViewModel.GetAllowedStatusesAsync(hotspotViewModel) is not { } allowedStatuses)
+        {
+            return;
+        }
+
+        var changeHotspotStatusViewModel = new ChangeHotspotStatusViewModel(hotspotViewModel.LocalHotspot.HotspotStatus, allowedStatuses);
+        var dialog = new ChangeStatusWindow(changeHotspotStatusViewModel, browserService, activeSolutionBoundTracker);
+        if (dialog.ShowDialog(Application.Current.MainWindow) is true)
+        {
+            var newStatus = changeHotspotStatusViewModel.SelectedStatusViewModel.GetCurrentStatus<HotspotStatus>();
+            var wasChanged = await HotspotsReportViewModel.ChangeHotspotStatusAsync(hotspotViewModel, newStatus);
+            if (wasChanged && newStatus is HotspotStatus.Fixed or HotspotStatus.Safe)
+            {
+                ReportViewModel.GroupViewModels.ToList().ForEach(vm => vm.FilteredIssues.Remove(hotspotViewModel));
+            }
         }
     }
 }

--- a/src/IssueViz.Security/Resources.Designer.cs
+++ b/src/IssueViz.Security/Resources.Designer.cs
@@ -792,6 +792,15 @@ namespace SonarLint.VisualStudio.IssueVisualization.Security {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to View security hotspot in browser.
+        /// </summary>
+        public static string ViewHotspotInBrowser {
+            get {
+                return ResourceManager.GetString("ViewHotspotInBrowser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to View in SonarQube Cloud.
         /// </summary>
         public static string ViewIssueInSonarQubeCloud {

--- a/src/IssueViz.Security/Resources.resx
+++ b/src/IssueViz.Security/Resources.resx
@@ -242,6 +242,9 @@ Please check the logs for more details.</value>
   <data name="ViewIssueInSonarQubeServer" xml:space="preserve">
     <value>View in SonarQube Server</value>
   </data>
+  <data name="ViewHotspotInBrowser" xml:space="preserve">
+    <value>View security hotspot in browser</value>
+  </data>
   <data name="ReportViewToolWindowCaption" xml:space="preserve">
     <value>SonarQube Dependency Risks</value>
   </data>


### PR DESCRIPTION
[SLVS-2522](https://sonarsource.atlassian.net/browse/SLVS-2522)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6423) in which the `ReportViewModel` was refactored to prevent crowding it with lots of logic.
The logic is mostly a copy-paste from `HotspotsControlViewModel` and its tests. Nothing new should have been added, just minor UI changes were done.

[SLVS-2522]: https://sonarsource.atlassian.net/browse/SLVS-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ