### PR TITLE
SLVS-2523 Implement telemetry for interacting with hotspots

### DIFF
--- a/src/Core/Telemetry/ITelemetryManager.cs
+++ b/src/Core/Telemetry/ITelemetryManager.cs
@@ -43,4 +43,8 @@ public interface ITelemetryManager
     void AddedAutomaticBindings();
 
     void DependencyRiskInvestigatedLocally();
+
+    void HotspotInvestigatedLocally();
+
+    void HotspotInvestigatedRemotely();
 }

--- a/src/Integration.UnitTests/Telemetry/TelemetryManagerTests.cs
+++ b/src/Integration.UnitTests/Telemetry/TelemetryManagerTests.cs
@@ -19,7 +19,6 @@
  */
 
 using Microsoft.VisualStudio.Shell;
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.Integration.Telemetry;
 using SonarLint.VisualStudio.SLCore.Service.Telemetry;
@@ -241,6 +240,30 @@ public class TelemetryManagerTests
         {
             telemetryHandler.Notify(Arg.Any<Action<ITelemetrySLCoreService>>());
             telemetryService.DependencyRiskInvestigatedLocally();
+        });
+    }
+
+    [TestMethod]
+    public void HotspotInvestigatedLocally_CallsRpcService()
+    {
+        telemetryManager.HotspotInvestigatedLocally();
+
+        Received.InOrder(() =>
+        {
+            telemetryHandler.Notify(Arg.Any<Action<ITelemetrySLCoreService>>());
+            telemetryService.HotspotInvestigatedLocally();
+        });
+    }
+
+    [TestMethod]
+    public void HotspotInvestigatedRemotely_CallsRpcService()
+    {
+        telemetryManager.HotspotInvestigatedRemotely();
+
+        Received.InOrder(() =>
+        {
+            telemetryHandler.Notify(Arg.Any<Action<ITelemetrySLCoreService>>());
+            telemetryService.HotspotInvestigatedRemotely();
         });
     }
 

--- a/src/Integration/Telemetry/TelemetryManager.cs
+++ b/src/Integration/Telemetry/TelemetryManager.cs
@@ -20,7 +20,6 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
-using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.SLCore.Service.Telemetry;
 using SonarLint.VisualStudio.SLCore.Service.Telemetry.Models;
@@ -67,6 +66,10 @@ internal sealed class TelemetryManager : ITelemetryManager,
     public void AddedAutomaticBindings() => telemetryHelper.Notify(telemetryService => telemetryService.AddedAutomaticBindings());
 
     public void DependencyRiskInvestigatedLocally() => telemetryHelper.Notify(telemetryService => telemetryService.DependencyRiskInvestigatedLocally());
+
+    public void HotspotInvestigatedLocally() => telemetryHelper.Notify(telemetryService => telemetryService.HotspotInvestigatedLocally());
+
+    public void HotspotInvestigatedRemotely() => telemetryHelper.Notify(telemetryService => telemetryService.HotspotInvestigatedRemotely());
 
     private static IEnumerable<FixSuggestionResolvedParams> ConvertFixSuggestionChangeToResolvedParams(string suggestionId, IEnumerable<bool> changeApplicationStatus) =>
         changeApplicationStatus

--- a/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotsReportViewModelTest.cs
+++ b/src/IssueViz.Security.UnitTests/ReportView/Hotspots/HotspotsReportViewModelTest.cs
@@ -21,6 +21,7 @@
 using System.Windows;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.Integration.TestInfrastructure;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
@@ -39,6 +40,7 @@ public class HotspotsReportViewModelTest
     private ILocalHotspotsStore localHotspotsStore;
     private IMessageBox messageBox;
     private IReviewHotspotsService reviewHotspotsService;
+    private ITelemetryManager telemetryManager;
     private HotspotsReportViewModel testSubject;
 
     [TestInitialize]
@@ -47,7 +49,8 @@ public class HotspotsReportViewModelTest
         localHotspotsStore = Substitute.For<ILocalHotspotsStore>();
         reviewHotspotsService = Substitute.For<IReviewHotspotsService>();
         messageBox = Substitute.For<IMessageBox>();
-        testSubject = new HotspotsReportViewModel(localHotspotsStore, reviewHotspotsService, messageBox);
+        telemetryManager = Substitute.For<ITelemetryManager>();
+        testSubject = new HotspotsReportViewModel(localHotspotsStore, reviewHotspotsService, messageBox, telemetryManager);
     }
 
     [TestMethod]
@@ -55,7 +58,8 @@ public class HotspotsReportViewModelTest
         MefTestHelpers.CheckTypeCanBeImported<HotspotsReportViewModel, IHotspotsReportViewModel>(
             MefTestHelpers.CreateExport<ILocalHotspotsStore>(),
             MefTestHelpers.CreateExport<IReviewHotspotsService>(),
-            MefTestHelpers.CreateExport<IMessageBox>()
+            MefTestHelpers.CreateExport<IMessageBox>(),
+            MefTestHelpers.CreateExport<ITelemetryManager>()
         );
 
     [TestMethod]
@@ -127,13 +131,14 @@ public class HotspotsReportViewModelTest
     }
 
     [TestMethod]
-    public async Task ShowHotspotInBrowserAsync_CallsHandler()
+    public async Task ShowHotspotInBrowserAsync_CallsHandlerAndTelemetry()
     {
         var hotspot = CreateMockedHotspot("myFile.cs");
 
         await testSubject.ShowHotspotInBrowserAsync(hotspot);
 
         reviewHotspotsService.Received(1).OpenHotspotAsync(hotspot.Visualization.Issue.IssueServerKey).IgnoreAwaitForAssert();
+        telemetryManager.Received(1).HotspotInvestigatedRemotely();
     }
 
     [TestMethod]

--- a/src/IssueViz.Security/ReportView/Hotspots/HotspotsReportViewModel.cs
+++ b/src/IssueViz.Security/ReportView/Hotspots/HotspotsReportViewModel.cs
@@ -23,6 +23,7 @@ using System.ComponentModel.Composition;
 using System.Windows;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.Core.Analysis;
+using SonarLint.VisualStudio.Core.Telemetry;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots;
 using SonarLint.VisualStudio.IssueVisualization.Security.Hotspots.ReviewHotspot;
 using SonarLint.VisualStudio.IssueVisualization.Security.IssuesStore;
@@ -49,13 +50,19 @@ internal sealed class HotspotsReportViewModel : IHotspotsReportViewModel
     private readonly ILocalHotspotsStore hotspotsStore;
     private readonly IReviewHotspotsService reviewHotspotsService;
     private readonly IMessageBox messageBox;
+    private readonly ITelemetryManager telemetryManager;
 
     [ImportingConstructor]
-    public HotspotsReportViewModel(ILocalHotspotsStore hotspotsStore, IReviewHotspotsService reviewHotspotsService, IMessageBox messageBox)
+    public HotspotsReportViewModel(
+        ILocalHotspotsStore hotspotsStore,
+        IReviewHotspotsService reviewHotspotsService,
+        IMessageBox messageBox,
+        ITelemetryManager telemetryManager)
     {
         this.hotspotsStore = hotspotsStore;
         this.reviewHotspotsService = reviewHotspotsService;
         this.messageBox = messageBox;
+        this.telemetryManager = telemetryManager;
         hotspotsStore.IssuesChanged += HotspotsStore_IssuesChanged;
     }
 
@@ -69,7 +76,11 @@ internal sealed class HotspotsReportViewModel : IHotspotsReportViewModel
         return GetGroupViewModel(hotspots);
     }
 
-    public async Task ShowHotspotInBrowserAsync(LocalHotspot localHotspot) => await reviewHotspotsService.OpenHotspotAsync(localHotspot.Visualization.Issue.IssueServerKey);
+    public async Task ShowHotspotInBrowserAsync(LocalHotspot localHotspot)
+    {
+        await reviewHotspotsService.OpenHotspotAsync(localHotspot.Visualization.Issue.IssueServerKey);
+        telemetryManager.HotspotInvestigatedRemotely();
+    }
 
     public async Task<IEnumerable<HotspotStatus>> GetAllowedStatusesAsync(HotspotViewModel selectedHotspotViewModel)
     {

--- a/src/IssueViz.Security/ReportView/ReportViewModel.cs
+++ b/src/IssueViz.Security/ReportView/ReportViewModel.cs
@@ -96,9 +96,14 @@ internal class ReportViewModel : ServerViewModel
 
     private void UpdateTelemetry(IIssueViewModel issueViewModel)
     {
-        if (issueViewModel is DependencyRiskViewModel)
+        switch (issueViewModel)
         {
-            telemetryManager.DependencyRiskInvestigatedLocally();
+            case DependencyRiskViewModel:
+                telemetryManager.DependencyRiskInvestigatedLocally();
+                break;
+            case HotspotViewModel:
+                telemetryManager.HotspotInvestigatedLocally();
+                break;
         }
     }
 

--- a/src/SLCore/Service/Telemetry/ITelemetrySLCoreService.cs
+++ b/src/SLCore/Service/Telemetry/ITelemetrySLCoreService.cs
@@ -27,18 +27,36 @@ namespace SonarLint.VisualStudio.SLCore.Service.Telemetry;
 public interface ITelemetrySLCoreService : ISLCoreService
 {
     Task<GetStatusResponse> GetStatusAsync();
+
     void EnableTelemetry();
+
     void DisableTelemetry();
+
     void AnalysisDoneOnSingleLanguage(AnalysisDoneOnSingleLanguageParams parameters);
+
     void DevNotificationsClicked(DevNotificationsClickedParams parameters);
+
     void TaintVulnerabilitiesInvestigatedLocally();
+
     void TaintVulnerabilitiesInvestigatedRemotely();
+
     void AddReportedRules(AddReportedRulesParams parameters);
+
     void AddQuickFixAppliedForRule(AddQuickFixAppliedForRuleParams parameters);
+
     void FixSuggestionResolved(FixSuggestionResolvedParams parameters);
+
     void HelpAndFeedbackLinkClicked(HelpAndFeedbackClickedParams parameters);
+
     void AddedManualBindings();
+
     void AddedImportedBindings();
+
     void AddedAutomaticBindings();
+
     void DependencyRiskInvestigatedLocally();
+
+    void HotspotInvestigatedLocally();
+
+    void HotspotInvestigatedRemotely();
 }


### PR DESCRIPTION
[SLVS-2523](https://sonarsource.atlassian.net/browse/SLVS-2523)

This targets the [PR](https://github.com/SonarSource/sonarlint-visualstudio/pull/6424) in which show in browser command has been implemented, because telemetry is also added for it 

[SLVS-2523]: https://sonarsource.atlassian.net/browse/SLVS-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ