### PR TITLE
SLVS-3014 Change the slack channel for freeze/unfreeze notifications

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -37,7 +37,7 @@ jobs:
       project-name: "SonarLint for Visual Studio"
       short-description: ${{ inputs.short-description }}
       branch: ${{ inputs.branch }}
-      slack-channel: "C02E6L5C01H"
+      slack-channel: "C093TDJ6JF5" #squad-ide-visualstudio-bots
       is-test-run: ${{ inputs.dry-run }}
       new-version: ${{ inputs.new-version }}
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration changes:**
    - Updated `slack-channel` in `full-release.yml` from `C02E6L5C01H` to `C093TDJ6JF5` for freeze/unfreeze notifications.

<sub>This will update automatically on new commits.</sub>