### PR TITLE
SLVS-2943 10.3.0 analyzer updates

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -7,7 +7,7 @@
     <!-- sonar-csharp-enterprise-plugin & sonar-vbnet-enterprise-plugin -->
     <EmbeddedSonarAnalyzerVersion>10.25.0.139117</EmbeddedSonarAnalyzerVersion>
     <!-- sonar-cfamily-plugin, only used for integration tests -->
-    <EmbeddedSonarCFamilyAnalyzerVersion>6.80.0.98490</EmbeddedSonarCFamilyAnalyzerVersion>
+    <EmbeddedSonarCFamilyAnalyzerVersion>6.81.0.99236</EmbeddedSonarCFamilyAnalyzerVersion>
     <!-- sonar-javascript-plugin -->
     <EmbeddedSonarJSAnalyzerVersion>12.4.0.40770</EmbeddedSonarJSAnalyzerVersion>
     <EmbeddedEsLintBridgeVersion>1.0.0</EmbeddedEsLintBridgeVersion>


### PR DESCRIPTION
Analyzer updates for the 10.3.0 release.

- SLVS-2943 Update CFamily analyzer to 6.81.0.99236

Updates `EmbeddedSonarCFamilyAnalyzerVersion` in `src/EmbeddedSonarAnalyzer.props`. Same ticket key referenced in sonarlint-core PR.