### PR TITLE
SLVS-2978 Update SLCore to 11.5.0.85871

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -18,6 +18,6 @@
     <!-- sonarqube-ide-visualstudio-roslyn --> 
     <EmbeddedSonarSqvsRoslynJarVersion>1.2.0.364</EmbeddedSonarSqvsRoslynJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->
-    <EmbeddedSloopVersion>11.4.0.85676</EmbeddedSloopVersion>
+    <EmbeddedSloopVersion>11.5.0.85871</EmbeddedSloopVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `EmbeddedSloopVersion` to `11.5.0.85871` in `src/EmbeddedSonarAnalyzer.props`.

<sub>This will update automatically on new commits.</sub>