### PR TITLE
SLVS-2979 Update version to 10.5.0

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
     <!-- Manually set the three-part main version and check in the changed file.
          The other required build properties (e.g. Sha1) will be set by the CI build when
          it builds ChangeVersion.proj. -->
-    <MainVersion>10.4.0</MainVersion>
+    <MainVersion>10.5.0</MainVersion>
     <!-- Properties set by the CI build pipeline -->
     <BuildNumber>0</BuildNumber>
     <Sha1>not-set</Sha1>

--- a/src/AssemblyInfo.Shared.cs
+++ b/src/AssemblyInfo.Shared.cs
@@ -22,9 +22,9 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 // Note: keep the version numbers in sync with the VSIX (source.extension.manifest)
-[assembly: AssemblyVersion("10.4.0")]
-[assembly: AssemblyFileVersion("10.4.0.0")] // This should exactly match the VSIX version
-[assembly: AssemblyInformationalVersion("Version:10.4.0.0 Branch:not-set Sha1:not-set Configuration:not-set")]
+[assembly: AssemblyVersion("10.5.0")]
+[assembly: AssemblyFileVersion("10.5.0.0")] // This should exactly match the VSIX version
+[assembly: AssemblyInformationalVersion("Version:10.5.0.0 Branch:not-set Sha1:not-set Configuration:not-set")]
 [assembly: AssemblyConfiguration("")]
 [assembly: ComVisible(false)]
 [assembly: AssemblyProduct("SonarQube for Visual Studio")]

--- a/src/Integration.Vsix/AsmRef_Integration.Vsix_Baseline_WithStrongNames.txt
+++ b/src/Integration.Vsix/AsmRef_Integration.Vsix_Baseline_WithStrongNames.txt
@@ -26,7 +26,7 @@ Exclude patterns:
 # Number of matches: 12
 
 ---
-Assembly: 'SonarLint.2022, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.2022, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.2022.dll'
 
 Referenced assemblies:
@@ -44,15 +44,15 @@ Referenced assemblies:
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.CFamily, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Integration, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.CFamily, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Integration, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -64,14 +64,14 @@ Referenced assemblies:
 # Number of references: 31
 
 ---
-Assembly: 'SonarLint.VisualStudio.CFamily, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.CFamily, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.CFamily.dll'
 
 Referenced assemblies:
 - 'Microsoft.VisualStudio.Shell.Framework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -79,7 +79,7 @@ Referenced assemblies:
 # Number of references: 8
 
 ---
-Assembly: 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.ConnectedMode.dll'
 
 Referenced assemblies:
@@ -96,9 +96,9 @@ Referenced assemblies:
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -110,7 +110,7 @@ Referenced assemblies:
 # Number of references: 24
 
 ---
-Assembly: 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.Core.dll'
 
 Referenced assemblies:
@@ -129,7 +129,7 @@ Referenced assemblies:
 # Number of references: 12
 
 ---
-Assembly: 'SonarLint.VisualStudio.Education, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.Education, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.Education.dll'
 
 Referenced assemblies:
@@ -143,9 +143,9 @@ Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -155,7 +155,7 @@ Referenced assemblies:
 # Number of references: 19
 
 ---
-Assembly: 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.Infrastructure.VS.dll'
 
 Referenced assemblies:
@@ -167,7 +167,7 @@ Referenced assemblies:
 - 'Microsoft.VisualStudio.Text.Data, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -176,7 +176,7 @@ Referenced assemblies:
 # Number of references: 14
 
 ---
-Assembly: 'SonarLint.VisualStudio.Integration, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.Integration, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.Integration.dll'
 
 Referenced assemblies:
@@ -193,10 +193,10 @@ Referenced assemblies:
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'Sentry, Version=6.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'StreamJsonRpc, Version=2.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
@@ -210,7 +210,7 @@ Referenced assemblies:
 # Number of references: 27
 
 ---
-Assembly: 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.IssueVisualization.dll'
 
 Referenced assemblies:
@@ -233,9 +233,9 @@ Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -246,7 +246,7 @@ Referenced assemblies:
 # Number of references: 29
 
 ---
-Assembly: 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.IssueVisualization.Security.dll'
 
 Referenced assemblies:
@@ -262,11 +262,11 @@ Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -275,7 +275,7 @@ Referenced assemblies:
 # Number of references: 22
 
 ---
-Assembly: 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.RoslynAnalyzerServer.dll'
 
 Referenced assemblies:
@@ -288,7 +288,7 @@ Referenced assemblies:
 - 'Microsoft.VisualStudio.Threading, Version=16.10.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -300,14 +300,14 @@ Referenced assemblies:
 # Number of references: 18
 
 ---
-Assembly: 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.SLCore.dll'
 
 Referenced assemblies:
 - 'Microsoft.VisualStudio.Threading, Version=16.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'StreamJsonRpc, Version=2.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
@@ -317,18 +317,18 @@ Referenced assemblies:
 # Number of references: 10
 
 ---
-Assembly: 'SonarLint.VisualStudio.SLCore.Listeners, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+Assembly: 'SonarLint.VisualStudio.SLCore.Listeners, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 Relative path: 'SonarLint.VisualStudio.SLCore.Listeners.dll'
 
 Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.Integration, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.Integration, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'

--- a/src/Integration.Vsix/AsmRef_Integration.Vsix_Baseline_WithoutStrongNames.txt
+++ b/src/Integration.Vsix/AsmRef_Integration.Vsix_Baseline_WithoutStrongNames.txt
@@ -26,7 +26,7 @@ Exclude patterns:
 # Number of matches: 12
 
 ---
-Assembly: 'SonarLint.2022, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.2022, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.2022.dll'
 
 Referenced assemblies:
@@ -44,15 +44,15 @@ Referenced assemblies:
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.CFamily, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Integration, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.CFamily, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Integration, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -64,14 +64,14 @@ Referenced assemblies:
 # Number of references: 31
 
 ---
-Assembly: 'SonarLint.VisualStudio.CFamily, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.CFamily, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.CFamily.dll'
 
 Referenced assemblies:
 - 'Microsoft.VisualStudio.Shell.Framework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -79,7 +79,7 @@ Referenced assemblies:
 # Number of references: 8
 
 ---
-Assembly: 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.ConnectedMode.dll'
 
 Referenced assemblies:
@@ -96,9 +96,9 @@ Referenced assemblies:
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -110,7 +110,7 @@ Referenced assemblies:
 # Number of references: 24
 
 ---
-Assembly: 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.Core.dll'
 
 Referenced assemblies:
@@ -129,7 +129,7 @@ Referenced assemblies:
 # Number of references: 12
 
 ---
-Assembly: 'SonarLint.VisualStudio.Education, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.Education, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.Education.dll'
 
 Referenced assemblies:
@@ -143,9 +143,9 @@ Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -155,7 +155,7 @@ Referenced assemblies:
 # Number of references: 19
 
 ---
-Assembly: 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.Infrastructure.VS.dll'
 
 Referenced assemblies:
@@ -167,7 +167,7 @@ Referenced assemblies:
 - 'Microsoft.VisualStudio.Text.Data, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -176,7 +176,7 @@ Referenced assemblies:
 # Number of references: 14
 
 ---
-Assembly: 'SonarLint.VisualStudio.Integration, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.Integration, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.Integration.dll'
 
 Referenced assemblies:
@@ -193,10 +193,10 @@ Referenced assemblies:
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'Sentry, Version=6.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'StreamJsonRpc, Version=2.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
@@ -210,7 +210,7 @@ Referenced assemblies:
 # Number of references: 27
 
 ---
-Assembly: 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.IssueVisualization.dll'
 
 Referenced assemblies:
@@ -233,9 +233,9 @@ Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -246,7 +246,7 @@ Referenced assemblies:
 # Number of references: 29
 
 ---
-Assembly: 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.IssueVisualization.Security.dll'
 
 Referenced assemblies:
@@ -262,11 +262,11 @@ Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 - 'PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Infrastructure.VS, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -275,7 +275,7 @@ Referenced assemblies:
 # Number of references: 22
 
 ---
-Assembly: 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.RoslynAnalyzerServer.dll'
 
 Referenced assemblies:
@@ -288,7 +288,7 @@ Referenced assemblies:
 - 'Microsoft.VisualStudio.Threading, Version=16.10.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
@@ -300,14 +300,14 @@ Referenced assemblies:
 # Number of references: 18
 
 ---
-Assembly: 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.SLCore.dll'
 
 Referenced assemblies:
 - 'Microsoft.VisualStudio.Threading, Version=16.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'StreamJsonRpc, Version=2.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
@@ -317,18 +317,18 @@ Referenced assemblies:
 # Number of references: 10
 
 ---
-Assembly: 'SonarLint.VisualStudio.SLCore.Listeners, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+Assembly: 'SonarLint.VisualStudio.SLCore.Listeners, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 Relative path: 'SonarLint.VisualStudio.SLCore.Listeners.dll'
 
 Referenced assemblies:
 - 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
-- 'SonarLint.VisualStudio.ConnectedMode, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Core, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.Integration, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.IssueVisualization, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
-- 'SonarLint.VisualStudio.SLCore, Version=10.4.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.ConnectedMode, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Core, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.Integration, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.IssueVisualization, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.IssueVisualization.Security, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.RoslynAnalyzerServer, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
+- 'SonarLint.VisualStudio.SLCore, Version=10.5.0.0, Culture=neutral, PublicKeyToken=null'
 - 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 - 'System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 - 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'

--- a/src/Integration.Vsix/Manifests/VS2022/source.extension.vsixmanifest
+++ b/src/Integration.Vsix/Manifests/VS2022/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <!-- Note: keep the version number in sync with AssemblyInfo.Shared.cs -->
-        <Identity Id="SonarLint.0DE19254-1DCA-4479-8EAF-58E5D677FF4D" Version="10.4.0.0" Language="en-US" Publisher="SonarSource" />
+        <Identity Id="SonarLint.0DE19254-1DCA-4479-8EAF-58E5D677FF4D" Version="10.5.0.0" Language="en-US" Publisher="SonarSource" />
         <DisplayName>SonarQube for Visual Studio</DisplayName>
         <Preview>false</Preview>
         <Description xml:space="preserve">Advanced linter to detect and fix coding issues locally in C#, VB.NET, C/C++, JS, TS, CSS, HTML, T-SQL. Use with SonarQube (Server, Cloud) for optimal team performance.</Description>

--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -39,7 +39,7 @@ namespace SonarLint.VisualStudio.Integration.Vsix
     [ProvideAutoLoad(VSConstants.UICONTEXT.ShellInitialized_string, PackageAutoLoadFlags.BackgroundLoad)]
     // Register the information needed to show the package in the Help/About dialog of VS.
     // NB: The version is automatically updated by the ChangeVersion.proj
-    [InstalledProductRegistration("#110", "#112", "10.4.0.0", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", "10.5.0.0", IconResourceID = 400)]
     [ProvideOptionPage(typeof(GeneralOptionsDialogPage), "SonarQube", GeneralOptionsDialogPage.PageName, 901, 902, false, 903)]
     [ProvideOptionPage(typeof(FileExclusionsDialogPage), "SonarQube", FileExclusionsDialogPage.PageName, 901, 905, true)]
     [ProvideOptionPage(typeof(OtherOptionsDialogPage), "SonarQube", OtherOptionsDialogPage.PageName, 901, 904, true)]


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
  - Updated solution version to `10.5.0` across `Version.props` and `AssemblyInfo.Shared.cs`
  - Synchronized `source.extension.vsixmanifest` and `SonarLintIntegrationPackage.cs` with the new version
- **Baseline updates:**
  - Updated assembly reference baselines in `AsmRef_Integration.Vsix_Baseline_WithStrongNames.txt` and `AsmRef_Integration.Vsix_Baseline_WithoutStrongNames.txt` to reflect the `10.5.0` version

<sub>This will update automatically on new commits.</sub>