### PR TITLE
SLVS-3000 Update SLCore to unreleased 11.7.0.86010

### DIFF
--- a/src/EmbeddedSonarAnalyzer.props
+++ b/src/EmbeddedSonarAnalyzer.props
@@ -18,6 +18,6 @@
     <!-- sonarqube-ide-visualstudio-roslyn --> 
     <EmbeddedSonarSqvsRoslynJarVersion>1.2.0.364</EmbeddedSonarSqvsRoslynJarVersion>
     <!-- SLOOP: Binaries for SonarLint Out Of Process -->
-    <EmbeddedSloopVersion>11.6.0.85952</EmbeddedSloopVersion>
+    <EmbeddedSloopVersion>11.7.0.86010</EmbeddedSloopVersion>
   </PropertyGroup>
 </Project>

--- a/src/SLCore/Common/Models/Language.cs
+++ b/src/SLCore/Common/Models/Language.cs
@@ -60,6 +60,7 @@ public enum Language
     PYTHON,
     RPG,
     RUBY,
+    RUST,
     SCALA,
     SECRETS,
     SHELL,


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `EmbeddedSloopVersion` in `EmbeddedSonarAnalyzer.props` to `11.7.0.86010` to align with the new SLCore release.
- **Enum updates:**
  - Added `RUST` to the `Language` enum in `src/SLCore/Common/Models/Language.cs`.

<sub>This will update automatically on new commits.</sub>