### PR TITLE
SLVS-2972 Configure Renovate post-upgrade task to regenerate NuGet

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:ide-xp-team"
+  ],
+  "packageRules": [
+    {
+      "description": "Regenerate NuGet lockfiles after dependency updates",
+      "matchManagers": [
+        "nuget"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "dotnet restore SonarQube.VisualStudio.sln"
+        ],
+        "fileFilters": [
+          "**/packages.lock.json"
+        ],
+        "executionMode": "branch"
+      }
+    }
   ]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate Configuration:**
  - Added a `postUpgradeTasks` rule to automatically regenerate `packages.lock.json` files for NuGet dependencies.
  - Configured the task to run `dotnet restore SonarQube.VisualStudio.sln` in `branch` execution mode.

<sub>This will update automatically on new commits.</sub>