### PR TITLE
SLVS-3027 Analysis causes VS lightbulb context menu to disappear

### DIFF
--- a/src/IssueViz.UnitTests/Editor/Common/TaggerTestHelper.cs
+++ b/src/IssueViz.UnitTests/Editor/Common/TaggerTestHelper.cs
@@ -99,6 +99,15 @@ internal static class TaggerTestHelper
         return tagSpanMock.Object;
     }
 
+    public static IMappingSpan CreateMappingSpan(ITextSnapshot snapshot, params Span[] spans)
+    {
+        var mappingSpanMock = new Mock<IMappingSpan>();
+        var normalizedSpanCollection = new NormalizedSnapshotSpanCollection(snapshot, spans);
+        mappingSpanMock.Setup(x => x.GetSpans(snapshot)).Returns(normalizedSpanCollection);
+
+        return mappingSpanMock.Object;
+    }
+
     public static IAnalysisIssueVisualization CreateIssueViz(ITextSnapshot snapshot, Span span,
         string locationMessage, string ruleKey = null, bool isResolved = false, bool isOnNewCode = false,
         __VSERRORCATEGORY vsSeverity = __VSERRORCATEGORY.EC_WARNING)
@@ -202,7 +211,7 @@ internal static class TaggerTestHelper
         return taggableBufferIndicator.Object;
     }
 
-    public static IWpfTextView CreateWpfTextView(ITextSnapshot snapshot = null, IFormattedLineSource formattedLineSource = null)
+    public static IWpfTextView CreateWpfTextView(ITextSnapshot snapshot = null, IFormattedLineSource formattedLineSource = null, int caretPosition = 0)
     {
         snapshot = snapshot ?? CreateSnapshot();
         var lineSource = formattedLineSource ?? CreateFormattedLineSource();
@@ -211,7 +220,16 @@ internal static class TaggerTestHelper
         viewMock.Setup(x => x.TextSnapshot).Returns(snapshot);
         viewMock.Setup(x => x.FormattedLineSource).Returns(lineSource);
         viewMock.Setup(x => x.TextBuffer).Returns(CreateBuffer());
+        viewMock.Setup(x => x.Caret).Returns(CreateCaret(snapshot, caretPosition));
         return viewMock.Object;
+    }
+
+    public static ITextCaret CreateCaret(ITextSnapshot snapshot, int caretPosition)
+    {
+        var caretMock = new Mock<ITextCaret>();
+        var position = new CaretPosition(new VirtualSnapshotPoint(new SnapshotPoint(snapshot, caretPosition)), Mock.Of<IMappingPoint>(), PositionAffinity.Successor);
+        caretMock.Setup(x => x.Position).Returns(position);
+        return caretMock.Object;
     }
 
     public static IFormattedLineSource CreateFormattedLineSource(double fontSize = 12d, string fontFamily = "Arial", Color? textColor = null)

--- a/src/IssueViz.UnitTests/Editor/FilteringTaggerBaseTests.cs
+++ b/src/IssueViz.UnitTests/Editor/FilteringTaggerBaseTests.cs
@@ -72,15 +72,18 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
         }
 
         [TestMethod]
-        public void OnAggregatorTagsChanged_NotifiesEditorOfChange()
+        public void OnAggregatorTagsChanged_HasChangedSpans_NotifiesEditorOfChangeWithMappedSpan()
         {
             var aggregatorMock = new Mock<ITagAggregator<TrackedTag>>();
 
             var testSubject = new TestableFilteringTagger(aggregatorMock.Object, ValidBuffer);
 
+            var snapshot = ValidBuffer.CurrentSnapshot;
+            var mappingSpanMock = new Mock<IMappingSpan>();
+            mappingSpanMock.Setup(x => x.GetSpans(snapshot)).Returns(new NormalizedSnapshotSpanCollection(snapshot, new Span(10, 5)));
+
             SnapshotSpanEventArgs suppliedArgs = null;
             int eventCount = 0;
-            SnapshotSpan expectedSnapshotSpan = new SnapshotSpan(ValidBuffer.CurrentSnapshot, new Span(0, ValidBuffer.CurrentSnapshot.Length));
             testSubject.TagsChanged += (sender, args) =>
             {
                 eventCount++;
@@ -88,11 +91,27 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor
             };
 
             // Act
-            aggregatorMock.Raise(x => x.BatchedTagsChanged += null, new BatchedTagsChangedEventArgs(Array.Empty<IMappingSpan>()));
+            aggregatorMock.Raise(x => x.BatchedTagsChanged += null, new BatchedTagsChangedEventArgs(new[] { mappingSpanMock.Object }));
 
             eventCount.Should().Be(1);
             suppliedArgs.Should().NotBeNull();
-            suppliedArgs.Span.Should().Be(expectedSnapshotSpan);
+            suppliedArgs.Span.Should().Be(new SnapshotSpan(snapshot, new Span(10, 5)));
+        }
+
+        [TestMethod]
+        public void OnAggregatorTagsChanged_NoChangedSpans_TagsChangedNotRaised()
+        {
+            var aggregatorMock = new Mock<ITagAggregator<TrackedTag>>();
+
+            var testSubject = new TestableFilteringTagger(aggregatorMock.Object, ValidBuffer);
+
+            var eventCount = 0;
+            testSubject.TagsChanged += (sender, args) => eventCount++;
+
+            // Act
+            aggregatorMock.Raise(x => x.BatchedTagsChanged += null, new BatchedTagsChangedEventArgs(Array.Empty<IMappingSpan>()));
+
+            eventCount.Should().Be(0);
         }
 
         [TestMethod]

--- a/src/IssueViz.UnitTests/Editor/LocationTagging/LocationTaggerTests.cs
+++ b/src/IssueViz.UnitTests/Editor/LocationTagging/LocationTaggerTests.cs
@@ -265,6 +265,30 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.LocationTag
         }
 
         [TestMethod]
+        public void OnIssuesChanged_DifferentIssueAtSameSpan_TagsChangedIsRaised()
+        {
+            var buffer = CreateBufferMock(filePath: ValidBufferDocName);
+            var oldIssue = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 10, 5), "old issue message");
+
+            var storeMock = new Mock<IIssueLocationStore>();
+            storeMock.Setup(x => x.GetLocations(ValidBufferDocName)).Returns(new[] { oldIssue });
+
+            var testSubject = new LocationTagger(buffer.Object, storeMock.Object, ValidSpanCalculator, ValidLogger);
+
+            var newIssue = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 10, 5), "new issue message");
+            storeMock.Setup(x => x.GetLocations(ValidBufferDocName)).Returns(new[] { newIssue });
+
+            SnapshotSpanEventArgs actualTagsChangedArgs = null;
+            testSubject.TagsChanged += (sender, args) => actualTagsChangedArgs = args;
+
+            RaiseIssuesChangedEvent(storeMock, ValidBufferDocName);
+
+            actualTagsChangedArgs.Should().NotBeNull();
+            actualTagsChangedArgs.Span.Start.Position.Should().Be(10);
+            actualTagsChangedArgs.Span.End.Position.Should().Be(15);
+        }
+
+        [TestMethod]
         public void OnIssuesChanged_FileIsRenamed_CurrentFileNameIsUsed()
         {
             const string originalName = "original file name.txt";
@@ -472,14 +496,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.LocationTag
             logger.AssertPartialOutputStringExists(ValidBufferDocName, "The specified ITextSnapshot doesn't belong to the correct TextBuffer.");
         }
 
-        private static IAnalysisIssueLocationVisualization CreateLocViz(SnapshotSpan? span)
+        private static IAnalysisIssueLocationVisualization CreateLocViz(SnapshotSpan? span, string message = null)
         {
             var locVizMock = new Mock<IAnalysisIssueLocationVisualization>();
             locVizMock.SetupProperty(x => x.Span);
             locVizMock.Object.Span = span;
 
-            locVizMock.Setup(x => x.Location).Returns(Mock.Of<IAnalysisIssueLocation>());
-            locVizMock.Setup(x => x.Location.TextRange).Returns(Mock.Of<ITextRange>());
+            var locationMock = new Mock<IAnalysisIssueLocation>();
+            locationMock.Setup(x => x.Message).Returns(message);
+            locationMock.Setup(x => x.TextRange).Returns(Mock.Of<ITextRange>());
+            locVizMock.Setup(x => x.Location).Returns(locationMock.Object);
 
             return locVizMock.Object;
         }

--- a/src/IssueViz.UnitTests/Editor/LocationTagging/LocationTaggerTests.cs
+++ b/src/IssueViz.UnitTests/Editor/LocationTagging/LocationTaggerTests.cs
@@ -215,6 +215,56 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.LocationTag
         }
 
         [TestMethod]
+        public void OnIssuesChanged_TagPositionsUnchanged_TagsChangedNotRaised()
+        {
+            var buffer = CreateBufferMock(filePath: ValidBufferDocName);
+            var issue1 = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 3, 1));
+            var issue2 = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 20, 2));
+
+            var storeMock = new Mock<IIssueLocationStore>();
+            storeMock.Setup(x => x.GetLocations(ValidBufferDocName)).Returns(new[] { issue1, issue2 });
+
+            var testSubject = new LocationTagger(buffer.Object, storeMock.Object, ValidSpanCalculator, ValidLogger);
+
+            var sameIssue1 = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 3, 1));
+            var sameIssue2 = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 20, 2));
+            storeMock.Setup(x => x.GetLocations(ValidBufferDocName)).Returns(new[] { sameIssue1, sameIssue2 });
+
+            var eventCount = 0;
+            testSubject.TagsChanged += (sender, args) => eventCount++;
+
+            RaiseIssuesChangedEvent(storeMock, ValidBufferDocName);
+
+            eventCount.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void OnIssuesChanged_OnlySomeTagsChanged_AffectedSpanCoversOnlyChangedTags()
+        {
+            var buffer = CreateBufferMock(filePath: ValidBufferDocName);
+            var unchangedIssue = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 3, 1));
+            var removedIssue = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 100, 2));
+
+            var storeMock = new Mock<IIssueLocationStore>();
+            storeMock.Setup(x => x.GetLocations(ValidBufferDocName)).Returns(new[] { unchangedIssue, removedIssue });
+
+            var testSubject = new LocationTagger(buffer.Object, storeMock.Object, ValidSpanCalculator, ValidLogger);
+
+            var stillUnchangedIssue = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 3, 1));
+            var addedIssue = CreateLocViz(new SnapshotSpan(buffer.Object.CurrentSnapshot, 40, 5));
+            storeMock.Setup(x => x.GetLocations(ValidBufferDocName)).Returns(new[] { stillUnchangedIssue, addedIssue });
+
+            SnapshotSpanEventArgs actualTagsChangedArgs = null;
+            testSubject.TagsChanged += (sender, args) => actualTagsChangedArgs = args;
+
+            RaiseIssuesChangedEvent(storeMock, ValidBufferDocName);
+
+            actualTagsChangedArgs.Should().NotBeNull();
+            actualTagsChangedArgs.Span.Start.Position.Should().Be(40); // addedIssue.Start
+            actualTagsChangedArgs.Span.End.Position.Should().Be(102); // removedIssue.Start + removedIssue.Length
+        }
+
+        [TestMethod]
         public void OnIssuesChanged_FileIsRenamed_CurrentFileNameIsUsed()
         {
             const string originalName = "original file name.txt";

--- a/src/IssueViz.UnitTests/Editor/LocationTagging/LocationTagger_BufferChangeTests.cs
+++ b/src/IssueViz.UnitTests/Editor/LocationTagging/LocationTagger_BufferChangeTests.cs
@@ -197,6 +197,43 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.LocationTag
             testSubject.TagSpans[0].Tag.Location.Span.Value.Snapshot.Should().Be(afterSnapshot);
         }
 
+        [TestMethod]
+        public void BufferChangedThenIssuesChanged_SameIssueAtTranslatedPosition_TagsChangedNotRaisedAgain()
+        {
+            // Regression test: the tagger tracks tag comparison keys in a field that is kept in sync with
+            // TagSpans across buffer edits (via TranslateTagSpans), rather than being rebuilt from TagSpans on
+            // every OnIssuesChanged. If that cache went stale after a buffer edit, re-analysis reporting the
+            // very same issue at its now-shifted position would look "changed" and trigger an unnecessary
+            // TagsChanged notification.
+            const string filePath = "test.cpp";
+            const int bufferLength = 100;
+            const string message = "same issue";
+
+            var buffer = CreateBufferMock(bufferLength, filePath);
+            var deletedSpan = new Span(5, 3);
+            var (beforeSnapshot, afterSnapshot) = CreateSnapshotChange(buffer.Object, bufferLength, deletedSpan);
+
+            var originalSpan = new Span(20, 10);
+            var location = CreateLocationViz(beforeSnapshot, originalSpan, message);
+            var storeMock = new Mock<IIssueLocationStore>();
+            storeMock.Setup(x => x.GetLocations(filePath)).Returns(new[] { location });
+
+            var testSubject = CreateTestSubject(buffer.Object, storeMock.Object);
+
+            RaiseBufferChangedEvent(buffer, beforeSnapshot, afterSnapshot);
+
+            var translatedSpan = new Span(originalSpan.Start - deletedSpan.Length, originalSpan.Length);
+            var reanalyzedLocation = CreateLocationViz(afterSnapshot, translatedSpan, message);
+            storeMock.Setup(x => x.GetLocations(filePath)).Returns(new[] { reanalyzedLocation });
+
+            var eventCount = 0;
+            testSubject.TagsChanged += (sender, args) => eventCount++;
+
+            storeMock.Raise(x => x.IssuesChanged += null, new IssuesChangedEventArgs(new[] { filePath }));
+
+            eventCount.Should().Be(0);
+        }
+
         private static void CheckStoreRefreshOnBufferChangedWasCalled(IIssueLocationStore store, string expectedFilePath)
         {
             var storeMock = ((IMocked<IIssueLocationStore>)store).Mock;

--- a/src/IssueViz.UnitTests/Editor/QuickActions/IssueLocationActionsSourceTests.cs
+++ b/src/IssueViz.UnitTests/Editor/QuickActions/IssueLocationActionsSourceTests.cs
@@ -91,12 +91,14 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         }
 
         [TestMethod]
-        public void OnTagsChanged_DismissLightBulbSession()
+        public void OnTagsChanged_ChangeIsAtCaret_DismissLightBulbSession()
         {
+            const int caretPosition = 10;
+
             var selectedIssueLocationsTagAggregator = new Mock<ITagAggregator<ISelectedIssueLocationTag>>();
             var issueLocationsTagAggregator = new Mock<ITagAggregator<IIssueLocationTag>>();
             var lightBulbBroker = new Mock<ILightBulbBroker>();
-            var textView = CreateWpfTextView();
+            var textView = CreateWpfTextView(caretPosition: caretPosition);
 
             TestInfrastructure.ThreadHelper.SetCurrentThreadAsUIThread();
 
@@ -107,11 +109,38 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
 
             lightBulbBroker.VerifyNoOtherCalls();
 
-            selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+            var changedSpanAtCaret = CreateMappingSpan(textView.TextSnapshot, new Span(caretPosition, 1));
+
+            selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanAtCaret));
             lightBulbBroker.Verify(x=> x.DismissSession(textView), Times.Once);
 
-            issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+            issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanAtCaret));
             lightBulbBroker.Verify(x => x.DismissSession(textView), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public void OnTagsChanged_ChangeIsFarFromCaret_LightBulbSessionNotDismissed()
+        {
+            const int caretPosition = 10;
+
+            var selectedIssueLocationsTagAggregator = new Mock<ITagAggregator<ISelectedIssueLocationTag>>();
+            var issueLocationsTagAggregator = new Mock<ITagAggregator<IIssueLocationTag>>();
+            var lightBulbBroker = new Mock<ILightBulbBroker>();
+            var textView = CreateWpfTextView(caretPosition: caretPosition);
+
+            TestInfrastructure.ThreadHelper.SetCurrentThreadAsUIThread();
+
+            CreateTestSubject(selectedIssueLocationsTagAggregator.Object,
+                issueLocationsTagAggregator.Object,
+                lightBulbBroker: lightBulbBroker.Object,
+                textView: textView);
+
+            var changedSpanFarFromCaret = CreateMappingSpan(textView.TextSnapshot, new Span(caretPosition + 100, 1));
+
+            selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanFarFromCaret));
+            issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanFarFromCaret));
+
+            lightBulbBroker.Verify(x => x.DismissSession(It.IsAny<ITextView>()), Times.Never);
         }
 
         [TestMethod]
@@ -119,13 +148,16 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         {
             var selectedIssueLocationsTagAggregator = new Mock<ITagAggregator<ISelectedIssueLocationTag>>();
             var issueLocationsTagAggregator = new Mock<ITagAggregator<IIssueLocationTag>>();
+            var textView = CreateWpfTextView();
 
-            CreateTestSubject(selectedIssueLocationsTagAggregator.Object, issueLocationsTagAggregator.Object);
+            CreateTestSubject(selectedIssueLocationsTagAggregator.Object, issueLocationsTagAggregator.Object, textView: textView);
 
-            Action act = () => selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+            var changedSpan = CreateMappingSpan(textView.TextSnapshot, new Span(0, 1));
+
+            Action act = () => selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpan));
             act.Should().NotThrow();
 
-            act = () => issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+            act = () => issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpan));
             act.Should().NotThrow();
         }
 
@@ -134,18 +166,23 @@ namespace SonarLint.VisualStudio.IssueVisualization.UnitTests.Editor.QuickAction
         {
             var selectedIssueLocationsTagAggregator = new Mock<ITagAggregator<ISelectedIssueLocationTag>>();
             var issueLocationsTagAggregator = new Mock<ITagAggregator<IIssueLocationTag>>();
+            var textView = CreateWpfTextView();
 
             var eventHandler = new Mock<EventHandler<EventArgs>>();
 
-            var testSubject = CreateTestSubject(selectedIssueLocationsTagAggregator.Object, issueLocationsTagAggregator.Object);
+            var testSubject = CreateTestSubject(selectedIssueLocationsTagAggregator.Object, issueLocationsTagAggregator.Object, textView: textView);
             testSubject.SuggestedActionsChanged += eventHandler.Object;
 
-            selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+            // Suggested actions are re-queried regardless of where the change happened - only the disruptive
+            // DismissSession call is gated on proximity to the caret.
+            var changedSpanFarFromCaret = CreateMappingSpan(textView.TextSnapshot, new Span(500, 1));
+
+            selectedIssueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanFarFromCaret));
             eventHandler.Verify(x=> x(It.IsAny<object>(), It.IsAny<EventArgs>()), Times.Once);
 
             eventHandler.Reset();
 
-            issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+            issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanFarFromCaret));
             eventHandler.Verify(x => x(It.IsAny<object>(), It.IsAny<EventArgs>()), Times.Once);
         }
 

--- a/src/IssueViz.UnitTests/Editor/QuickActions/QuickFixes/QuickFixActionsSourceTests.cs
+++ b/src/IssueViz.UnitTests/Editor/QuickActions/QuickFixes/QuickFixActionsSourceTests.cs
@@ -84,8 +84,11 @@ public class QuickFixActionsSourceTests
     }
 
     [TestMethod]
-    public void OnTagsChanged_DismissLightBulbSession()
+    public void OnTagsChanged_ChangeIsAtCaret_DismissLightBulbSession()
     {
+        const int caretPosition = 10;
+        textView = CreateWpfTextView(caretPosition: caretPosition);
+
         var issueLocationsTagAggregator = new Mock<ITagAggregator<IIssueLocationTag>>();
         var lightBulbBroker = new Mock<ILightBulbBroker>();
 
@@ -93,13 +96,36 @@ public class QuickFixActionsSourceTests
 
         lightBulbBroker.VerifyNoOtherCalls();
 
-        issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+        var changedSpanAtCaret = CreateMappingSpan(textView.TextSnapshot, new Span(caretPosition, 1));
+
+        issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanAtCaret));
         lightBulbBroker.Verify(x => x.DismissSession(textView), Times.Once);
+    }
+
+    [TestMethod]
+    public void OnTagsChanged_ChangeIsFarFromCaret_LightBulbSessionNotDismissed()
+    {
+        const int caretPosition = 10;
+        textView = CreateWpfTextView(caretPosition: caretPosition);
+
+        var issueLocationsTagAggregator = new Mock<ITagAggregator<IIssueLocationTag>>();
+        var lightBulbBroker = new Mock<ILightBulbBroker>();
+
+        CreateTestSubject(issueLocationsTagAggregator.Object, lightBulbBroker.Object);
+
+        var changedSpanFarFromCaret = CreateMappingSpan(textView.TextSnapshot, new Span(caretPosition + 100, 1));
+
+        issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanFarFromCaret));
+
+        lightBulbBroker.Verify(x => x.DismissSession(It.IsAny<ITextView>()), Times.Never);
     }
 
     [TestMethod]
     public void OnTagsChanged_NonCriticalException_ExceptionIsCaught()
     {
+        const int caretPosition = 10;
+        textView = CreateWpfTextView(caretPosition: caretPosition);
+
         var lightBulbBroker = new Mock<ILightBulbBroker>();
         lightBulbBroker
             .Setup(x => x.DismissSession(textView))
@@ -109,7 +135,9 @@ public class QuickFixActionsSourceTests
 
         lightBulbBroker.VerifyNoOtherCalls();
 
-        var act = async () => await testSubject.HandleTagsChangedAsync();
+        var changedSpanAtCaret = CreateMappingSpan(textView.TextSnapshot, new Span(caretPosition, 1));
+
+        var act = async () => await testSubject.HandleTagsChangedAsync(changedSpanAtCaret);
         act.Should().NotThrow();
 
         lightBulbBroker.Verify(x => x.DismissSession(textView), Times.Once);
@@ -118,6 +146,9 @@ public class QuickFixActionsSourceTests
     [TestMethod]
     public async Task OnTagsChanged_CriticalException_ExceptionIsNotCaught()
     {
+        const int caretPosition = 10;
+        textView = CreateWpfTextView(caretPosition: caretPosition);
+
         var lightBulbBroker = new Mock<ILightBulbBroker>();
         lightBulbBroker
             .Setup(x => x.DismissSession(textView))
@@ -127,7 +158,9 @@ public class QuickFixActionsSourceTests
 
         lightBulbBroker.VerifyNoOtherCalls();
 
-        var act = async () => await testSubject.HandleTagsChangedAsync();
+        var changedSpanAtCaret = CreateMappingSpan(textView.TextSnapshot, new Span(caretPosition, 1));
+
+        var act = async () => await testSubject.HandleTagsChangedAsync(changedSpanAtCaret);
         act.Should().ThrowExactly<StackOverflowException>().And.Message.Should().Be("this is a test");
 
         lightBulbBroker.Verify(x => x.DismissSession(textView), Times.Once);
@@ -140,7 +173,9 @@ public class QuickFixActionsSourceTests
 
         CreateTestSubject(issueLocationsTagAggregator.Object);
 
-        var act = () => issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+        var changedSpan = CreateMappingSpan(textView.TextSnapshot, new Span(0, 1));
+
+        var act = () => issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpan));
         act.Should().NotThrow();
     }
 
@@ -154,7 +189,11 @@ public class QuickFixActionsSourceTests
         var testSubject = CreateTestSubject(issueLocationsTagAggregator.Object);
         testSubject.SuggestedActionsChanged += eventHandler.Object;
 
-        issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(Mock.Of<IMappingSpan>()));
+        // Suggested actions are re-queried regardless of where the change happened - only the disruptive
+        // DismissSession call is gated on proximity to the caret.
+        var changedSpanFarFromCaret = CreateMappingSpan(textView.TextSnapshot, new Span(500, 1));
+
+        issueLocationsTagAggregator.Raise(x => x.TagsChanged += null, new TagsChangedEventArgs(changedSpanFarFromCaret));
 
         eventHandler.Verify(x => x(It.IsAny<object>(), It.IsAny<EventArgs>()), Times.Once);
     }

--- a/src/IssueViz/Editor/FilteringTaggerBase.cs
+++ b/src/IssueViz/Editor/FilteringTaggerBase.cs
@@ -108,11 +108,32 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor
         private void OnAggregatorTagsChanged(object sender, BatchedTagsChangedEventArgs e)
         {
             // We need to propagate the change notification, otherwise our GetTags method won't be called.
+            var affectedSpan = CalculateAffectedSpan(e.Spans);
 
-            // Note: we're currently reporting the whole snapshot as having changed. We could be more specific
-            // if our buffer raised a more specific notification.
-            // See #3692 for more information.
-            NotifyTagsChanged();
+            if (affectedSpan.HasValue)
+            {
+                TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(affectedSpan.Value));
+            }
+        }
+
+        /// <summary>
+        /// Maps the aggregator's reported spans onto our snapshot, so we only notify the editor about the region
+        /// that actually changed instead of the whole file. See #3692 for background.
+        /// </summary>
+        private SnapshotSpan? CalculateAffectedSpan(IEnumerable<IMappingSpan> mappingSpans)
+        {
+            var snapshot = GetSnapshot();
+            var mappedSpans = mappingSpans.SelectMany(x => x.GetSpans(snapshot)).ToArray();
+
+            if (mappedSpans.Length == 0)
+            {
+                return null;
+            }
+
+            var start = mappedSpans.Min(x => x.Start.Position);
+            var end = mappedSpans.Max(x => x.End.Position);
+
+            return new SnapshotSpan(snapshot, Span.FromBounds(start, end));
         }
 
         #region ITagger implementation

--- a/src/IssueViz/Editor/LocationTagging/LocationTagger.cs
+++ b/src/IssueViz/Editor/LocationTagging/LocationTagger.cs
@@ -43,6 +43,13 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
 
         internal /* for testing */ IList<ITagSpan<IIssueLocationTag>> TagSpans { get; private set; }
 
+        /// <summary>
+        /// Comparison keys for the tags currently in <see cref="TagSpans"/>, kept in sync with it (including by
+        /// <see cref="TranslateTagSpans"/>) so <see cref="CalculateSpanOfChangedTags"/> never has to rebuild it
+        /// from <see cref="TagSpans"/> before diffing.
+        /// </summary>
+        private HashSet<(int Start, int Length, string Message)> tagKeys = new HashSet<(int Start, int Length, string Message)>();
+
         public LocationTagger(ITextBuffer buffer, IIssueLocationStore locationService, IIssueSpanCalculator spanCalculator, ILogger logger)
         {
             this.buffer = buffer;
@@ -75,10 +82,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
         private void UpdateTags()
         {
             var textSnapshot = buffer.CurrentSnapshot;
-            var oldTags = TagSpans;
             TagSpans = CreateTagSpans(textSnapshot);
 
-            var affectedSpan = CalculateSpanOfChangedTags(oldTags, TagSpans, textSnapshot);
+            var affectedSpan = CalculateSpanOfChangedTags(TagSpans, textSnapshot);
             if (affectedSpan.HasValue)
             {
                 NotifyTagsChanged(affectedSpan.Value);
@@ -153,6 +159,10 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
 
             foreach (var old in TagSpans)
             {
+                // The tag is either dropped or replaced by a translated one below, so remove its key up front:
+                // this keeps tagKeys in sync with TagSpans even if IsNavigable/TranslateTo/InvalidateSpan throws.
+                tagKeys.Remove(GetComparisonKey(old));
+
                 try
                 {
                     if (!old.Tag.Location.Span.IsNavigable())
@@ -171,7 +181,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
                     else
                     {
                         old.Tag.Location.Span = newSpan;
-                        translatedTagSpans.Add(new TagSpan<IIssueLocationTag>(newSpan, old.Tag));
+                        var translatedTagSpan = new TagSpan<IIssueLocationTag>(newSpan, old.Tag);
+                        translatedTagSpans.Add(translatedTagSpan);
+                        tagKeys.Add(GetComparisonKey(translatedTagSpan));
                     }
                 }
                 catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
@@ -226,9 +238,9 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
         }
 
         /// <summary>
-        /// Calculates the span covering only the tags that were added or removed between the old and new tag sets.
-        /// Returns null if the set of tags is unchanged, so that callers can avoid raising an unnecessary
-        /// TagsChanged notification.
+        /// Calculates the span covering only the tags that were added or removed since the last time this was
+        /// called, by diffing <paramref name="newTags"/> against <see cref="tagKeys"/>. Returns null if the set
+        /// of tags is unchanged, so that callers can avoid raising an unnecessary TagsChanged notification.
         /// </summary>
         /// <remarks>
         /// Tags are compared by position and message rather than by tag/location identity, since a fresh set of
@@ -236,14 +248,17 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
         /// changed. Comparing by message still detects the case where a different issue happens to occupy the
         /// same span as a previous one.
         /// </remarks>
-        private static SnapshotSpan? CalculateSpanOfChangedTags(IList<ITagSpan<IIssueLocationTag>> oldTags, IList<ITagSpan<IIssueLocationTag>> newTags, ITextSnapshot textSnapshot)
+        private SnapshotSpan? CalculateSpanOfChangedTags(IList<ITagSpan<IIssueLocationTag>> newTags, ITextSnapshot textSnapshot)
         {
-            var oldKeys = new HashSet<(int Start, int Length, string Message)>((oldTags ?? Array.Empty<ITagSpan<IIssueLocationTag>>()).Select(GetComparisonKey));
             var newKeys = new HashSet<(int Start, int Length, string Message)>(newTags.Select(GetComparisonKey));
 
-            var changedKeys = oldKeys.Except(newKeys).Concat(newKeys.Except(oldKeys)).ToArray();
+            // Turn the previous tag keys into the symmetric difference in place, then swap in newKeys as the
+            // tracked state for next time - no extra copy of either set is needed for the diff.
+            var changedKeys = tagKeys;
+            changedKeys.SymmetricExceptWith(newKeys);
+            tagKeys = newKeys;
 
-            if (changedKeys.Length == 0)
+            if (changedKeys.Count == 0)
             {
                 return null;
             }

--- a/src/IssueViz/Editor/LocationTagging/LocationTagger.cs
+++ b/src/IssueViz/Editor/LocationTagging/LocationTagger.cs
@@ -78,8 +78,11 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
             var oldTags = TagSpans;
             TagSpans = CreateTagSpans(textSnapshot);
 
-            var affectedSpan = CalculateSpanOfAllTags(oldTags, textSnapshot);
-            NotifyTagsChanged(affectedSpan);
+            var affectedSpan = CalculateSpanOfChangedTags(oldTags, TagSpans, textSnapshot);
+            if (affectedSpan.HasValue)
+            {
+                NotifyTagsChanged(affectedSpan.Value);
+            }
         }
 
         private List<ITagSpan<IIssueLocationTag>> CreateTagSpans(ITextSnapshot textSnapshot)
@@ -223,16 +226,24 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
         }
 
         /// <summary>
-        /// Method calculates the span from the start of (old+new) TagSpans and until the end of (old+new) TagSpans
+        /// Calculates the span covering only the tags that were added or removed between the old and new tag sets.
+        /// Returns null if the set of tag positions is unchanged, so that callers can avoid raising an unnecessary
+        /// TagsChanged notification.
         /// </summary>
-        private SnapshotSpan CalculateSpanOfAllTags(IList<ITagSpan<IIssueLocationTag>> oldTags, ITextSnapshot textSnapshot)
+        private static SnapshotSpan? CalculateSpanOfChangedTags(IList<ITagSpan<IIssueLocationTag>> oldTags, IList<ITagSpan<IIssueLocationTag>> newTags, ITextSnapshot textSnapshot)
         {
-            var allTagSpans = TagSpans
-                .Union(oldTags ?? Array.Empty<ITagSpan<IIssueLocationTag>>())
-                .Select(x => x.Span.Span)
-                .ToArray();
+            var oldPositions = new HashSet<(int Start, int Length)>((oldTags ?? Array.Empty<ITagSpan<IIssueLocationTag>>()).Select(x => (x.Span.Span.Start, x.Span.Span.Length)));
+            var newPositions = new HashSet<(int Start, int Length)>(newTags.Select(x => (x.Span.Span.Start, x.Span.Span.Length)));
 
-            return CalculateAffectedSpan(textSnapshot, allTagSpans, allTagSpans);
+            var changedPositions = oldPositions.Except(newPositions).Concat(newPositions.Except(oldPositions)).ToArray();
+
+            if (changedPositions.Length == 0)
+            {
+                return null;
+            }
+
+            var changedSpans = changedPositions.Select(x => new Span(x.Start, x.Length)).ToArray();
+            return CalculateAffectedSpan(textSnapshot, changedSpans, changedSpans);
         }
 
         /// <summary>

--- a/src/IssueViz/Editor/LocationTagging/LocationTagger.cs
+++ b/src/IssueViz/Editor/LocationTagging/LocationTagger.cs
@@ -227,24 +227,33 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging
 
         /// <summary>
         /// Calculates the span covering only the tags that were added or removed between the old and new tag sets.
-        /// Returns null if the set of tag positions is unchanged, so that callers can avoid raising an unnecessary
+        /// Returns null if the set of tags is unchanged, so that callers can avoid raising an unnecessary
         /// TagsChanged notification.
         /// </summary>
+        /// <remarks>
+        /// Tags are compared by position and message rather than by tag/location identity, since a fresh set of
+        /// location visualization objects is created on every analysis even when the reported issues haven't
+        /// changed. Comparing by message still detects the case where a different issue happens to occupy the
+        /// same span as a previous one.
+        /// </remarks>
         private static SnapshotSpan? CalculateSpanOfChangedTags(IList<ITagSpan<IIssueLocationTag>> oldTags, IList<ITagSpan<IIssueLocationTag>> newTags, ITextSnapshot textSnapshot)
         {
-            var oldPositions = new HashSet<(int Start, int Length)>((oldTags ?? Array.Empty<ITagSpan<IIssueLocationTag>>()).Select(x => (x.Span.Span.Start, x.Span.Span.Length)));
-            var newPositions = new HashSet<(int Start, int Length)>(newTags.Select(x => (x.Span.Span.Start, x.Span.Span.Length)));
+            var oldKeys = new HashSet<(int Start, int Length, string Message)>((oldTags ?? Array.Empty<ITagSpan<IIssueLocationTag>>()).Select(GetComparisonKey));
+            var newKeys = new HashSet<(int Start, int Length, string Message)>(newTags.Select(GetComparisonKey));
 
-            var changedPositions = oldPositions.Except(newPositions).Concat(newPositions.Except(oldPositions)).ToArray();
+            var changedKeys = oldKeys.Except(newKeys).Concat(newKeys.Except(oldKeys)).ToArray();
 
-            if (changedPositions.Length == 0)
+            if (changedKeys.Length == 0)
             {
                 return null;
             }
 
-            var changedSpans = changedPositions.Select(x => new Span(x.Start, x.Length)).ToArray();
+            var changedSpans = changedKeys.Select(x => new Span(x.Start, x.Length)).ToArray();
             return CalculateAffectedSpan(textSnapshot, changedSpans, changedSpans);
         }
+
+        private static (int Start, int Length, string Message) GetComparisonKey(ITagSpan<IIssueLocationTag> tagSpan) =>
+            (tagSpan.Span.Span.Start, tagSpan.Span.Span.Length, tagSpan.Tag.Location.Location.Message);
 
         /// <summary>
         /// Method calculates the span from the start of the editor changes and until the end of TagSpans

--- a/src/IssueViz/Editor/QuickActions/IssueLocationActionsSource.cs
+++ b/src/IssueViz/Editor/QuickActions/IssueLocationActionsSource.cs
@@ -45,7 +45,8 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
         private readonly ITagAggregator<IIssueLocationTag> issueLocationsTagAggregator;
         private readonly ITagAggregator<ISelectedIssueLocationTag> selectedIssueLocationsTagAggregator;
 
-        public IssueLocationActionsSource(ILightBulbBroker lightBulbBroker,
+        public IssueLocationActionsSource(
+            ILightBulbBroker lightBulbBroker,
             IVsUIShell vsUiShell,
             IBufferTagAggregatorFactoryService bufferTagAggregatorFactoryService,
             ITextView textView,
@@ -86,7 +87,7 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
 
             if (allActions.Any())
             {
-                return new[] {new SuggestedActionSet(allActions)};
+                return new[] { new SuggestedActionSet(allActions) };
             }
 
             return Enumerable.Empty<SuggestedActionSet>();
@@ -140,10 +141,13 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
 
         private void TagAggregator_TagsChanged(object sender, TagsChangedEventArgs e)
         {
-            if (textView.IsChangeNearCaret(e.Span))
+            RunOnUIThread.Run(() =>
             {
-                RunOnUIThread.Run(() => lightBulbBroker.DismissSession(textView));
-            }
+                if (textView.IsChangeNearCaret(e.Span))
+                {
+                    lightBulbBroker.DismissSession(textView);
+                }
+            });
 
             SuggestedActionsChanged?.Invoke(this, EventArgs.Empty);
         }

--- a/src/IssueViz/Editor/QuickActions/IssueLocationActionsSource.cs
+++ b/src/IssueViz/Editor/QuickActions/IssueLocationActionsSource.cs
@@ -140,7 +140,10 @@ namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
 
         private void TagAggregator_TagsChanged(object sender, TagsChangedEventArgs e)
         {
-            RunOnUIThread.Run(() => lightBulbBroker.DismissSession(textView));
+            if (textView.IsChangeNearCaret(e.Span))
+            {
+                RunOnUIThread.Run(() => lightBulbBroker.DismissSession(textView));
+            }
 
             SuggestedActionsChanged?.Invoke(this, EventArgs.Empty);
         }

--- a/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSource.cs
+++ b/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSource.cs
@@ -21,10 +21,12 @@
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Threading;
 using SonarLint.VisualStudio.Core;
 using SonarLint.VisualStudio.IssueVisualization.Editor.LocationTagging;
+using SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions;
 using SonarLint.VisualStudio.IssueVisualization.Models;
 
 namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions.QuickFixes;
@@ -129,13 +131,16 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
     }
 
     private void TagAggregator_TagsChanged(object sender, TagsChangedEventArgs e)
-        => HandleTagsChangedAsync().Forget();
+        => HandleTagsChangedAsync(e.Span).Forget();
 
-    internal /* for testing */ async Task HandleTagsChangedAsync()
+    internal /* for testing */ async Task HandleTagsChangedAsync(IMappingSpan changedSpan)
     {
         try
         {
-            await threadHandling.RunOnUIThreadAsync(() => lightBulbBroker.DismissSession(textView));
+            if (textView.IsChangeNearCaret(changedSpan))
+            {
+                await threadHandling.RunOnUIThreadAsync(() => lightBulbBroker.DismissSession(textView));
+            }
 
             SuggestedActionsChanged?.Invoke(this, EventArgs.Empty);
         }

--- a/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSource.cs
+++ b/src/IssueViz/Editor/QuickActions/QuickFixes/QuickFixActionsSource.cs
@@ -41,7 +41,8 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
     private readonly ITagAggregator<IIssueLocationTag> issueLocationsTagAggregator;
     private readonly IQuickFixApplicationLogic quickFixApplicationLogic;
 
-    public QuickFixActionsSource(ILightBulbBroker lightBulbBroker,
+    public QuickFixActionsSource(
+        ILightBulbBroker lightBulbBroker,
         IBufferTagAggregatorFactoryService bufferTagAggregatorFactoryService,
         ITextView textView,
         ITextBuffer textBuffer,
@@ -98,7 +99,7 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
         {
             await threadHandling.RunOnUIThreadAsync(() => hasActions = IsOnIssueWithApplicableQuickFixes(range, out _));
         }
-        catch(Exception ex) when (!ErrorHandler.IsCriticalException(ex))
+        catch (Exception ex) when (!ErrorHandler.IsCriticalException(ex))
         {
             logger.WriteLine(string.Format(Resources.ERR_QuickFixes_Exception, ex));
         }
@@ -130,17 +131,19 @@ internal sealed class QuickFixActionsSource : ISuggestedActionsSource
         issueLocationsTagAggregator.Dispose();
     }
 
-    private void TagAggregator_TagsChanged(object sender, TagsChangedEventArgs e)
-        => HandleTagsChangedAsync(e.Span).Forget();
+    private void TagAggregator_TagsChanged(object sender, TagsChangedEventArgs e) => HandleTagsChangedAsync(e.Span).Forget();
 
     internal /* for testing */ async Task HandleTagsChangedAsync(IMappingSpan changedSpan)
     {
         try
         {
-            if (textView.IsChangeNearCaret(changedSpan))
+            await threadHandling.RunOnUIThreadAsync(() =>
             {
-                await threadHandling.RunOnUIThreadAsync(() => lightBulbBroker.DismissSession(textView));
-            }
+                if (textView.IsChangeNearCaret(changedSpan))
+                {
+                    lightBulbBroker.DismissSession(textView);
+                }
+            });
 
             SuggestedActionsChanged?.Invoke(this, EventArgs.Empty);
         }

--- a/src/IssueViz/Editor/QuickActions/TextViewCaretExtensions.cs
+++ b/src/IssueViz/Editor/QuickActions/TextViewCaretExtensions.cs
@@ -1,0 +1,44 @@
+/*
+ * SonarLint for Visual Studio
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Projection;
+
+namespace SonarLint.VisualStudio.IssueVisualization.Editor.QuickActions
+{
+    internal static class TextViewCaretExtensions
+    {
+        /// <summary>
+        /// An open light bulb session tracks a span anchored to the caret, but ILightBulbBroker.DismissSession
+        /// closes the whole view's session unconditionally. Callers should use this to check whether a reported
+        /// tag change is actually near the caret before dismissing - otherwise any issue changing anywhere in
+        /// the file, however far from the caret, would dismiss a session the user is actively interacting with.
+        /// </summary>
+        public static bool IsChangeNearCaret(this ITextView textView, IMappingSpan changedSpan)
+        {
+            var caretSpan = new SnapshotSpan(textView.Caret.Position.BufferPosition, 0);
+            var mappedSpans = changedSpan.GetSpans(textView.TextSnapshot);
+
+            return mappedSpans.Any(x => x.IntersectsWith(caretSpan));
+        }
+    }
+}


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Root cause fix — lightbulb dismissal was too aggressive:**
    - `QuickFixActionsSource` and `IssueLocationActionsSource` now only dismiss the light bulb session when the reported tag change is near the caret (`TextViewCaretExtensions.IsChangeNearCaret`), instead of dismissing on every `TagsChanged` event regardless of where it occurred
    - Suggested actions are still re-queried on every change; only the disruptive `DismissSession` call is gated on caret proximity

- **Narrower change notifications from taggers:**
    - `LocationTagger` and `FilteringTaggerBase` now report only the span covering the tags that actually changed (added/removed/moved), instead of the whole buffer or the full old+new tag range
    - `LocationTagger` caches the previous set of tags (by position and message) so it can diff against the new set and skip raising `TagsChanged` entirely when nothing actually changed

<sub>This will update automatically on new commits.</sub>
