### PR TITLE
test: run build on ci-ami-images PR #367 temp runner (nuget feed)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: warp-custom-sonarlint-visualstudio
+    runs-on: warp-custom-pr-367-sonarlint-visualstudio-v20260615143319
     name: Build
     environment: ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'branch-')) && 'release-ready-build' || '' }}
     steps:


### PR DESCRIPTION
----
## Summary by Gitar

- **CI Configuration:**
  - Updated `build.yml` to use `warp-custom-pr-367-sonarlint-visualstudio-v20260615143319` runner for testing NuGet feed integration.

<sub>This will update automatically on new commits.</sub>