### PR TITLE
SLVS-3002 Show server soon unsupported notification

### DIFF
--- a/src/Integration.UnitTests/ShowServerSoonUnsupportedNotificationTests.cs
+++ b/src/Integration.UnitTests/ShowServerSoonUnsupportedNotificationTests.cs
@@ -1,0 +1,98 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarLint.VisualStudio.Core.Notifications;
+using SonarLint.VisualStudio.TestInfrastructure;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests;
+
+[TestClass]
+public class ShowServerSoonUnsupportedNotificationTests
+{
+    private INotificationService notificationService;
+    private IDoNotShowAgainNotificationAction doNotShowAgainNotificationAction;
+    private ShowServerSoonUnsupportedNotification testSubject;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        notificationService = Substitute.For<INotificationService>();
+        doNotShowAgainNotificationAction = Substitute.For<IDoNotShowAgainNotificationAction>();
+        testSubject = new ShowServerSoonUnsupportedNotification(notificationService, doNotShowAgainNotificationAction);
+    }
+
+    [TestMethod]
+    public void MefCtor_CheckExports() =>
+        MefTestHelpers.CheckTypeCanBeImported<ShowServerSoonUnsupportedNotification, IShowServerSoonUnsupportedNotification>(
+            MefTestHelpers.CreateExport<INotificationService>(),
+            MefTestHelpers.CreateExport<IDoNotShowAgainNotificationAction>());
+
+    [TestMethod]
+    public void MefCtor_CheckIsSingleton() =>
+        MefTestHelpers.CheckIsSingletonMefComponent<ShowServerSoonUnsupportedNotification>();
+
+    [TestMethod]
+    public void ShowSoonUnsupportedMessage_ShowsNotificationWithCorrectMessageAndId()
+    {
+        const string text = "Server will soon be unsupported";
+        const string notificationId = "server.soon.unsupported.9.9";
+
+        testSubject.ShowSoonUnsupportedMessage(text, notificationId);
+
+        notificationService.Received(1).ShowNotification(Arg.Is<INotification>(n =>
+            n.Id == notificationId &&
+            n.Message == text));
+    }
+
+    [TestMethod]
+    public void ShowSoonUnsupportedMessage_ConfiguresNotificationCorrectly()
+    {
+        testSubject.ShowSoonUnsupportedMessage("text", "id");
+
+        notificationService.Received(1).ShowNotification(Arg.Is<INotification>(n =>
+            !n.CloseOnSolutionClose));
+    }
+
+    [TestMethod]
+    public void ShowSoonUnsupportedMessage_HasDoNotShowAgainAction()
+    {
+        testSubject.ShowSoonUnsupportedMessage("text", "id");
+
+        notificationService.Received(1).ShowNotification(Arg.Is<INotification>(n =>
+            n.Actions.Count() == 1 &&
+            n.Actions.Single() == doNotShowAgainNotificationAction));
+    }
+
+    [TestMethod]
+    public void ShowSoonUnsupportedMessage_UsesNotificationIdForDoNotShowAgainStorage()
+    {
+        const string notificationId = "server.soon.unsupported.9.9";
+
+        testSubject.ShowSoonUnsupportedMessage("text", notificationId);
+
+        var notification = GetNotification();
+        notification.Id.Should().Be(notificationId);
+    }
+
+    private INotification GetNotification() =>
+        notificationService.ReceivedCalls()
+            .Select(call => call.GetArguments()[0] as INotification)
+            .First();
+}

--- a/src/Integration/ShowServerSoonUnsupportedNotification.cs
+++ b/src/Integration/ShowServerSoonUnsupportedNotification.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.ComponentModel.Composition;
+using SonarLint.VisualStudio.Core.Notifications;
+
+namespace SonarLint.VisualStudio.Integration;
+
+public interface IShowServerSoonUnsupportedNotification
+{
+    void ShowSoonUnsupportedMessage(string text, string notificationId);
+}
+
+[Export(typeof(IShowServerSoonUnsupportedNotification))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+[method: ImportingConstructor]
+public sealed class ShowServerSoonUnsupportedNotification(
+    INotificationService notificationService,
+    IDoNotShowAgainNotificationAction doNotShowAgainNotificationAction) : IShowServerSoonUnsupportedNotification
+{
+    public void ShowSoonUnsupportedMessage(string text, string notificationId)
+    {
+        var notification = new Notification(
+            id: notificationId,
+            message: text,
+            actions: [doNotShowAgainNotificationAction],
+            closeOnSolutionClose: false);
+        notificationService.ShowNotification(notification);
+    }
+}

--- a/src/SLCore.Listeners.UnitTests/Implementation/PromoteListenerTests.cs
+++ b/src/SLCore.Listeners.UnitTests/Implementation/PromoteListenerTests.cs
@@ -31,6 +31,7 @@ public class PromoteListenerTests
 {
     private IPromoteNotification promoteNotification;
     private IShowMessageNotification showMessageNotification;
+    private IShowServerSoonUnsupportedNotification showServerSoonUnsupportedNotification;
     private PromoteListener testSubject;
 
     [TestInitialize]
@@ -38,14 +39,16 @@ public class PromoteListenerTests
     {
         promoteNotification = Substitute.For<IPromoteNotification>();
         showMessageNotification = Substitute.For<IShowMessageNotification>();
-        testSubject = new PromoteListener(promoteNotification, showMessageNotification);
+        showServerSoonUnsupportedNotification = Substitute.For<IShowServerSoonUnsupportedNotification>();
+        testSubject = new PromoteListener(promoteNotification, showMessageNotification, showServerSoonUnsupportedNotification);
     }
 
     [TestMethod]
     public void MefCtor_CheckExports() =>
         MefTestHelpers.CheckTypeCanBeImported<PromoteListener, ISLCoreListener>(
             MefTestHelpers.CreateExport<IPromoteNotification>(),
-            MefTestHelpers.CreateExport<IShowMessageNotification>());
+            MefTestHelpers.CreateExport<IShowMessageNotification>(),
+            MefTestHelpers.CreateExport<IShowServerSoonUnsupportedNotification>());
 
     [TestMethod]
     public void MefCtor_CheckIsSingleton() => MefTestHelpers.CheckIsSingletonMefComponent<PromoteListener>();
@@ -77,6 +80,16 @@ public class PromoteListenerTests
         await showMessageNotification.Received().ShowAsync(message, actions);
         result.selectedKey.Should().Be(returnedKey);
         result.closedByUser.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void ShowSoonUnsupportedMessage_PassesTextAndDoNotShowAgainIdToNotification()
+    {
+        var parameters = new ShowSoonUnsupportedMessageParams("DO_NOT_SHOW_AGAIN_ID", "CONFIGURATION_SCOPE_ID", "Server will soon be unsupported");
+
+        testSubject.ShowSoonUnsupportedMessage(parameters);
+
+        showServerSoonUnsupportedNotification.Received().ShowSoonUnsupportedMessage("Server will soon be unsupported", "DO_NOT_SHOW_AGAIN_ID");
     }
 
     private static List<MessageActionItem> CreateActions(int count)

--- a/src/SLCore.Listeners/Implementation/PromoteListener.cs
+++ b/src/SLCore.Listeners/Implementation/PromoteListener.cs
@@ -30,7 +30,9 @@ namespace SonarLint.VisualStudio.SLCore.Listeners.Implementation;
 [Export(typeof(ISLCoreListener))]
 [PartCreationPolicy(CreationPolicy.Shared)]
 [method: ImportingConstructor]
-public class PromoteListener(IPromoteNotification promoteNotification, IShowMessageNotification reviewCampaignNotification) : IPromoteListener
+public class PromoteListener(IPromoteNotification promoteNotification,
+    IShowMessageNotification showMessageNotification,
+    IShowServerSoonUnsupportedNotification showServerSoonUnsupportedNotification) : IPromoteListener
 {
     public void PromoteExtraEnabledLanguagesInConnectedMode(PromoteExtraEnabledLanguagesInConnectedModeParams parameters)
     {
@@ -42,7 +44,10 @@ public class PromoteListener(IPromoteNotification promoteNotification, IShowMess
 
     public async Task<ShowMessageRequestResponse> ShowMessageRequestAsync(ShowMessageRequestParams parameters)
     {
-        var key = await reviewCampaignNotification.ShowAsync(parameters.message, parameters.actions);
+        var key = await showMessageNotification.ShowAsync(parameters.message, parameters.actions);
         return new ShowMessageRequestResponse(key, false);
     }
+
+    public void ShowSoonUnsupportedMessage(ShowSoonUnsupportedMessageParams parameters) =>
+        showServerSoonUnsupportedNotification.ShowSoonUnsupportedMessage(parameters.text, parameters.doNotShowAgainId);
 }

--- a/src/SLCore.UnitTests/Listener/Promote/ShowSoonUnsupportedMessageParamsTests.cs
+++ b/src/SLCore.UnitTests/Listener/Promote/ShowSoonUnsupportedMessageParamsTests.cs
@@ -1,0 +1,46 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Newtonsoft.Json;
+using SonarLint.VisualStudio.SLCore.Listener.Promote;
+
+namespace SonarLint.VisualStudio.SLCore.UnitTests.Listener.Promote;
+
+[TestClass]
+public class ShowSoonUnsupportedMessageParamsTests
+{
+    [TestMethod]
+    public void Deserialize_AsExpected()
+    {
+        var expectedObject = new ShowSoonUnsupportedMessageParams("DO_NOT_SHOW_AGAIN_ID", "CONFIG_SCOPE_ID", "Server will soon be unsupported");
+
+        const string serializedParams = """
+                                        {
+                                          "doNotShowAgainId": "DO_NOT_SHOW_AGAIN_ID",
+                                          "configurationScopeId": "CONFIG_SCOPE_ID",
+                                          "text": "Server will soon be unsupported"
+                                        }
+                                        """;
+
+        var deserializedObject = JsonConvert.DeserializeObject<ShowSoonUnsupportedMessageParams>(serializedParams);
+
+        deserializedObject.Should().BeEquivalentTo(expectedObject, options => options.ComparingByMembers<ShowSoonUnsupportedMessageParams>());
+    }
+}

--- a/src/SLCore/Listener/Promote/ShowSoonUnsupportedMessageParams.cs
+++ b/src/SLCore/Listener/Promote/ShowSoonUnsupportedMessageParams.cs
@@ -18,15 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarLint.VisualStudio.SLCore.Core;
-
 namespace SonarLint.VisualStudio.SLCore.Listener.Promote;
 
-public interface IPromoteListener : ISLCoreListener
-{
-    void PromoteExtraEnabledLanguagesInConnectedMode(PromoteExtraEnabledLanguagesInConnectedModeParams parameters);
-
-    Task<ShowMessageRequestResponse> ShowMessageRequestAsync(ShowMessageRequestParams parameters);
-
-    void ShowSoonUnsupportedMessage(ShowSoonUnsupportedMessageParams parameters);
-}
+public record ShowSoonUnsupportedMessageParams(string doNotShowAgainId, string configurationScopeId, string text);


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **New notification service:**
    - Added `ShowServerSoonUnsupportedNotification` to trigger UI notifications with a "Do not show again" action.
- **Listener integration:**
    - Updated `PromoteListener` to handle `ShowSoonUnsupportedMessage` requests via `ShowSoonUnsupportedMessageParams`.

<sub>This will update automatically on new commits.</sub>